### PR TITLE
Method to get local UTC offset at a given datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,11 @@ Versioning].
   for `f64` only.
 - `UtcOffset::local_offset_at(OffsetDateTime)`, which will obtain the system's
   local offset at the provided moment in time.
-  - `OffsetDateTime::now()` and `impl From<SystemTime> for OffsetDateTime` both
-    return a value with the local offset.
-  - `OffsetDateTime::now_utc()` is equivalent to calling
-    `OffsetDateTime::now().to_offset(offset!(UTC))`.
+  - `OffsetDateTime::now_local()` is equivalent to calling
+    `OffsetDateTime::now().to_offset(UtcOffset::local_offset_at(OffsetDateTime::now()))`
+    (but more efficient).
   - `UtcOffset::current_local_offset()` will return the equivalent of
-    `OffsetDateTime::now().offset()`.
+    `OffsetDateTime::now_local().offset()`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ Versioning].
 - `NumericalDuration` has been implemented for `f32` and `f64`.
   `NumericalStdDuration` and `NumericalStdDurationShort` have been implemented
   for `f64` only.
+- `UtcOffset::local_offset_at(OffsetDateTime)`, which will obtain the system's
+  local offset at the provided moment in time.
+  - `OffsetDateTime::now()` and `impl From<SystemTime> for OffsetDateTime` both
+    return a value with the local offset.
+  - `UtcOffset::current_local_offset()` will return the equivalent of
+    `OffsetDateTime::now().offset()`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Versioning].
   local offset at the provided moment in time.
   - `OffsetDateTime::now()` and `impl From<SystemTime> for OffsetDateTime` both
     return a value with the local offset.
+  - `OffsetDateTime::now_utc()` is equivalent to calling
+    `OffsetDateTime::now().to_offset(offset!(UTC))`.
   - `UtcOffset::current_local_offset()` will return the equivalent of
     `OffsetDateTime::now().offset()`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 default = ["deprecated", "std"]
 deprecated = []
 panicking-api = []
-std = []
+std = ["libc", "winapi"]
 
 # Internal usage. This is used when building for docs.rs and time-rs.github.io.
 # This feature should never be used by external users. It will likely be
@@ -32,3 +32,9 @@ time-macros = { version = "0.1", path = "time-macros" }
 
 [workspace]
 members = ["time-macros", "time-macros-impl"]
+
+[target.'cfg(unix)'.dependencies]
+libc = { version = "0.2", optional = true }
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["minwinbase", "minwindef", "timezoneapi"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,8 +123,8 @@
 
 #![cfg_attr(feature = "__doc", feature(doc_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![forbid(unsafe_code)]
 #![deny(
+    unsafe_code, // Used when interacting with system APIs
     anonymous_parameters,
     rust_2018_idioms,
     trivial_casts,

--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -42,9 +42,6 @@ pub struct OffsetDateTime {
 impl OffsetDateTime {
     /// Create a new `OffsetDateTime` with the current date and time.
     ///
-    /// This currently returns an offset of UTC, though this behavior will
-    /// change once a way to obtain the local offset is implemented.
-    ///
     /// ```rust
     /// # use time::{OffsetDateTime, offset};
     /// assert!(OffsetDateTime::now().year() >= 2019);
@@ -926,7 +923,8 @@ impl From<SystemTime> for OffsetDateTime {
                 .expect("overflow converting `std::time::Duration` to `time::Duration`"),
         };
 
-        Self::unix_epoch() + duration
+        let t = Self::unix_epoch() + duration;
+        t.to_offset(UtcOffset::local_offset_at(t))
     }
 }
 
@@ -957,7 +955,10 @@ mod test {
     #[cfg(feature = "std")]
     fn now() {
         assert!(OffsetDateTime::now().year() >= 2019);
-        assert_eq!(OffsetDateTime::now().offset(), offset!(UTC));
+        assert_eq!(
+            OffsetDateTime::now().offset(),
+            UtcOffset::current_local_offset()
+        );
     }
 
     #[test]

--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -40,18 +40,35 @@ pub struct OffsetDateTime {
 }
 
 impl OffsetDateTime {
-    /// Create a new `OffsetDateTime` with the current date and time.
+    /// Create a new `OffsetDateTime` with the current date and time in the
+    /// local offset.
     ///
     /// ```rust
     /// # use time::{OffsetDateTime, offset};
     /// assert!(OffsetDateTime::now().year() >= 2019);
-    /// assert_eq!(OffsetDateTime::now().offset(), offset!(UTC));
     /// ```
     #[inline(always)]
     #[cfg(feature = "std")]
     #[cfg_attr(feature = "__doc", doc(cfg(feature = "std")))]
     pub fn now() -> Self {
         SystemTime::now().into()
+    }
+
+    /// Create a new `OffsetDateTime` with the current date and time in UTC.
+    ///
+    /// ```rust
+    /// # use time::{OffsetDateTime, offset};
+    /// assert!(OffsetDateTime::now_utc().year() >= 2019);
+    /// assert_eq!(OffsetDateTime::now_utc().offset(), offset!(UTC));
+    /// ```
+    #[inline(always)]
+    #[cfg(feature = "std")]
+    #[cfg_attr(feature = "__doc", doc(cfg(feature = "std")))]
+    pub fn now_utc() -> Self {
+        match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+            Ok(duration) => Self::unix_epoch() + duration,
+            Err(err) => Self::unix_epoch() - err.duration(),
+        }
     }
 
     /// Convert the `OffsetDateTime` from the current `UtcOffset` to the
@@ -959,6 +976,13 @@ mod test {
             OffsetDateTime::now().offset(),
             UtcOffset::current_local_offset()
         );
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn now_utc() {
+        assert!(OffsetDateTime::now_utc().year() >= 2019);
+        assert_eq!(OffsetDateTime::now_utc().offset(), offset!(UTC));
     }
 
     #[test]

--- a/src/utc_offset.rs
+++ b/src/utc_offset.rs
@@ -1,5 +1,7 @@
 #[cfg(not(feature = "std"))]
 use crate::alloc_prelude::*;
+#[cfg(feature = "std")]
+use crate::OffsetDateTime;
 use crate::{
     format::{parse, ParseError, ParseResult, ParsedItems},
     DeferredFormat, Duration,
@@ -197,6 +199,35 @@ impl UtcOffset {
     pub(crate) const fn as_duration(self) -> Duration {
         Duration::seconds(self.seconds as i64)
     }
+
+    /// Obtain the system's UTC offset at a known moment in time. If the offset
+    /// cannot be determined, UTC is returned.
+    ///
+    /// ```rust,no_run
+    /// # use time::{UtcOffset, OffsetDateTime};
+    /// let unix_epoch = OffsetDateTime::unix_epoch();
+    /// let local_offset = UtcOffset::local_offset_at(unix_epoch);
+    /// println!("{}", local_offset.format("%z"));
+    /// ```
+    #[inline(always)]
+    #[cfg(feature = "std")]
+    pub fn local_offset_at(datetime: OffsetDateTime) -> Self {
+        try_local_offset_at(datetime).unwrap_or(Self::UTC)
+    }
+
+    /// Obtain the system's current UTC offset. If the offset cannot be
+    /// determined, UTC is returned.
+    ///
+    /// ```rust,no_run
+    /// # use time::UtcOffset;
+    /// let local_offset = UtcOffset::current_local_offset();
+    /// println!("{}", local_offset.format("%z"));
+    /// ```
+    #[inline(always)]
+    #[cfg(feature = "std")]
+    pub fn current_local_offset() -> Self {
+        OffsetDateTime::now().offset()
+    }
 }
 
 /// Methods that allow parsing and formatting the `UtcOffset`.
@@ -253,6 +284,171 @@ impl Display for UtcOffset {
         }
 
         Ok(())
+    }
+}
+
+/// Attempt to obtain the system's UTC offset. If the offset cannot be
+/// determined, `None` is returned.
+#[cfg(feature = "std")]
+#[allow(clippy::too_many_lines)] //
+fn try_local_offset_at(datetime: OffsetDateTime) -> Option<UtcOffset> {
+    use core::{convert::TryInto, mem};
+
+    #[cfg(target_family = "unix")]
+    {
+        /// Convert the given Unix timestamp to a `libc::tm`. Returns `None` on
+        /// any error.
+        fn timestamp_to_tm(timestamp: i64) -> Option<libc::tm> {
+            extern "C" {
+                fn tzset();
+            }
+
+            let timestamp = timestamp.try_into().ok()?;
+
+            // Safety: Plain old data.
+            #[allow(unsafe_code)]
+            let mut tm = unsafe { mem::zeroed() };
+
+            // Update timezone information from system. `localtime_r` does not
+            // do this for us.
+            //
+            // Safety: tzset is thread-safe.
+            #[allow(unsafe_code)]
+            unsafe {
+                tzset();
+            }
+
+            // Safety: We are calling a system API, which mutates the `tm`
+            // variable. If a null pointer is returned, an error occurred.
+            #[allow(unsafe_code)]
+            let tm_ptr = unsafe { libc::localtime_r(&timestamp, &mut tm) };
+
+            if tm_ptr.is_null() {
+                None
+            } else {
+                Some(tm)
+            }
+        }
+
+        let tm = timestamp_to_tm(datetime.timestamp())?;
+
+        // `tm_gmtoff` extension
+        #[cfg(not(target_os = "solaris"))]
+        {
+            tm.tm_gmtoff.try_into().ok().map(UtcOffset::seconds)
+        }
+
+        // No `tm_gmtoff` extension
+        #[cfg(target_os = "solaris")]
+        {
+            use crate::Date;
+            use core::convert::TryFrom;
+
+            let mut tm = tm;
+            if tm.tm_sec == 60 {
+                // Leap seconds are not currently supported.
+                tm.tm_sec = 59;
+            }
+
+            let local_timestamp =
+                Date::try_from_yo(1900 + tm.tm_year, u16::try_from(tm.tm_yday).ok()? + 1)
+                    .ok()?
+                    .try_with_hms(
+                        tm.tm_hour.try_into().ok()?,
+                        tm.tm_min.try_into().ok()?,
+                        tm.tm_sec.try_into().ok()?,
+                    )
+                    .ok()?
+                    .assume_utc()
+                    .timestamp();
+
+            (local_timestamp - datetime.timestamp())
+                .try_into()
+                .ok()
+                .map(UtcOffset::seconds)
+        }
+    }
+
+    #[cfg(target_family = "windows")]
+    {
+        use crate::offset;
+        use winapi::{
+            shared::minwindef::FILETIME,
+            um::{
+                minwinbase::SYSTEMTIME,
+                timezoneapi::{SystemTimeToFileTime, SystemTimeToTzSpecificLocalTime},
+            },
+        };
+
+        /// Convert a `SYSTEMTIME` to a `FILETIME`. Returns `None` if any error
+        /// occurred.
+        fn systemtime_to_filetime(systime: &SYSTEMTIME) -> Option<FILETIME> {
+            // Safety: We only read `ft` if it is properly initialized.
+            #[allow(unsafe_code, deprecated)]
+            let mut ft = unsafe { mem::uninitialized() };
+
+            // Safety: `SystemTimeToFileTime` is thread-safe.
+            #[allow(unsafe_code)]
+            {
+                if 0 == unsafe { SystemTimeToFileTime(systime, &mut ft) } {
+                    // failed
+                    None
+                } else {
+                    Some(ft)
+                }
+            }
+        }
+
+        /// Convert a `FILETIME` to an `i64`, representing a number of seconds.
+        fn filetime_to_secs(filetime: &FILETIME) -> i64 {
+            /// FILETIME represents 100-nanosecond intervals
+            const FT_TO_SECS: i64 = 10_000_000;
+            ((filetime.dwHighDateTime as i64) << 32 | filetime.dwLowDateTime as i64) / FT_TO_SECS
+        }
+
+        /// Convert an `OffsetDateTime` to a `SYSTEMTIME`.
+        fn offset_to_systemtime(datetime: OffsetDateTime) -> SYSTEMTIME {
+            let (month, day_of_month) = datetime.to_offset(offset!(UTC)).month_day();
+            SYSTEMTIME {
+                wYear: datetime.year() as u16,
+                wMonth: month as u16,
+                wDay: day_of_month as u16,
+                wDayOfWeek: 0, // ignored
+                wHour: datetime.hour() as u16,
+                wMinute: datetime.minute() as u16,
+                wSecond: datetime.second() as u16,
+                wMilliseconds: datetime.millisecond(),
+            }
+        }
+
+        // This function falls back to UTC if any system call fails.
+        let systime_utc = offset_to_systemtime(datetime.to_offset(offset!(UTC)));
+
+        // Safety: `local_time` is only read if it is properly initialized, and
+        // `SystemTimeToTzSpecificLocalTime` is thread-safe.
+        #[allow(unsafe_code)]
+        let systime_local = unsafe {
+            #[allow(deprecated)]
+            let mut local_time = mem::uninitialized();
+            if 0 == SystemTimeToTzSpecificLocalTime(
+                core::ptr::null(), // use system's current timezone
+                &systime_utc,
+                &mut local_time,
+            ) {
+                // call failed
+                return None;
+            } else {
+                local_time
+            }
+        };
+
+        // Convert SYSTEMTIMEs to FILETIMEs so we can perform arithmetic on them.
+        let ft_system = systemtime_to_filetime(&systime_utc)?;
+        let ft_local = systemtime_to_filetime(&systime_local)?;
+
+        let diff_secs = filetime_to_secs(&ft_local) - filetime_to_secs(&ft_system);
+
+        diff_secs.try_into().ok().map(UtcOffset::seconds)
     }
 }
 

--- a/src/utc_offset.rs
+++ b/src/utc_offset.rs
@@ -226,7 +226,7 @@ impl UtcOffset {
     #[inline(always)]
     #[cfg(feature = "std")]
     pub fn current_local_offset() -> Self {
-        OffsetDateTime::now().offset()
+        OffsetDateTime::now_local().offset()
     }
 }
 


### PR DESCRIPTION
This implementation should work on Windows, Mac, Linux, and Solaris. As Redox is *nix, it should work there as well.

`OffsetDateTime::now_local()` returns a value with the local offset.

This necessarily requires syscalls, and as such `#![forbid(unsafe_code)]` has been changed to `#![deny(unsafe_code)]`. It must be explicitly `#[allow]`ed in every location it is used, along with a general message describing why the usage is safe.