### PR TITLE
Remove the patch revision specification for libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "time"
-version = "0.1.42"
+version = "0.1.43"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/rust-lang/time"
@@ -16,7 +16,7 @@ travis-ci = { repository = "rust-lang-deprecated/time" }
 appveyor = { repository = "alexcrichton/time" }
 
 [dependencies]
-libc = "0.2.1"
+libc = "0.2"
 rustc-serialize = { version = "0.3", optional = true }
 
 [target.'cfg(target_os = "redox")'.dependencies]


### PR DESCRIPTION
Making the dependency on "libc" specific to the patch revision removes the ability to get new updates. For example, the 0.2.62 version is needed for Redox to work, but this crate does not allow it.

Remove the patch version and also bump the patch version of the crate for release.