### PR TITLE
NaCl/PNaCl (w/ Newlib) doesn't provide librt.a.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,8 @@ mod imp {
     use libc::{c_int, timespec};
 
     // Apparently android provides this in some other library?
-    #[cfg(not(target_os = "android"))]
+    #[cfg(all(not(target_os = "android"),
+              not(target_os = "nacl")))]
     #[link(name = "rt")]
     extern {}
 


### PR DESCRIPTION
So don't link it if targeting NaCl/PNaCl.
