### PR TITLE
Fix incorrect parsing of the offset of a RFC-3339 time string

### DIFF
--- a/src/format/well_known.rs
+++ b/src/format/well_known.rs
@@ -103,12 +103,12 @@ pub(crate) mod rfc3339 {
                         })
                     }
                 };
-            let offset_hour: i32 =
+            let offset_hour: i16 =
                 try_consume_exact_digits(s, 2, Padding::Zero).ok_or(error::Parse::InvalidOffset)?;
             try_consume_char(s, ':')?;
-            let offset_minute: i32 =
+            let offset_minute: i16 =
                 try_consume_exact_digits(s, 2, Padding::Zero).ok_or(error::Parse::InvalidOffset)?;
-            items.offset = Some(UtcOffset::seconds(
+            items.offset = Some(UtcOffset::minutes(
                 offset_sign * (offset_hour * 60 + offset_minute),
             ));
         }

--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -1351,6 +1351,13 @@ mod test {
                 .with_time(time!(3:04:05))
                 .assume_offset(offset!(+6)))
         );
+        assert_eq!(
+            OffsetDateTime::parse("2020-09-08T08:44:31+02:30", Format::Rfc3339),
+            Ok(date!(2020-09-08)
+                .with_time(time!(08:44:31))
+                .assume_offset(offset!(+02:30)))
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION
The offset in 2020-09-08T08:44:31+02:30 was incorrectly interpreted as 2 minutes and 30 seconds.