### PR TITLE
`#![no_std]`, embedded support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,9 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: [1.34.0, 1.36.0, stable, nightly]
+        rust: [1.34.0, 1.36.0, stable]
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        target: [thumbv7em-none-eabihf]
 
     steps:
       - name: Checkout sources
@@ -29,23 +28,22 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
           override: true
 
-      # ensure `#![no_std]` support on embedded target
+      # ensure `#![no_std]` support
       - name: Run `cargo check --no-default-features`
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --no-default-features --target ${{ matrix.target }}
+          args: --no-default-features
         if: matrix.rust != '1.34.0' # alloc is unstable in 1.34
 
-      # `#![no_std]` with serde, rand on embedded target
+      # `#![no_std]` with serde, rand
       - name: Run `cargo check --no-default-features --features serde,rand`
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --no-default-features  --target ${{ matrix.target }} --features serde,rand
+          args: --no-default-features --features serde,rand
         if: matrix.rust != '1.34.0' # alloc is unstable in 1.34
 
       # everything
@@ -55,12 +53,55 @@ jobs:
           command: check
           args: --features serde,deprecated,panicking-api,rand
 
+  check-embedded:
+    name: Type checking (embedded)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [1.34.0, 1.36.0, stable]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Cache target
+        uses: actions/cache@v1
+        env:
+          cache-name: target
+        with:
+          path: ./target
+          key: ubuntu-latest-typecheck-target-${{ matrix.rust }}-thumbv7em-none-eabihf
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: thumbv7em-none-eabihf
+          override: true
+
+      # ensure `#![no_std]` support
+      - name: Run `cargo check --no-default-features`
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features --target thumbv7em-none-eabihf
+        if: matrix.rust != '1.34.0' # alloc is unstable in 1.34
+
+      # `#![no_std]` with serde, rand
+      - name: Run `cargo check --no-default-features --features serde,rand`
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features --features serde,rand --target thumbv7em-none-eabihf
+        if: matrix.rust != '1.34.0' # alloc is unstable in 1.34
+
   test:
     name: Test suite
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: [1.34.0, 1.36.0, stable, nightly] # 1.36 is when alloc was stabilized
+        rust: [1.34.0, 1.36.0, stable] # 1.36 is when alloc was stabilized
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,8 +8,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: [1.34.0, 1.36.0, stable]
+        rust: [1.34.0, 1.36.0, stable, nightly]
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        target: [thumbv7em-none-eabihf]
 
     steps:
       - name: Checkout sources
@@ -28,22 +29,23 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
           override: true
 
-      # ensure `#![no_std]` support
+      # ensure `#![no_std]` support on embedded target
       - name: Run `cargo check --no-default-features`
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --no-default-features
+          args: --no-default-features --target ${{ matrix.target }}
         if: matrix.rust != '1.34.0' # alloc is unstable in 1.34
 
-      # `#![no_std]` with serde, rand
+      # `#![no_std]` with serde, rand on embedded target
       - name: Run `cargo check --no-default-features --features serde,rand`
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --no-default-features --features serde,rand
+          args: --no-default-features  --target ${{ matrix.target }} --features serde,rand
         if: matrix.rust != '1.34.0' # alloc is unstable in 1.34
 
       # everything
@@ -58,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: [1.34.0, 1.36.0, stable] # 1.36 is when alloc was stabilized
+        rust: [1.34.0, 1.36.0, stable, nightly] # 1.36 is when alloc was stabilized
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ cfg-if = "0.1.10"
 rand = { version = "0.7", optional = true, default-features = false }
 rustversion = "1"
 serde = { version = "1", optional = true, default-features = false, features = ["derive"] }
-standback = { version = "0.2", default-features = false }
+standback = { version = "0.2.3", default-features = false }
 time-macros = { version = "0.1", path = "time-macros" }
 
 [workspace]

--- a/build.rs
+++ b/build.rs
@@ -14,12 +14,6 @@ fn features(features: &[(&str, &str)]) {
     }
 }
 
-fn no_std() {
-    if env::var("CARGO_FEATURE_STD").is_err() {
-        println!("cargo:rustc-cfg=no_std");
-    }
-}
-
 #[rustversion::since(1.40.0)]
 fn non_exhaustive() {
     println!("cargo:rustc-cfg=supports_non_exhaustive");
@@ -38,6 +32,5 @@ fn main() {
         ("SERDE", "serde"),
         ("__DOC", "docs"),
     ]);
-    no_std();
     non_exhaustive();
 }

--- a/src/format/format.rs
+++ b/src/format/format.rs
@@ -1,6 +1,6 @@
 //! The `Format` struct and its implementations.
 
-#[cfg(no_std)]
+#[cfg(not(std))]
 use crate::internal_prelude::*;
 
 /// Various well-known formats, along with the possibility for a custom format

--- a/src/format/parse_items.rs
+++ b/src/format/parse_items.rs
@@ -1,7 +1,7 @@
 //! Parse formats used in the `format` and `parse` methods.
 
 use crate::format::{FormatItem, Padding, Specifier};
-#[cfg(no_std)]
+#[cfg(not(std))]
 use crate::internal_prelude::*;
 
 /// Parse the formatting string. Panics if not valid.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@
 //! | `0`              | Pad with zeros  | `%0d` => `05` |
 
 #![cfg_attr(docs, feature(doc_cfg))]
-#![cfg_attr(no_std, no_std)]
+#![cfg_attr(not(std), no_std)]
 #![deny(
     unsafe_code, // Used when interacting with system APIs
     anonymous_parameters,
@@ -203,7 +203,7 @@ compile_error!("The `__doc` feature requires a nightly compiler, and is for inte
 #[rustversion::before(1.34.0)]
 compile_error!("The time crate has a minimum supported rust version of 1.34.0.");
 
-#[cfg(no_std)]
+#[cfg(not(std))]
 #[rustversion::before(1.36.0)]
 compile_error!(
     "Using the time crate without the standard library enabled requires a global allocator. This \
@@ -218,7 +218,7 @@ macro_rules! format_conditional {
     };
 
     ($first_conditional:ident, $($conditional:ident),*) => {{
-        #[cfg(no_std)]
+        #[cfg(not(std))]
         let mut s = alloc::string::String::new();
         #[cfg(std)]
         let mut s = String::new();
@@ -457,7 +457,7 @@ pub mod prelude {
 mod internal_prelude {
     #![allow(unused_imports)]
 
-    #[cfg(no_std)]
+    #[cfg(not(std))]
     extern crate alloc;
 
     #[cfg(std)]
@@ -469,7 +469,7 @@ mod internal_prelude {
         PrimitiveDateTime, Time, UtcOffset,
         Weekday::{self, Friday, Monday, Saturday, Sunday, Thursday, Tuesday, Wednesday},
     };
-    #[cfg(no_std)]
+    #[cfg(not(std))]
     pub(crate) use alloc::{
         borrow::ToOwned,
         boxed::Box,

--- a/time-macros/src/lib.rs
+++ b/time-macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 use proc_macro_hack::proc_macro_hack;
 
 #[proc_macro_hack]


### PR DESCRIPTION
Fixes #243 
Requires jhpratt/standback#6

This should allow `time` to be used with no_std targets **assuming** the author of standback accepts my PR.

The second commit isn't required, but (in my opinion) is a cleaner way of checking the `std` feature. It might be completely wrong.