### PR TITLE
Change cfg_attr(tarpaulin, skip)

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -736,7 +736,7 @@ impl Duration {
 /// Functions that have been renamed or had signatures changed since v0.1. As
 /// such, they are deprecated.
 #[cfg(v01_deprecated_api)]
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 #[allow(clippy::missing_docs_in_private_items, clippy::missing_const_for_fn)]
 impl Duration {
     #[inline(always)]

--- a/src/instant.rs
+++ b/src/instant.rs
@@ -123,7 +123,7 @@ impl Instant {
 impl Instant {
     #[inline(always)]
     #[cfg(v01_deprecated_api)]
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     #[deprecated(since = "0.2.0", note = "Use `rhs - lhs`")]
     pub fn to(&self, later: Self) -> Duration {
         later - *self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -578,19 +578,17 @@ pub fn parse<T: private::Parsable>(s: impl AsRef<str>, format: impl AsRef<str>) 
 // and methods. They will be removed completely in 0.3.
 
 #[cfg(all(std, v01_deprecated_api))]
-#[cfg_attr(tarpaulin, skip)]
 #[allow(clippy::missing_docs_in_private_items)]
 #[deprecated(since = "0.2.0", note = "Use `Instant`")]
 pub type PreciseTime = Instant;
 
 #[cfg(all(std, v01_deprecated_api))]
-#[cfg_attr(tarpaulin, skip)]
 #[allow(clippy::missing_docs_in_private_items)]
 #[deprecated(since = "0.2.0", note = "Use `Instant`")]
 pub type SteadyTime = Instant;
 
 #[cfg(all(std, v01_deprecated_api))]
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 #[allow(clippy::missing_docs_in_private_items)]
 #[deprecated(
     since = "0.2.0",
@@ -609,7 +607,7 @@ pub fn precise_time_ns() -> u64 {
 }
 
 #[cfg(all(std, v01_deprecated_api))]
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 #[allow(clippy::missing_docs_in_private_items)]
 #[deprecated(
     since = "0.2.0",


### PR DESCRIPTION
So in 0.13.4 (yanked) tarpaulin actually started passing `--cfg=tarpaulin` so users could do `#[cfg_attr(tarpaulin, ignore)]` to ignore certain tests in coverage and also conditionally include/exclude code in coverage. This had the unintended result of breaking the recommended skip attr. 

Because of that 0.13.4 was yanked and later on a 0.14.0 version released which still did `--cfg=tarpaulin` but also `--cfg=tarpaulin_include` so that code could now be skipped but still included if you did `#[cfg(not(tarpaulin_include))]`. There's also an unstable `#[tarpaulin::skip]` tool attribute for those using nightly.

This PR changes time to use the new attributes as a user of time and tarpaulin found this broke their coverage CI. 

Link to relevant tarpaulin issue: https://github.com/xd009642/tarpaulin/issues/487 