### PR TITLE
JS' new Date() expects milliseconds + fix operator precedence

### DIFF
--- a/src/utc_offset.rs
+++ b/src/utc_offset.rs
@@ -460,7 +460,9 @@ fn try_local_offset_at(datetime: OffsetDateTime) -> Option<UtcOffset> {
             let high_bits = (timestamp_utc >> 32) as i32;
 
             let timezone_offset = js! {
-                return new Date(((@{high_bits} << 32) + @{low_bits}) * 1000).getTimezoneOffset() * -60;
+                return
+                    new Date(((@{high_bits} << 32) + @{low_bits}) * 1000)
+                        .getTimezoneOffset() * -60;
             };
 
             timezone_offset.try_into().ok().map(UtcOffset::seconds)

--- a/src/utc_offset.rs
+++ b/src/utc_offset.rs
@@ -460,7 +460,7 @@ fn try_local_offset_at(datetime: OffsetDateTime) -> Option<UtcOffset> {
             let high_bits = (timestamp_utc >> 32) as i32;
 
             let timezone_offset = js! {
-                return new Date(@{high_bits} << 32 + @{low_bits}).getTimezoneOffset() * -60;
+                return new Date(((@{high_bits} << 32) + @{low_bits}) * 1000).getTimezoneOffset() * -60;
             };
 
             timezone_offset.try_into().ok().map(UtcOffset::seconds)


### PR DESCRIPTION
I'm sorry, I checked the function some more and turns out I made two errors: The operator precedence is not what I assumed in JS plus "new Date(...)" expects EPOCH in milliseconds, not seconds.