### PR TITLE
Symlink licenses into subcrates

### DIFF
--- a/time-macros-impl/LICENSE-Apache
+++ b/time-macros-impl/LICENSE-Apache
@@ -1,0 +1,1 @@
+../LICENSE-Apache

--- a/time-macros-impl/LICENSE-MIT
+++ b/time-macros-impl/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/time-macros/LICENSE-Apache
+++ b/time-macros/LICENSE-Apache
@@ -1,0 +1,1 @@
+../LICENSE-Apache

--- a/time-macros/LICENSE-MIT
+++ b/time-macros/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
These licenses usually require that they are distributed along with the
sources they apply to, but they are currently missing from the crates.io
packages for `time-macros` and `time-macros-impl`. Simple symlinks here
will solve this if you're publishing from unix-like platforms, but
they'll need complete copies for this to work from Windows.