### PR TITLE
Remove rustc-serialize as a dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,5 @@ Utilities for working with time-related functions in Rust.
 [build-dependencies]
 gcc = "0.1"
 
-[dependencies]
-rustc-serialize = "0.1"
-
 [dev-dependencies]
 log = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 
 #[cfg(test)] #[phase(plugin, link)] extern crate log;
 
-extern crate "rustc-serialize" as rustc_serialize;
 extern crate libc;
 
 use std::fmt::Show;
@@ -75,8 +74,7 @@ mod imp {
 }
 
 /// A record specifying a time value in seconds and nanoseconds.
-#[deriving(Copy, Clone, PartialEq, Eq, PartialOrd, Ord,
-           RustcEncodable, RustcDecodable, Show)]
+#[deriving(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Show)]
 pub struct Timespec { pub sec: i64, pub nsec: i32 }
 /*
  * Timespec assumes that pre-epoch Timespecs have negative sec and positive


### PR DESCRIPTION
Requiring it brings in another dependency that can break
and needs to be updated, slowing development in downstream
packages which depend on time.
