### PR TITLE
Hack around a getting precise time in Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://doc.rust-lang.org/time"
 description = """
 Utilities for working with time-related functions in Rust.
 """
+build = "build.rs"
 
 [dependencies]
 libc = "0.2.1"
@@ -20,6 +21,9 @@ redox_syscall = "0.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.0", features = ["std", "minwinbase", "minwindef", "ntdef", "profileapi", "sysinfoapi", "timezoneapi"] }
+
+[build-dependencies]
+rustc_version = "0.2"
 
 [dev-dependencies]
 log = "0.4"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+extern crate rustc_version;
+use rustc_version::{version, Version};
+
+fn main() {
+    if version().unwrap() >= Version::parse("1.31.0").unwrap() {
+        println!("cargo:rustc-cfg=feature=\"has_const_fn\"");
+    }
+}

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -881,6 +881,12 @@ mod inner {
 
             use std::sync::atomic::{AtomicUsize, Ordering};
             use winapi::um::libloaderapi;
+
+            #[cfg(not(feature = "has_const_fn"))]
+            use std::sync::atomic::{ATOMIC_USIZE_INIT};
+            #[cfg(not(feature = "has_const_fn"))]
+            static PTR: AtomicUsize = ATOMIC_USIZE_INIT;
+            #[cfg(feature = "has_const_fn")]
             static PTR: AtomicUsize = AtomicUsize::new(0);
 
             // FIXME: not even sure if this atomic ordering stuff is needed.


### PR DESCRIPTION
This takes the approach from https://github.com/rust-lang/rust/issues/67266 by @dbergman. This may be necessary for the v0.1 branch of `time` because the widely-used `chrono` crate still depends on it. When writing logs on Windows, crates such as `simplelog` which depend on `chrono` would benefit from a better timestamp. @quodlibetor @Drakulix