### PR TITLE
Fix for rust change 'Disallow coercions from [T, ..n] to &[T]or *[T]'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -900,7 +900,7 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ParseError> {
     fn parse_type(s: &str, pos: uint, ch: char, tm: &mut Tm)
       -> Result<uint, ParseError> {
         match ch {
-          'A' => match match_strs(s, pos, [
+          'A' => match match_strs(s, pos, &[
               ("Sunday", 0_i32),
               ("Monday", 1_i32),
               ("Tuesday", 2_i32),
@@ -912,7 +912,7 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ParseError> {
             Some(item) => { let (v, pos) = item; tm.tm_wday = v; Ok(pos) }
             None => Err(InvalidDay)
           },
-          'a' => match match_strs(s, pos, [
+          'a' => match match_strs(s, pos, &[
               ("Sun", 0_i32),
               ("Mon", 1_i32),
               ("Tue", 2_i32),
@@ -924,7 +924,7 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ParseError> {
             Some(item) => { let (v, pos) = item; tm.tm_wday = v; Ok(pos) }
             None => Err(InvalidDay)
           },
-          'B' => match match_strs(s, pos, [
+          'B' => match match_strs(s, pos, &[
               ("January", 0_i32),
               ("February", 1_i32),
               ("March", 2_i32),
@@ -941,7 +941,7 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ParseError> {
             Some(item) => { let (v, pos) = item; tm.tm_mon = v; Ok(pos) }
             None => Err(InvalidMonth)
           },
-          'b' | 'h' => match match_strs(s, pos, [
+          'b' | 'h' => match match_strs(s, pos, &[
               ("Jan", 0_i32),
               ("Feb", 1_i32),
               ("Mar", 2_i32),
@@ -1067,13 +1067,13 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ParseError> {
           }
           'n' => parse_char(s, pos, '\n'),
           'P' => match match_strs(s, pos,
-                                  [("am", 0_i32), ("pm", 12_i32)]) {
+                                  &[("am", 0_i32), ("pm", 12_i32)]) {
 
             Some(item) => { let (v, pos) = item; tm.tm_hour += v; Ok(pos) }
             None => Err(InvalidHour)
           },
           'p' => match match_strs(s, pos,
-                                  [("AM", 0_i32), ("PM", 12_i32)]) {
+                                  &[("AM", 0_i32), ("PM", 12_i32)]) {
 
             Some(item) => { let (v, pos) = item; tm.tm_hour += v; Ok(pos) }
             None => Err(InvalidHour)
@@ -1225,7 +1225,7 @@ pub fn strptime(s: &str, format: &str) -> Result<Tm, ParseError> {
         let ch = range.ch;
         let next = range.next;
 
-        let mut buf = [0];
+        let mut buf = &mut [0];
         let c = match rdr.read(buf) {
             Ok(..) => buf[0] as char,
             Err(..) => break


### PR DESCRIPTION
Fix for breaking change in rust master.
