### PR TITLE
Add timestamp serde support via with-annotation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,11 +47,11 @@ jobs:
         if: matrix.rust != '1.32.0' # alloc is unstable in 1.32
 
       # everything
-      - name: Run `cargo check --features serde,_serde_json,deprecated,panicking-api,rand`
+      - name: Run `cargo check --features serde,deprecated,panicking-api,rand`
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --features serde,_serde_json,deprecated,panicking-api,rand
+          args: --features serde,deprecated,panicking-api,rand
 
   check-embedded:
     name: Type checking (embedded)
@@ -144,11 +144,11 @@ jobs:
         if: matrix.rust != '1.32.0' # alloc is unstable in 1.32
 
       # everything
-      - name: Run `cargo check --features serde,_serde_json,deprecated,panicking-api,rand`
+      - name: Run `cargo check --features serde,deprecated,panicking-api,rand`
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --features serde,_serde_json,deprecated,panicking-api,rand
+          args: --features serde,deprecated,panicking-api,rand
 
   test:
     name: Test suite
@@ -186,11 +186,11 @@ jobs:
         if: matrix.rust != '1.32.0' # alloc is unstable in 1.32
 
       # everything
-      - name: Run `cargo test --features serde,_serde_json,deprecated,panicking-api,rand`
+      - name: Run `cargo test --features serde,deprecated,panicking-api,rand`
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features serde,_serde_json,deprecated,panicking-api,rand
+          args: --features serde,deprecated,panicking-api,rand
 
   fmt:
     name: Formatting
@@ -237,11 +237,11 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Run `cargo clippy --features serde,_serde_json,deprecated,rand,panicking-api`
+      - name: Run `cargo clippy --features serde,deprecated,rand,panicking-api`
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --features serde,_serde_json,deprecated,rand,panicking-api
+          args: --features serde,deprecated,rand,panicking-api
 
   documentation:
     name: Documentation

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,11 +47,11 @@ jobs:
         if: matrix.rust != '1.32.0' # alloc is unstable in 1.32
 
       # everything
-      - name: Run `cargo check --features serde,deprecated,panicking-api,rand`
+      - name: Run `cargo check --features serde,serde_json,deprecated,panicking-api,rand`
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --features serde,deprecated,panicking-api,rand
+          args: --features serde,serde_json,deprecated,panicking-api,rand
 
   check-embedded:
     name: Type checking (embedded)
@@ -144,11 +144,11 @@ jobs:
         if: matrix.rust != '1.32.0' # alloc is unstable in 1.32
 
       # everything
-      - name: Run `cargo check --features serde,deprecated,panicking-api,rand`
+      - name: Run `cargo check --features serde,serde_json,deprecated,panicking-api,rand`
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --features serde,deprecated,panicking-api,rand
+          args: --features serde,serde_json,deprecated,panicking-api,rand
 
   test:
     name: Test suite
@@ -186,11 +186,11 @@ jobs:
         if: matrix.rust != '1.32.0' # alloc is unstable in 1.32
 
       # everything
-      - name: Run `cargo test --features serde,deprecated,panicking-api,rand`
+      - name: Run `cargo test --features serde,serde_json,deprecated,panicking-api,rand`
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features serde,deprecated,panicking-api,rand
+          args: --features serde,serde_json,deprecated,panicking-api,rand
 
   fmt:
     name: Formatting
@@ -237,11 +237,11 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Run `cargo clippy --features serde,deprecated,rand,panicking-api`
+      - name: Run `cargo clippy --features serde,serde_json,deprecated,rand,panicking-api`
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --features serde,deprecated,rand,panicking-api
+          args: --features serde,serde_json,deprecated,rand,panicking-api
 
   documentation:
     name: Documentation

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,11 +47,11 @@ jobs:
         if: matrix.rust != '1.32.0' # alloc is unstable in 1.32
 
       # everything
-      - name: Run `cargo check --features serde,serde_json,deprecated,panicking-api,rand`
+      - name: Run `cargo check --features serde,_serde_json,deprecated,panicking-api,rand`
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --features serde,serde_json,deprecated,panicking-api,rand
+          args: --features serde,_serde_json,deprecated,panicking-api,rand
 
   check-embedded:
     name: Type checking (embedded)
@@ -144,11 +144,11 @@ jobs:
         if: matrix.rust != '1.32.0' # alloc is unstable in 1.32
 
       # everything
-      - name: Run `cargo check --features serde,serde_json,deprecated,panicking-api,rand`
+      - name: Run `cargo check --features serde,_serde_json,deprecated,panicking-api,rand`
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --features serde,serde_json,deprecated,panicking-api,rand
+          args: --features serde,_serde_json,deprecated,panicking-api,rand
 
   test:
     name: Test suite
@@ -186,11 +186,11 @@ jobs:
         if: matrix.rust != '1.32.0' # alloc is unstable in 1.32
 
       # everything
-      - name: Run `cargo test --features serde,serde_json,deprecated,panicking-api,rand`
+      - name: Run `cargo test --features serde,_serde_json,deprecated,panicking-api,rand`
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features serde,serde_json,deprecated,panicking-api,rand
+          args: --features serde,_serde_json,deprecated,panicking-api,rand
 
   fmt:
     name: Formatting
@@ -237,11 +237,11 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Run `cargo clippy --features serde,serde_json,deprecated,rand,panicking-api`
+      - name: Run `cargo clippy --features serde,_serde_json,deprecated,rand,panicking-api`
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --features serde,serde_json,deprecated,rand,panicking-api
+          args: --features serde,_serde_json,deprecated,rand,panicking-api
 
   documentation:
     name: Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning].
 
 ---
 
+## 0.2.16 [2020-05-12]
+
+### Added
+
+`OffsetDateTime`s can now be represented as Unix timestamps with serde. To do
+this, you can use the `time::serde::timestamp` and
+`time::serde::timestamp::option` modules.
+
 ## 0.2.15 [2020-05-04]
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time"
-version = "0.2.15"
+version = "0.2.16"
 authors = ["Jacob Pratt <the.z.cuber@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/time-rs/time"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ __doc = []
 cfg-if = "0.1.10"
 rand = { version = "0.7", optional = true, default-features = false }
 serde = { version = "1", optional = true, default-features = false, features = ["derive"] }
-serde_json = { version = "1", optional = true }
+_serde_json = { package = "serde_json", version = "1", optional = true }
 standback = { version = "0.2.5", default-features = false }
 time-macros = { version = "0.1", path = "time-macros" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ __doc = []
 cfg-if = "0.1.10"
 rand = { version = "0.7", optional = true, default-features = false }
 serde = { version = "1", optional = true, default-features = false, features = ["derive"] }
-_serde_json = { package = "serde_json", version = "1", optional = true }
 standback = { version = "0.2.5", default-features = false }
 time-macros = { version = "0.1", path = "time-macros" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,4 +50,5 @@ stdweb = { version = "0.4", default-features = false, optional = true }
 version_check = "0.9"
 
 [dev-dependencies]
+serde_json = "1"
 time-macros = { path = "time-macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,13 @@ std = ["libc", "winapi", "stdweb", "standback/std"]
 # Internal usage. This is used when building for docs.rs and time-rs.github.io.
 # This feature should never be used by external users. It will likely be
 # removed in the first release after the `doc_cfg` feature gets stabilized.
-__doc = []
+__doc = ["serde_json"]
 
 [dependencies]
 cfg-if = "0.1.10"
 rand = { version = "0.7", optional = true, default-features = false }
 serde = { version = "1", optional = true, default-features = false, features = ["derive"] }
+serde_json = { version = "1", optional = true }
 standback = { version = "0.2.5", default-features = false }
 time-macros = { version = "0.1", path = "time-macros" }
 
@@ -50,5 +51,4 @@ stdweb = { version = "0.4", default-features = false, optional = true }
 version_check = "0.9"
 
 [dev-dependencies]
-serde_json = "1"
 time-macros = { path = "time-macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ std = ["libc", "winapi", "stdweb", "standback/std"]
 # Internal usage. This is used when building for docs.rs and time-rs.github.io.
 # This feature should never be used by external users. It will likely be
 # removed in the first release after the `doc_cfg` feature gets stabilized.
-__doc = ["serde_json"]
+__doc = []
 
 [dependencies]
 cfg-if = "0.1.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,7 +373,7 @@ mod primitive_date_time;
 mod rand;
 #[cfg(serde)]
 #[allow(missing_copy_implementations, missing_debug_implementations)]
-mod serde;
+pub mod serde;
 /// The `Sign` struct and its associated `impl`s.
 mod sign;
 /// The `Time` struct and its associated `impl`s.

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,10 +1,12 @@
-//! Types with guaranteed stable serde representations.
-//!
-//! This allows for the ability to change the internal structure of a type while
-//! maintaining backwards compatibility.
-//!
-//! Strings are avoided where possible to allow for optimal representations in
-//! various binary forms.
+//! Differential formats for serde.
+
+// Types with guaranteed stable serde representations.
+//
+// This allows for the ability to change the internal structure of a type while
+// maintaining backwards compatibility.
+//
+// Strings are avoided where possible to allow for optimal representations in
+// various binary forms.
 
 #![allow(clippy::missing_docs_in_private_items)]
 
@@ -15,10 +17,9 @@ mod duration;
 mod primitive_date_time;
 mod sign;
 mod time;
+pub mod timestamp;
 mod utc_offset;
 mod weekday;
-
-pub mod timestamp;
 
 pub(crate) use self::time::Time;
 pub(crate) use date::Date;

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -18,41 +18,6 @@ mod time;
 mod utc_offset;
 mod weekday;
 
-/// De/serialize [`OffsetDateTime`] from/to [Unix timestamps](https://en.wikipedia.org/wiki/Unix_time).
-///
-/// Use this module in combination with [serde's with-annotation](https://serde.rs/field-attrs.html#with).
-///
-/// Note that the timestamp represenatioon lacks [`UtcOffset`],
-/// which is being lost on serialization and assumed 0 on deserialization.
-///
-/// # Examples
-///
-/// ```
-/// # use serde::{Deserialize, Serialize};
-/// # use serde_json::json;
-/// use time::serde::timestamp;
-/// # use time::{date, time, OffsetDateTime};
-///
-/// #[derive(Deserialize, Serialize)]
-/// struct S {
-///     #[serde(with = "timestamp")]
-///     datetime: OffsetDateTime,
-/// }
-///
-/// # fn test() -> Result<(), serde_json::Error> {
-/// let s = S {
-///     datetime: date!(1970-01-01).with_time(time!(1:00)).assume_utc(),
-/// };
-/// let v = json!({ "datetime": 3600 });
-/// assert_eq!(s.datetime, serde_json::from_value::<S>(v.clone())?.datetime);
-/// assert_eq!(v, serde_json::to_value(&s)?);
-/// # Ok(())
-/// # }
-/// # test().unwrap();
-/// ```
-///
-/// [`OffsetDateTime`]: crate::OffsetDateTime
-/// [`UtcOffset`]: crate::UtcOffset
 pub mod timestamp;
 
 pub(crate) use self::time::Time;

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -39,13 +39,16 @@ mod weekday;
 ///     datetime: OffsetDateTime,
 /// }
 ///
+/// # fn test() -> Result<(), serde_json::Error> {
 /// let s = S {
 ///     datetime: date!(1970-01-01).with_time(time!(1:00)).assume_utc(),
 /// };
 /// let v = json!({ "datetime": 3600 });
 /// assert_eq!(s.datetime, serde_json::from_value::<S>(v.clone())?.datetime);
 /// assert_eq!(v, serde_json::to_value(&s)?);
-/// # Ok::<(), serde_json::Error>(())
+/// # Ok(())
+/// # }
+/// # test().unwrap();
 /// ```
 pub mod timestamp;
 

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -50,6 +50,9 @@ mod weekday;
 /// # }
 /// # test().unwrap();
 /// ```
+///
+/// [`OffsetDateTime`]: crate::OffsetDateTime
+/// [`UtcOffset`]: crate::UtcOffset
 pub mod timestamp;
 
 pub(crate) use self::time::Time;

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -18,6 +18,37 @@ mod time;
 mod utc_offset;
 mod weekday;
 
+/// De/serialize [`OffsetDateTime`] from/to [Unix timestamps](https://en.wikipedia.org/wiki/Unix_time).
+///
+/// Use this module in combination with [serde's with-annotation](https://serde.rs/field-attrs.html#with).
+///
+/// Note that the timestamp represenatioon lacks [`UtcOffset`],
+/// which is being lost on serialization and assumed 0 on deserialization.
+///
+/// # Examples
+///
+/// ```
+/// # use serde::{Deserialize, Serialize};
+/// # use serde_json::json;
+/// use time::serde::timestamp;
+/// # use time::{date, time, OffsetDateTime};
+///
+/// #[derive(Deserialize, Serialize)]
+/// struct S {
+///     #[serde(with = "timestamp")]
+///     datetime: OffsetDateTime,
+/// }
+///
+/// let s = S {
+///     datetime: date!(1970-01-01).with_time(time!(1:00)).assume_utc(),
+/// };
+/// let v = json!({ "datetime": 3600 });
+/// assert_eq!(s.datetime, serde_json::from_value::<S>(v.clone())?.datetime);
+/// assert_eq!(v, serde_json::to_value(&s)?);
+/// # Ok::<(), serde_json::Error>(())
+/// ```
+pub mod timestamp;
+
 pub(crate) use self::time::Time;
 pub(crate) use date::Date;
 pub(crate) use duration::Duration;

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -1,3 +1,39 @@
+//! De/serialize [`OffsetDateTime`] from/to [Unix timestamps](https://en.wikipedia.org/wiki/Unix_time).
+//!
+//! Use this module in combination with [serde's with-annotation](https://serde.rs/field-attrs.html#with).
+//!
+//! Note that the timestamp represenatioon lacks [`UtcOffset`],
+//! which is being lost on serialization and assumed 0 on deserialization.
+//!
+//! # Examples
+//!
+//! ```
+//! # use serde::{Deserialize, Serialize};
+//! # use serde_json::json;
+//! use time::serde::timestamp;
+//! # use time::{date, time, OffsetDateTime};
+//!
+//! #[derive(Deserialize, Serialize)]
+//! struct S {
+//!     #[serde(with = "timestamp")]
+//!     datetime: OffsetDateTime,
+//! }
+//!
+//! # fn test() -> Result<(), serde_json::Error> {
+//! let s = S {
+//!     datetime: date!(1970-01-01).with_time(time!(1:00)).assume_utc(),
+//! };
+//! let v = json!({ "datetime": 3600 });
+//! assert_eq!(s.datetime, serde_json::from_value::<S>(v.clone())?.datetime);
+//! assert_eq!(v, serde_json::to_value(&s)?);
+//! # Ok(())
+//! # }
+//! # test().unwrap();
+//! ```
+//!
+//! [`OffsetDateTime`]: crate::OffsetDateTime
+//! [`UtcOffset`]: crate::UtcOffset
+
 use crate::OffsetDateTime;
 use core::fmt;
 use serde::{

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -15,6 +15,7 @@
 //! use time::serde::timestamp;
 //! # use time::{date, time, OffsetDateTime};
 //!
+//! # #[derive(Debug, PartialEq)]
 //! #[derive(Deserialize, Serialize)]
 //! struct S {
 //!     #[serde(with = "timestamp")]
@@ -26,8 +27,8 @@
 //!     datetime: date!(2019-01-01).midnight().assume_utc(),
 //! };
 //! let v = json!({ "datetime": 1_546_300_800 });
-//! assert_eq!(s.datetime, serde_json::from_value::<S>(v.clone())?.datetime);
 //! assert_eq!(v, serde_json::to_value(&s)?);
+//! assert_eq!(s, serde_json::from_value(v)?);
 //! # Ok(())
 //! # }
 //! # test().unwrap();
@@ -86,6 +87,7 @@ where
 /// use time::serde::timestamp;
 /// # use time::{date, time, OffsetDateTime};
 ///
+/// # #[derive(Debug, PartialEq)]
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
 ///     #[serde(default, with = "timestamp::option")]
@@ -97,16 +99,16 @@ where
 ///     datetime: Some(date!(2019-01-01).midnight().assume_utc()),
 /// };
 /// let v_some = json!({ "datetime": 1_546_300_800 });
-/// assert_eq!(s_some.datetime, serde_json::from_value::<S>(v_some.clone())?.datetime);
 /// assert_eq!(v_some, serde_json::to_value(&s_some)?);
+/// assert_eq!(s_some, serde_json::from_value(v_some)?);
 ///
 /// let s_none = S { datetime: None };
 /// let v_null = json!({ "datetime": null });
-/// assert_eq!(s_none.datetime, serde_json::from_value::<S>(v_null.clone())?.datetime);
 /// assert_eq!(v_null, serde_json::to_value(&s_none)?);
+/// assert_eq!(s_none, serde_json::from_value(v_null)?);
 ///
 /// let v_missing = json!({});
-/// assert_eq!(s_none.datetime, serde_json::from_value::<S>(v_missing.clone())?.datetime);
+/// assert_eq!(s_none, serde_json::from_value(v_missing)?);
 /// # Ok(())
 /// # }
 /// # test().unwrap();

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -44,6 +44,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// Fullfills the requirements for [serde's serialize_with-annotation](https://serde.rs/field-attrs.html#serialize_with).
 ///
 /// Prefer using the parent module instead for brevity.
+#[allow(single_use_lifetimes)]
 pub fn serialize<S>(datetime: &OffsetDateTime, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -8,6 +8,7 @@
 //! # Examples
 //!
 //! ```
+//! # #[cfg(feature = "serde_json")] {
 //! # use serde::{Deserialize, Serialize};
 //! # use serde_json::json;
 //! use time::serde::timestamp;
@@ -29,6 +30,7 @@
 //! # Ok(())
 //! # }
 //! # test().unwrap();
+//! # }
 //! ```
 //!
 //! [`OffsetDateTime`]: crate::OffsetDateTime
@@ -96,6 +98,7 @@ where
 /// # Examples
 ///
 /// ```
+/// # #[cfg(feature = "serde_json")] {
 /// # use serde::{Deserialize, Serialize};
 /// # use serde_json::json;
 /// use time::serde::timestamp;
@@ -122,6 +125,7 @@ where
 /// # Ok(())
 /// # }
 /// # test().unwrap();
+/// # }
 /// ```
 ///
 /// [`OffsetDateTime`]: crate::OffsetDateTime

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -1,149 +1,99 @@
-//! De/serialize [`OffsetDateTime`] from/to [Unix timestamps](https://en.wikipedia.org/wiki/Unix_time).
+//! Treat an [`OffsetDateTime`] as a [Unix timestamp] for the purposes of serde.
 //!
-//! Use this module in combination with [serde's with-annotation](https://serde.rs/field-attrs.html#with).
+//! Use this module in combination with serde's [`#[with]`][with] attribute.
 //!
-//! Note that the timestamp represenatioon lacks [`UtcOffset`],
-//! which is being lost on serialization and assumed 0 on deserialization.
+//! When deserializing, the offset is assumed to be UTC.
 //!
-//! # Examples
+//! ```rust,ignore
+//! use serde_json::json;
 //!
-//! ```ignore
-//! # #[cfg(feature = "_serde_json")] {
-//! # use serde::{Deserialize, Serialize};
-//! # use _serde_json as serde_json;
-//! # use serde_json::json;
-//! use time::serde::timestamp;
-//! # use time::{date, time, OffsetDateTime};
-//!
-//! # #[derive(Debug, PartialEq)]
-//! #[derive(Deserialize, Serialize)]
+//! #[derive(Serialize, Deserialize)]
 //! struct S {
-//!     #[serde(with = "timestamp")]
+//!     #[serde(with = "time::serde::timestamp")]
 //!     datetime: OffsetDateTime,
 //! }
 //!
-//! # fn test() -> Result<(), serde_json::Error> {
 //! let s = S {
 //!     datetime: date!(2019-01-01).midnight().assume_utc(),
 //! };
 //! let v = json!({ "datetime": 1_546_300_800 });
 //! assert_eq!(v, serde_json::to_value(&s)?);
 //! assert_eq!(s, serde_json::from_value(v)?);
-//! # Ok(())
-//! # }
-//! # test().unwrap();
-//! # }
 //! ```
 //!
-//! [`UtcOffset`]: crate::UtcOffset
+//! [Unix timestamp]: https://en.wikipedia.org/wiki/Unix_time
+//! [with]: https://serde.rs/field-attrs.html#with
 
 use crate::OffsetDateTime;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-/// Fullfills the requirements for [serde's serialize_with-annotation](https://serde.rs/field-attrs.html#serialize_with).
-///
-/// Prefer using the parent module instead for brevity.
-#[allow(single_use_lifetimes)]
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)]
+struct Wrapper(i64);
+
 pub fn serialize<S: Serializer>(
     datetime: &OffsetDateTime,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    #[derive(Serialize)]
-    #[serde(transparent)]
-    struct Wrapper<'a>(&'a i64);
-
-    Wrapper(&datetime.timestamp()).serialize(serializer)
+    Wrapper(datetime.timestamp()).serialize(serializer)
 }
 
-/// Fullfills the requirements for [serde's deserialize_with-annotation](https://serde.rs/field-attrs.html#deserialize_with).
-///
-/// Prefer using the parent module instead for brevity.
 #[allow(single_use_lifetimes)]
-pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<OffsetDateTime, D::Error> {
-    #[derive(Deserialize)]
-    #[serde(transparent)]
-    struct Wrapper(i64);
-
+pub fn deserialize<'a, D: Deserializer<'a>>(deserializer: D) -> Result<OffsetDateTime, D::Error> {
     Wrapper::deserialize(deserializer)
         .map(|Wrapper(timestamp)| timestamp)
         .map(OffsetDateTime::from_unix_timestamp)
 }
 
-/// De/serialize [`Option`]`<`[`OffsetDateTime`]`>` from/to [Unix timestamps](https://en.wikipedia.org/wiki/Unix_time).
+/// Treat an `Option<OffsetDateTime>` as a [Unix timestamp] for the purposes of
+/// serde.
 ///
-/// Use this module in combination with [serde's with-annotation](https://serde.rs/field-attrs.html#with).
+/// Use this module in combination with serde's [`#[with]`][with] attribute.
 ///
-/// Note that the timestamp represenatioon lacks [`UtcOffset`],
-/// which is being lost on serialization and assumed 0 on deserialization.
+/// When deserializing, the offset is assumed to be UTC.
 ///
-/// # Examples
+/// ```rust,ignore
+/// use serde_json::json;
 ///
-/// ```ignore
-/// # #[cfg(feature = "_serde_json")] {
-/// # use serde::{Deserialize, Serialize};
-/// # use _serde_json as serde_json;
-/// # use serde_json::json;
-/// use time::serde::timestamp;
-/// # use time::{date, time, OffsetDateTime};
-///
-/// # #[derive(Debug, PartialEq)]
-/// #[derive(Deserialize, Serialize)]
+/// #[derive(Serialize, Deserialize)]
 /// struct S {
-///     #[serde(default, with = "timestamp::option")]
+///     #[serde(with = "time::serde::timestamp::option")]
 ///     datetime: Option<OffsetDateTime>,
 /// }
 ///
-/// # fn test() -> Result<(), serde_json::Error> {
-/// let s_some = S {
+/// let s = S {
 ///     datetime: Some(date!(2019-01-01).midnight().assume_utc()),
 /// };
-/// let v_some = json!({ "datetime": 1_546_300_800 });
-/// assert_eq!(v_some, serde_json::to_value(&s_some)?);
-/// assert_eq!(s_some, serde_json::from_value(v_some)?);
+/// let v = json!({ "datetime": 1_546_300_800 });
+/// assert_eq!(v, serde_json::to_value(&s)?);
+/// assert_eq!(s, serde_json::from_value(v)?);
 ///
-/// let s_none = S { datetime: None };
-/// let v_null = json!({ "datetime": null });
-/// assert_eq!(v_null, serde_json::to_value(&s_none)?);
-/// assert_eq!(s_none, serde_json::from_value(v_null)?);
-///
-/// let v_missing = json!({});
-/// assert_eq!(s_none, serde_json::from_value(v_missing)?);
-/// # Ok(())
-/// # }
-/// # test().unwrap();
-/// # }
+/// let s = S { datetime: None };
+/// let v = json!({ "datetime": null });
+/// assert_eq!(v, serde_json::to_value(&s)?);
+/// assert_eq!(s, serde_json::from_value(v)?);
 /// ```
 ///
-/// [`UtcOffset`]: crate::UtcOffset
+/// [Unix timestamp]: https://en.wikipedia.org/wiki/Unix_time
+/// [with]: https://serde.rs/field-attrs.html#with
 pub mod option {
     use super::*;
 
-    /// Fullfills the requirements for [serde's serialize_with-annotation](https://serde.rs/field-attrs.html#serialize_with).
-    ///
-    /// Prefer using the parent module instead for brevity.
-    #[allow(single_use_lifetimes)]
+    #[derive(Serialize, Deserialize)]
+    #[serde(transparent)]
+    struct Wrapper(#[serde(with = "super")] OffsetDateTime);
+
     pub fn serialize<S: Serializer>(
         option: &Option<OffsetDateTime>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
-        #[derive(Serialize)]
-        #[serde(transparent)]
-        struct Wrapper<'a>(#[serde(with = "super")] &'a OffsetDateTime);
-
-        option.as_ref().map(Wrapper).serialize(serializer)
+        option.map(Wrapper).serialize(serializer)
     }
 
-    /// Fullfills the requirements for [serde's deserialize_with-annotation](https://serde.rs/field-attrs.html#deserialize_with).
-    ///
-    /// Prefer using the parent module instead for brevity.
     #[allow(single_use_lifetimes)]
-    pub fn deserialize<'de, D: Deserializer<'de>>(
+    pub fn deserialize<'a, D: Deserializer<'a>>(
         deserializer: D,
     ) -> Result<Option<OffsetDateTime>, D::Error> {
-        #[derive(Deserialize)]
-        #[serde(transparent)]
-        struct Wrapper(#[serde(with = "super")] OffsetDateTime);
-
         Option::deserialize(deserializer).map(|opt| opt.map(|Wrapper(datetime)| datetime))
     }
 }

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -50,6 +50,7 @@ where
     S: Serializer,
 {
     #[derive(Serialize)]
+    #[serde(transparent)]
     struct Wrapper<'a>(&'a i64);
 
     Wrapper(&datetime.timestamp()).serialize(serializer)
@@ -64,6 +65,7 @@ where
     D: Deserializer<'de>,
 {
     #[derive(Deserialize)]
+    #[serde(transparent)]
     struct Wrapper(i64);
 
     Wrapper::deserialize(deserializer)
@@ -130,6 +132,7 @@ pub mod option {
         S: Serializer,
     {
         #[derive(Serialize)]
+        #[serde(transparent)]
         struct Wrapper<'a>(#[serde(with = "super")] &'a OffsetDateTime);
 
         option.as_ref().map(Wrapper).serialize(serializer)
@@ -144,6 +147,7 @@ pub mod option {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(transparent)]
         struct Wrapper(#[serde(with = "super")] OffsetDateTime);
 
         Option::deserialize(deserializer).map(|opt| opt.map(|Wrapper(datetime)| datetime))

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -44,10 +44,10 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 ///
 /// Prefer using the parent module instead for brevity.
 #[allow(single_use_lifetimes)]
-pub fn serialize<S>(datetime: &OffsetDateTime, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
+pub fn serialize<S: Serializer>(
+    datetime: &OffsetDateTime,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
     #[derive(Serialize)]
     #[serde(transparent)]
     struct Wrapper<'a>(&'a i64);
@@ -125,10 +125,10 @@ pub mod option {
     ///
     /// Prefer using the parent module instead for brevity.
     #[allow(single_use_lifetimes)]
-    pub fn serialize<S>(option: &Option<OffsetDateTime>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
+    pub fn serialize<S: Serializer>(
+        option: &Option<OffsetDateTime>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
         #[derive(Serialize)]
         #[serde(transparent)]
         struct Wrapper<'a>(#[serde(with = "super")] &'a OffsetDateTime);

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -50,7 +50,7 @@ where
     serializer.serialize_i64(datetime.timestamp())
 }
 
-/// De/serialize [`Option<OffsetDateTime>`] from/to [Unix timestamps](https://en.wikipedia.org/wiki/Unix_time).
+/// De/serialize [`Option`]`<`[`OffsetDateTime`]`>` from/to [Unix timestamps](https://en.wikipedia.org/wiki/Unix_time).
 ///
 /// Use this module in combination with [serde's with-annotation](https://serde.rs/field-attrs.html#with).
 ///
@@ -87,6 +87,9 @@ where
 /// # }
 /// # test().unwrap();
 /// ```
+///
+/// [`OffsetDateTime`]: crate::OffsetDateTime
+/// [`UtcOffset`]: crate::UtcOffset
 pub mod option {
     use super::*;
 

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -8,8 +8,9 @@
 //! # Examples
 //!
 //! ```
-//! # #[cfg(feature = "serde_json")] {
+//! # #[cfg(feature = "_serde_json")] {
 //! # use serde::{Deserialize, Serialize};
+//! # use _serde_json as serde_json;
 //! # use serde_json::json;
 //! use time::serde::timestamp;
 //! # use time::{date, time, OffsetDateTime};
@@ -98,8 +99,9 @@ where
 /// # Examples
 ///
 /// ```
-/// # #[cfg(feature = "serde_json")] {
+/// # #[cfg(feature = "_serde_json")] {
 /// # use serde::{Deserialize, Serialize};
+/// # use _serde_json as serde_json;
 /// # use serde_json::json;
 /// use time::serde::timestamp;
 /// # use time::{date, time, OffsetDateTime};

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -7,7 +7,7 @@
 //!
 //! # Examples
 //!
-//! ```
+//! ```ignore
 //! # #[cfg(feature = "_serde_json")] {
 //! # use serde::{Deserialize, Serialize};
 //! # use _serde_json as serde_json;
@@ -82,7 +82,7 @@ where
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// # #[cfg(feature = "_serde_json")] {
 /// # use serde::{Deserialize, Serialize};
 /// # use _serde_json as serde_json;

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -59,7 +59,7 @@ where
 ///
 /// Prefer using the parent module instead for brevity.
 #[allow(single_use_lifetimes)]
-pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<OffsetDateTime, D::Error>
+pub fn deserialize<'de, D>(deserializer: D) -> Result<OffsetDateTime, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -135,12 +135,12 @@ pub mod option {
     /// Fullfills the requirements for [serde's serialize_with-annotation](https://serde.rs/field-attrs.html#serialize_with).
     ///
     /// Prefer using the parent module instead for brevity.
-    pub fn serialize<S>(opt: &Option<OffsetDateTime>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(option: &Option<OffsetDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        match *opt {
-            Some(ref value) => super::serialize(value, serializer),
+        match *option {
+            Some(ref datetime) => serializer.serialize_some(&datetime.timestamp()),
             None => serializer.serialize_none(),
         }
     }

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -44,6 +44,16 @@ use serde::{
     Deserializer, Serializer,
 };
 
+/// Fullfills the requirements for [serde's serialize_with-annotation](https://serde.rs/field-attrs.html#serialize_with).
+///
+/// Prefer using the parent module instead for brevity.
+pub fn serialize<S>(datetime: &OffsetDateTime, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_i64(datetime.timestamp())
+}
+
 /// Fullfills the requirements for [serde's deserialize_with-annotation](https://serde.rs/field-attrs.html#deserialize_with).
 ///
 /// Prefer using the parent module instead for brevity.
@@ -77,16 +87,6 @@ where
     }
 
     deserializer.deserialize_i64(OffsetDateTimeVisitor)
-}
-
-/// Fullfills the requirements for [serde's serialize_with-annotation](https://serde.rs/field-attrs.html#serialize_with).
-///
-/// Prefer using the parent module instead for brevity.
-pub fn serialize<S>(datetime: &OffsetDateTime, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_i64(datetime.timestamp())
 }
 
 /// De/serialize [`Option`]`<`[`OffsetDateTime`]`>` from/to [Unix timestamps](https://en.wikipedia.org/wiki/Unix_time).
@@ -135,6 +135,19 @@ where
 pub mod option {
     use super::*;
 
+    /// Fullfills the requirements for [serde's serialize_with-annotation](https://serde.rs/field-attrs.html#serialize_with).
+    ///
+    /// Prefer using the parent module instead for brevity.
+    pub fn serialize<S>(option: &Option<OffsetDateTime>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match *option {
+            Some(ref datetime) => serializer.serialize_some(&datetime.timestamp()),
+            None => serializer.serialize_none(),
+        }
+    }
+
     /// Fullfills the requirements for [serde's deserialize_with-annotation](https://serde.rs/field-attrs.html#deserialize_with).
     ///
     /// Prefer using the parent module instead for brevity.
@@ -175,18 +188,5 @@ pub mod option {
         }
 
         deserializer.deserialize_option(OffsetDateTimeOptionVisitor)
-    }
-
-    /// Fullfills the requirements for [serde's serialize_with-annotation](https://serde.rs/field-attrs.html#serialize_with).
-    ///
-    /// Prefer using the parent module instead for brevity.
-    pub fn serialize<S>(option: &Option<OffsetDateTime>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match *option {
-            Some(ref datetime) => serializer.serialize_some(&datetime.timestamp()),
-            None => serializer.serialize_none(),
-        }
     }
 }

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -71,6 +71,7 @@ where
 ///     datetime: Option<OffsetDateTime>,
 /// }
 ///
+/// # fn test() -> Result<(), serde_json::Error> {
 /// let s = S {
 ///     datetime: Some(date!(1970-01-01).with_time(time!(1:00)).assume_utc()),
 /// };
@@ -82,7 +83,9 @@ where
 /// let v = json!({ "datetime": null });
 /// assert_eq!(s.datetime, serde_json::from_value::<S>(v.clone())?.datetime);
 /// assert_eq!(v, serde_json::to_value(&s)?);
-/// # Ok::<(), serde_json::Error>(())
+/// # Ok(())
+/// # }
+/// # test().unwrap();
 /// ```
 pub mod option {
     use super::*;

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -35,7 +35,6 @@
 //! # }
 //! ```
 //!
-//! [`OffsetDateTime`]: crate::OffsetDateTime
 //! [`UtcOffset`]: crate::UtcOffset
 
 use crate::OffsetDateTime;
@@ -118,7 +117,6 @@ where
 /// # }
 /// ```
 ///
-/// [`OffsetDateTime`]: crate::OffsetDateTime
 /// [`UtcOffset`]: crate::UtcOffset
 pub mod option {
     use super::*;

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -59,10 +59,7 @@ pub fn serialize<S: Serializer>(
 ///
 /// Prefer using the parent module instead for brevity.
 #[allow(single_use_lifetimes)]
-pub fn deserialize<'de, D>(deserializer: D) -> Result<OffsetDateTime, D::Error>
-where
-    D: Deserializer<'de>,
-{
+pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<OffsetDateTime, D::Error> {
     #[derive(Deserialize)]
     #[serde(transparent)]
     struct Wrapper(i64);
@@ -140,10 +137,9 @@ pub mod option {
     ///
     /// Prefer using the parent module instead for brevity.
     #[allow(single_use_lifetimes)]
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<OffsetDateTime>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<OffsetDateTime>, D::Error> {
         #[derive(Deserialize)]
         #[serde(transparent)]
         struct Wrapper(#[serde(with = "super")] OffsetDateTime);

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -23,9 +23,9 @@
 //!
 //! # fn test() -> Result<(), serde_json::Error> {
 //! let s = S {
-//!     datetime: date!(1970-01-01).with_time(time!(1:00)).assume_utc(),
+//!     datetime: date!(2019-01-01).midnight().assume_utc(),
 //! };
-//! let v = json!({ "datetime": 3600 });
+//! let v = json!({ "datetime": 1_546_300_800 });
 //! assert_eq!(s.datetime, serde_json::from_value::<S>(v.clone())?.datetime);
 //! assert_eq!(v, serde_json::to_value(&s)?);
 //! # Ok(())
@@ -88,22 +88,25 @@ where
 ///
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
-///     #[serde(with = "timestamp::option")]
+///     #[serde(default, with = "timestamp::option")]
 ///     datetime: Option<OffsetDateTime>,
 /// }
 ///
 /// # fn test() -> Result<(), serde_json::Error> {
-/// let s = S {
-///     datetime: Some(date!(1970-01-01).with_time(time!(1:00)).assume_utc()),
+/// let s_some = S {
+///     datetime: Some(date!(2019-01-01).midnight().assume_utc()),
 /// };
-/// let v = json!({ "datetime": 3600 });
-/// assert_eq!(s.datetime, serde_json::from_value::<S>(v.clone())?.datetime);
-/// assert_eq!(v, serde_json::to_value(&s)?);
+/// let v_some = json!({ "datetime": 1_546_300_800 });
+/// assert_eq!(s_some.datetime, serde_json::from_value::<S>(v_some.clone())?.datetime);
+/// assert_eq!(v_some, serde_json::to_value(&s_some)?);
 ///
-/// let s = S { datetime: None };
-/// let v = json!({ "datetime": null });
-/// assert_eq!(s.datetime, serde_json::from_value::<S>(v.clone())?.datetime);
-/// assert_eq!(v, serde_json::to_value(&s)?);
+/// let s_none = S { datetime: None };
+/// let v_null = json!({ "datetime": null });
+/// assert_eq!(s_none.datetime, serde_json::from_value::<S>(v_null.clone())?.datetime);
+/// assert_eq!(v_null, serde_json::to_value(&s_none)?);
+///
+/// let v_missing = json!({});
+/// assert_eq!(s_none.datetime, serde_json::from_value::<S>(v_missing.clone())?.datetime);
 /// # Ok(())
 /// # }
 /// # test().unwrap();

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -1,9 +1,9 @@
 use crate::OffsetDateTime;
+use core::fmt;
 use serde::{
     de::{self, Visitor},
     Deserializer, Serializer,
 };
-use std::fmt;
 
 /// Fullfills the requirements for [serde's deserialize_with-annotation](https://serde.rs/field-attrs.html#deserialize_with).
 ///

--- a/src/serde/timestamp.rs
+++ b/src/serde/timestamp.rs
@@ -1,0 +1,144 @@
+use crate::OffsetDateTime;
+use serde::{
+    de::{self, Visitor},
+    Deserializer, Serializer,
+};
+use std::fmt;
+
+/// Fullfills the requirements for [serde's deserialize_with-annotation](https://serde.rs/field-attrs.html#deserialize_with).
+///
+/// Prefer using the parent module instead for brevity.
+#[allow(single_use_lifetimes)]
+pub fn deserialize<'de, D>(deserializer: D) -> Result<OffsetDateTime, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    /// A Visitor that deserializes a OffsetDateTime from a Unix timestamp
+    struct OffsetDateTimeVisitor;
+    impl Visitor<'_> for OffsetDateTimeVisitor {
+        type Value = OffsetDateTime;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a Unix timestamp")
+        }
+
+        fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(Self::Value::from_unix_timestamp(value))
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(Self::Value::from_unix_timestamp(value as i64))
+        }
+    }
+
+    deserializer.deserialize_i64(OffsetDateTimeVisitor)
+}
+
+/// Fullfills the requirements for [serde's serialize_with-annotation](https://serde.rs/field-attrs.html#serialize_with).
+///
+/// Prefer using the parent module instead for brevity.
+pub fn serialize<S>(datetime: &OffsetDateTime, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_i64(datetime.timestamp())
+}
+
+/// De/serialize [`Option<OffsetDateTime>`] from/to [Unix timestamps](https://en.wikipedia.org/wiki/Unix_time).
+///
+/// Use this module in combination with [serde's with-annotation](https://serde.rs/field-attrs.html#with).
+///
+/// Note that the timestamp represenatioon lacks [`UtcOffset`],
+/// which is being lost on serialization and assumed 0 on deserialization.
+///
+/// # Examples
+///
+/// ```
+/// # use serde::{Deserialize, Serialize};
+/// # use serde_json::json;
+/// use time::serde::timestamp;
+/// # use time::{date, time, OffsetDateTime};
+///
+/// #[derive(Deserialize, Serialize)]
+/// struct S {
+///     #[serde(with = "timestamp::option")]
+///     datetime: Option<OffsetDateTime>,
+/// }
+///
+/// let s = S {
+///     datetime: Some(date!(1970-01-01).with_time(time!(1:00)).assume_utc()),
+/// };
+/// let v = json!({ "datetime": 3600 });
+/// assert_eq!(s.datetime, serde_json::from_value::<S>(v.clone())?.datetime);
+/// assert_eq!(v, serde_json::to_value(&s)?);
+///
+/// let s = S { datetime: None };
+/// let v = json!({ "datetime": null });
+/// assert_eq!(s.datetime, serde_json::from_value::<S>(v.clone())?.datetime);
+/// assert_eq!(v, serde_json::to_value(&s)?);
+/// # Ok::<(), serde_json::Error>(())
+/// ```
+pub mod option {
+    use super::*;
+
+    /// Fullfills the requirements for [serde's deserialize_with-annotation](https://serde.rs/field-attrs.html#deserialize_with).
+    ///
+    /// Prefer using the parent module instead for brevity.
+    #[allow(single_use_lifetimes)]
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<OffsetDateTime>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        /// A Visitor that deserializes an optional OffsetDateTime from a Unix timestamp
+        struct OffsetDateTimeOptionVisitor;
+        impl<'de> Visitor<'de> for OffsetDateTimeOptionVisitor {
+            type Value = Option<OffsetDateTime>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an optional Unix timestamp")
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(None)
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(None)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                super::deserialize(deserializer).map(Some)
+            }
+        }
+
+        deserializer.deserialize_option(OffsetDateTimeOptionVisitor)
+    }
+
+    /// Fullfills the requirements for [serde's serialize_with-annotation](https://serde.rs/field-attrs.html#serialize_with).
+    ///
+    /// Prefer using the parent module instead for brevity.
+    pub fn serialize<S>(opt: &Option<OffsetDateTime>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match *opt {
+            Some(ref value) => super::serialize(value, serializer),
+            None => serializer.serialize_none(),
+        }
+    }
+}


### PR DESCRIPTION
Fixes #255.

This adds two modules fulfilling the requirements for serde's with-annotation: `time::serde::timestamp::{self, option}`.

As this requires a public module, I published the `time::serde` module. Would you prefer another place for this instead?