### PR TITLE
Restrict parsed years to 4 digits unless sign is present

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -2176,10 +2176,7 @@ mod test {
             Date::parse("2019-W01-3", "%G-W%V-%u"),
             Ok(date!(2019-W01-3))
         );
-        assert_eq!(
-            Date::parse("20200201", "%Y%m%d"),
-            Ok(date!(2020-02-01))
-        );
+        assert_eq!(Date::parse("20200201", "%Y%m%d"), Ok(date!(2020-02-01)));
     }
 
     // See #221.

--- a/src/date.rs
+++ b/src/date.rs
@@ -2176,6 +2176,10 @@ mod test {
             Date::parse("2019-W01-3", "%G-W%V-%u"),
             Ok(date!(2019-W01-3))
         );
+        assert_eq!(
+            Date::parse("20200201", "%Y%m%d"),
+            Ok(date!(2020-02-01))
+        );
     }
 
     // See #221.

--- a/src/format/date.rs
+++ b/src/format/date.rs
@@ -364,13 +364,13 @@ pub(crate) fn fmt_Y(f: &mut Formatter<'_>, date: Date, padding: Padding) -> fmt:
 /// Full year
 #[inline(always)]
 pub(crate) fn parse_Y(items: &mut ParsedItems, s: &mut &str, padding: Padding) -> ParseResult<()> {
-    let (sign, digits) =
+    let (sign, max_digits) =
         try_consume_first_match(s, [("+", (1, 6)), ("-", (-1, 6))].iter().cloned())
             .unwrap_or((1, 4));
 
     consume_padding(s, padding.default_to(Padding::Zero), 3);
 
-    items.year = try_consume_digits_in_range(s, 1..=digits, -100_000..=100_000)
+    items.year = try_consume_digits_in_range(s, 1..=max_digits, -100_000..=100_000)
         .map(|v: i32| sign * v)
         .ok_or(ParseError::InvalidYear)?
         .into();

--- a/src/format/date.rs
+++ b/src/format/date.rs
@@ -364,11 +364,15 @@ pub(crate) fn fmt_Y(f: &mut Formatter<'_>, date: Date, padding: Padding) -> fmt:
 /// Full year
 #[inline(always)]
 pub(crate) fn parse_Y(items: &mut ParsedItems, s: &mut &str, padding: Padding) -> ParseResult<()> {
-    let sign = try_consume_first_match(s, [("+", 1), ("-", -1)].iter().cloned()).unwrap_or(1);
+    let (sign, digits) =
+        try_consume_first_match(s, [("+", (1, 6)), ("-", (-1, 6))]
+        .iter()
+        .cloned())
+        .unwrap_or((1, 4));
 
     consume_padding(s, padding.default_to(Padding::Zero), 3);
 
-    items.year = try_consume_digits_in_range(s, 1..=6, -100_000..=100_000)
+    items.year = try_consume_digits_in_range(s, 1..=digits, -100_000..=100_000)
         .map(|v: i32| sign * v)
         .ok_or(ParseError::InvalidYear)?
         .into();

--- a/src/format/date.rs
+++ b/src/format/date.rs
@@ -365,10 +365,8 @@ pub(crate) fn fmt_Y(f: &mut Formatter<'_>, date: Date, padding: Padding) -> fmt:
 #[inline(always)]
 pub(crate) fn parse_Y(items: &mut ParsedItems, s: &mut &str, padding: Padding) -> ParseResult<()> {
     let (sign, digits) =
-        try_consume_first_match(s, [("+", (1, 6)), ("-", (-1, 6))]
-        .iter()
-        .cloned())
-        .unwrap_or((1, 4));
+        try_consume_first_match(s, [("+", (1, 6)), ("-", (-1, 6))].iter().cloned())
+            .unwrap_or((1, 4));
 
     consume_padding(s, padding.default_to(Padding::Zero), 3);
 


### PR DESCRIPTION
This pull request fixes the problem identified in #228 .

I made the parser accept a year string with more than 4 digits only when the string has a sign (+/-), so that it can parse a string where a 4-digits year and other numbers are put together without spacing. For example: `Date::parse("20200201", "%Y%m%d")`.