### PR TITLE
Integer conversion on Solaris and Illumos

### DIFF
--- a/src/utc_offset.rs
+++ b/src/utc_offset.rs
@@ -378,6 +378,7 @@ fn try_local_offset_at(datetime: OffsetDateTime) -> Option<UtcOffset> {
         #[cfg(any(target_os = "solaris", target_os = "illumos"))]
         {
             use crate::Date;
+            use std::convert::TryFrom;
 
             let mut tm = tm;
             if tm.tm_sec == 60 {


### PR DESCRIPTION
The library was not used anywhere and it prevented the build from running on Illumos, this fixes it as far as I can tell.