### PR TITLE
Replace 'trim_left_matches' with 'trim_start_matches'

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -326,7 +326,7 @@ fn match_digits_i64(ss: &mut &str, min_digits : usize, max_digits: usize, ws: bo
     let mut value : i64 = 0;
     let mut n = 0;
     if ws {
-        let s2 = ss.trim_left_matches(" ");
+        let s2 = ss.trim_start_matches(" ");
         n = ss.len() - s2.len();
         if n > max_digits { return None }
     }


### PR DESCRIPTION
In Rust 1.33.0, [`trim_left_matches`](https://doc.rust-lang.org/nightly/std/primitive.str.html#method.trim_left_matches) is replaced by `trim_start_matched` so this crate cannot be compiled. This change is to fix it.