### PR TITLE
Force cfg-if 0.1.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ std = ["libc", "winapi", "stdweb", "standback/std"]
 __doc = []
 
 [dependencies]
-cfg-if = "0.1"
+cfg-if = "0.1.10"
 rand = { version = "0.7", optional = true, default-features = false }
 rustversion = "1"
 serde = { version = "1", optional = true, default-features = false, features = ["derive"] }


### PR DESCRIPTION
When using cfg-if version `0.1.9`, compiling fails with the following
error message.

    error: expected an item keyword
       -->
    .../time-0.2.8/src/utc_offset.rs:366:13
        |
    366 |             let tm = timestamp_to_tm(datetime.timestamp())?;

Forcing 0.1.10 fixes this.

Fixes #233