### PR TITLE
fix redox build by added additional target_os check for unixes

### DIFF
--- a/src/sys.rs
+++ b/src/sys.rs
@@ -347,7 +347,7 @@ mod inner {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "redox")))]
 mod inner {
     use libc::{self, time_t};
     use std::mem;


### PR DESCRIPTION
one way to partially fix https://gitlab.redox-os.org/redox-os/redox/issues/1279