### PR TITLE
Put 'non_exhaustive' attribute behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ license = "MIT OR Apache-2.0"
 # TODO Add GitHub Actions badge once rust-lang/crates.io#1838 is merged.
 
 [features]
-default = ["std", "deprecated"]
+default = ["std", "deprecated", "unstable"]
 deprecated = ["log"]
 std = []
+unstable = []
 
 [dependencies]
 log = { version = "0.4", optional = true }

--- a/src/format/language.rs
+++ b/src/format/language.rs
@@ -10,7 +10,7 @@
 /// - Short month names
 /// - Weekday names
 /// - Short weekday names
-#[non_exhaustive]
+#[cfg_attr(feature = "unstable", non_exhaustive)]
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Language {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,7 +314,7 @@ mod no_std_prelude {
 /// let error = StdDuration::try_from(Duration::seconds(-1)).unwrap_err();
 /// assert!(Any::is::<OutOfRangeError>(&error));
 /// ```
-#[non_exhaustive]
+#[cfg_attr(feature = "unstable", non_exhaustive)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OutOfRangeError;
 


### PR DESCRIPTION
This is a problem when compiling for stable versions of rust