### PR TITLE
[v0.1] Fix warnings and test dates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: false
 matrix:
   include:
     - rust: 1.21.0
+      before_script:
+        - cargo generate-lockfile
+        - cargo update -p cfg-if --precise 0.1.9
     - rust: stable
     - os: osx
     - rust: beta

--- a/src/display.rs
+++ b/src/display.rs
@@ -11,9 +11,9 @@ impl<'a> fmt::Display for TmFmt<'a> {
                     if ch == '%' {
                         // we've already validated that % always precedes
                         // another char
-                        try!(parse_type(fmt, chars.next().unwrap(), self.tm));
+                        parse_type(fmt, chars.next().unwrap(), self.tm)?;
                     } else {
-                        try!(fmt.write_char(ch));
+                        fmt.write_char(ch)?;
                     }
                 }
 
@@ -148,31 +148,31 @@ fn parse_type(fmt: &mut fmt::Formatter, ch: char, tm: &Tm) -> fmt::Result {
         }),
         'C' => write!(fmt, "{:02}", (tm.tm_year + 1900) / 100),
         'c' => {
-            try!(parse_type(fmt, 'a', tm));
-            try!(fmt.write_str(" "));
-            try!(parse_type(fmt, 'b', tm));
-            try!(fmt.write_str(" "));
-            try!(parse_type(fmt, 'e', tm));
-            try!(fmt.write_str(" "));
-            try!(parse_type(fmt, 'T', tm));
-            try!(fmt.write_str(" "));
+            parse_type(fmt, 'a', tm)?;
+            fmt.write_str(" ")?;
+            parse_type(fmt, 'b', tm)?;
+            fmt.write_str(" ")?;
+            parse_type(fmt, 'e', tm)?;
+            fmt.write_str(" ")?;
+            parse_type(fmt, 'T', tm)?;
+            fmt.write_str(" ")?;
             parse_type(fmt, 'Y', tm)
         }
         'D' | 'x' => {
-            try!(parse_type(fmt, 'm', tm));
-            try!(fmt.write_str("/"));
-            try!(parse_type(fmt, 'd', tm));
-            try!(fmt.write_str("/"));
+            parse_type(fmt, 'm', tm)?;
+            fmt.write_str("/")?;
+            parse_type(fmt, 'd', tm)?;
+            fmt.write_str("/")?;
             parse_type(fmt, 'y', tm)
         }
         'd' => write!(fmt, "{:02}", tm.tm_mday),
         'e' => write!(fmt, "{:2}", tm.tm_mday),
         'f' => write!(fmt, "{:09}", tm.tm_nsec),
         'F' => {
-            try!(parse_type(fmt, 'Y', tm));
-            try!(fmt.write_str("-"));
-            try!(parse_type(fmt, 'm', tm));
-            try!(fmt.write_str("-"));
+            parse_type(fmt, 'Y', tm)?;
+            fmt.write_str("-")?;
+            parse_type(fmt, 'm', tm)?;
+            fmt.write_str("-")?;
             parse_type(fmt, 'd', tm)
         }
         'G' => iso_week(fmt, 'G', tm),
@@ -198,26 +198,26 @@ fn parse_type(fmt: &mut fmt::Formatter, ch: char, tm: &Tm) -> fmt::Result {
         'P' => fmt.write_str(if tm.tm_hour < 12 { "am" } else { "pm" }),
         'p' => fmt.write_str(if (tm.tm_hour) < 12 { "AM" } else { "PM" }),
         'R' => {
-            try!(parse_type(fmt, 'H', tm));
-            try!(fmt.write_str(":"));
+            parse_type(fmt, 'H', tm)?;
+            fmt.write_str(":")?;
             parse_type(fmt, 'M', tm)
         }
         'r' => {
-            try!(parse_type(fmt, 'I', tm));
-            try!(fmt.write_str(":"));
-            try!(parse_type(fmt, 'M', tm));
-            try!(fmt.write_str(":"));
-            try!(parse_type(fmt, 'S', tm));
-            try!(fmt.write_str(" "));
+            parse_type(fmt, 'I', tm)?;
+            fmt.write_str(":")?;
+            parse_type(fmt, 'M', tm)?;
+            fmt.write_str(":")?;
+            parse_type(fmt, 'S', tm)?;
+            fmt.write_str(" ")?;
             parse_type(fmt, 'p', tm)
         }
         'S' => write!(fmt, "{:02}", tm.tm_sec),
         's' => write!(fmt, "{}", tm.to_timespec().sec),
         'T' | 'X' => {
-            try!(parse_type(fmt, 'H', tm));
-            try!(fmt.write_str(":"));
-            try!(parse_type(fmt, 'M', tm));
-            try!(fmt.write_str(":"));
+            parse_type(fmt, 'H', tm)?;
+            fmt.write_str(":")?;
+            parse_type(fmt, 'M', tm)?;
+            fmt.write_str(":")?;
             parse_type(fmt, 'S', tm)
         }
         't' => fmt.write_str("\t"),
@@ -228,10 +228,10 @@ fn parse_type(fmt: &mut fmt::Formatter, ch: char, tm: &Tm) -> fmt::Result {
         }
         'V' => iso_week(fmt, 'V', tm),
         'v' => {
-            try!(parse_type(fmt, 'e', tm));
-            try!(fmt.write_str("-"));
-            try!(parse_type(fmt, 'b', tm));
-            try!(fmt.write_str("-"));
+            parse_type(fmt, 'e', tm)?;
+            fmt.write_str("-")?;
+            parse_type(fmt, 'b', tm)?;
+            fmt.write_str("-")?;
             parse_type(fmt, 'Y', tm)
         }
         'W' => {

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -407,6 +407,7 @@ impl fmt::Display for Duration {
 pub struct OutOfRangeError(());
 
 impl fmt::Display for OutOfRangeError {
+    #[allow(deprecated)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description())
     }

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -377,20 +377,20 @@ impl fmt::Display for Duration {
         let hasdate = days != 0;
         let hastime = (secs != 0 || abs.nanos != 0) || !hasdate;
 
-        try!(write!(f, "{}P", sign));
+        write!(f, "{}P", sign)?;
 
         if hasdate {
-            try!(write!(f, "{}D", days));
+            write!(f, "{}D", days)?;
         }
         if hastime {
             if abs.nanos == 0 {
-                try!(write!(f, "T{}S", secs));
+                write!(f, "T{}S", secs)?;
             } else if abs.nanos % NANOS_PER_MILLI == 0 {
-                try!(write!(f, "T{}.{:03}S", secs, abs.nanos / NANOS_PER_MILLI));
+                write!(f, "T{}.{:03}S", secs, abs.nanos / NANOS_PER_MILLI)?;
             } else if abs.nanos % NANOS_PER_MICRO == 0 {
-                try!(write!(f, "T{}.{:06}S", secs, abs.nanos / NANOS_PER_MICRO));
+                write!(f, "T{}.{:06}S", secs, abs.nanos / NANOS_PER_MICRO)?;
             } else {
-                try!(write!(f, "T{}.{:09}S", secs, abs.nanos));
+                write!(f, "T{}.{:09}S", secs, abs.nanos)?;
             }
         }
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/time/")]
+#![allow(unknown_lints)]
+#![allow(ellipsis_inclusive_range_patterns)] // `..=` requires Rust 1.26
 #![allow(trivial_numeric_casts)]
 #![cfg_attr(test, deny(warnings))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -553,6 +553,7 @@ pub enum ParseError {
 
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        #[allow(deprecated)]
         match *self {
             InvalidFormatSpecifier(ch) => {
                 write!(f, "{}: %{}", self.description(), ch)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -654,7 +654,9 @@ mod tests {
     use super::ParseError::{InvalidTime, InvalidYear, MissingFormatConverter,
                             InvalidFormatSpecifier};
 
-    use std::sync::{Once, ONCE_INIT, Mutex, MutexGuard, LockResult};
+    #[allow(deprecated)] // `Once::new` is const starting in Rust 1.32
+    use std::sync::ONCE_INIT;
+    use std::sync::{Once, Mutex, MutexGuard, LockResult};
     use std::mem;
 
     struct TzReset {
@@ -666,6 +668,7 @@ mod tests {
         // Lock manages current timezone because some tests require LA some
         // London
         static mut LOCK: *mut Mutex<()> = 0 as *mut _;
+        #[allow(deprecated)] // `Once::new` is const starting in Rust 1.32
         static INIT: Once = ONCE_INIT;
 
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,6 +657,7 @@ mod tests {
     #[allow(deprecated)] // `Once::new` is const starting in Rust 1.32
     use std::sync::ONCE_INIT;
     use std::sync::{Once, Mutex, MutexGuard, LockResult};
+    use std::i32;
     use std::mem;
 
     struct TzReset {
@@ -699,8 +700,8 @@ mod tests {
 
     #[test]
     fn test_get_time() {
-        static SOME_RECENT_DATE: i64 = 1325376000i64; // 2012-01-01T00:00:00Z
-        static SOME_FUTURE_DATE: i64 = 1577836800i64; // 2020-01-01T00:00:00Z
+        static SOME_RECENT_DATE: i64 = 1577836800i64; // 2020-01-01T00:00:00Z
+        static SOME_FUTURE_DATE: i64 = i32::MAX as i64; // Y2038
 
         let tv1 = get_time();
         debug!("tv1={} sec + {} nsec", tv1.sec, tv1.nsec);

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -326,6 +326,7 @@ fn match_digits_i64(ss: &mut &str, min_digits : usize, max_digits: usize, ws: bo
     let mut value : i64 = 0;
     let mut n = 0;
     if ws {
+        #[allow(deprecated)] // use `trim_start_matches` starting in 1.30
         let s2 = ss.trim_left_matches(" ");
         n = ss.len() - s2.len();
         if n > max_digits { return None }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -20,10 +20,10 @@ pub fn strptime(mut s: &str, format: &str) -> Result<Tm, ParseError> {
     while let Some(ch) = chars.next() {
         if ch == '%' {
             if let Some(ch) = chars.next() {
-                try!(parse_type(&mut s, ch, &mut tm));
+                parse_type(&mut s, ch, &mut tm)?;
             }
         } else {
-            try!(parse_char(&mut s, ch));
+            parse_char(&mut s, ch)?;
         }
     }
 


### PR DESCRIPTION
While time-0.1 is not actively maintained anymore, these warnings might cause issues if there's ever a need to issue a patch release, so I think they're worth fixing. `SOME_FUTURE_DATE` also caused an amusing failure since we're now in that future, so I've bumped that date out to [Y2038](https://en.wikipedia.org/wiki/Year_2038_problem). Everything is still compatible with Rust 1.21.