### PR TITLE
Add WASI support for the 0.1 branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ rustc-serialize = { version = "0.3", optional = true }
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.0", features = ["std", "minwinbase", "minwindef", "ntdef", "profileapi", "sysinfoapi", "timezoneapi"] }
 
+[target.'cfg(target_os = "wasi")'.dependencies]
+wasi = "=0.10.0"
+
 [dev-dependencies]
 log = "0.4"
 winapi = { version = "0.3.0", features = ["std", "processthreadsapi", "winbase"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@
 #[cfg(windows)] extern crate winapi;
 #[cfg(feature = "rustc-serialize")] extern crate rustc_serialize;
 
+#[cfg(target_os = "wasi")] extern crate wasi;
+
 #[cfg(test)] #[macro_use] extern crate log;
 
 use std::cmp::Ordering;


### PR DESCRIPTION
This adds WASI support to the v0.1 branch, since some crates still depend on 0.1.x.