### PR TITLE
Implement `get_time` for wasm32 targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ redox_syscall = "0.1"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.0", features = ["std", "minwinbase", "minwindef", "ntdef", "profileapi", "sysinfoapi", "timezoneapi"] }
 
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+js-sys = { version = "0.3" }
+
 [dev-dependencies]
 log = "0.4"
 winapi = { version = "0.3.0", features = ["std", "processthreadsapi", "winbase"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 #[cfg(target_os = "redox")] extern crate syscall;
 #[cfg(unix)] extern crate libc;
 #[cfg(windows)] extern crate winapi;
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))] extern crate js_sys;
 #[cfg(feature = "rustc-serialize")] extern crate rustc_serialize;
 
 #[cfg(test)] #[macro_use] extern crate log;

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -99,7 +99,11 @@ mod inner {
     }
 
     pub fn get_time() -> (i64, i32) {
-        unimplemented!()
+        let now = js_sys::Date::new_0();
+        let millisecs_since_unix_epoch: u64 = now.get_time() as u64;
+        let secs  = millisecs_since_unix_epoch / 1000;
+        let nanos = 1_000_000 * (millisecs_since_unix_epoch - 1000 * secs);
+        (secs as i64, nanos as i32)
     }
 
     pub fn get_precise_ns() -> u64 {


### PR DESCRIPTION
I pulled the implementation chrono's wasm32 support: https://github.com/chronotope/chrono/blob/c045750e06b4ea59fa09241eeb585e0bacd0cbb8/src/offset/utc.rs#L48-L58