### PR TITLE
Add benchmarks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,6 +138,38 @@ jobs:
           command: web
           args: check --all-features
 
+  check-benchmarks:
+    name: Type-check benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Change directories
+        run: cd time-benchmarks
+
+      - name: Cache cargo output
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ubuntu-latest-cargo-stable-benchmarks-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Type-check benchmarks
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --benches
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}
@@ -261,6 +293,7 @@ jobs:
     needs:
       - check-other-targets
       - check-web
+      - check-benchmarks
       - test
       - fmt
       - clippy

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+**/target
 **/*.rs.bk
 Cargo.lock
 tarpaulin-report.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ standback = { version = "0.2.5", default-features = false }
 time-macros = { version = "0.1", path = "time-macros", optional = true }
 
 [workspace]
-members = ["time-macros", "time-macros-impl"]
+members = ["time-benchmarks", "time-macros", "time-macros-impl"]
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }

--- a/tests/instant.rs
+++ b/tests/instant.rs
@@ -30,14 +30,14 @@ fn checked_sub() {
 }
 
 #[test]
-fn from_std() {
+fn std_from() {
     let now_time = Instant::now();
     let now_std = StdInstant::from(now_time);
     assert_eq!(now_time, now_std);
 }
 
 #[test]
-fn to_std() {
+fn from_std() {
     let now_std = StdInstant::now();
     let now_time = Instant::from(now_std);
     assert_eq!(now_time, now_std);

--- a/tests/offset_date_time.rs
+++ b/tests/offset_date_time.rs
@@ -713,7 +713,7 @@ fn eq_std() {
 fn std_eq() {
     let now_datetime = OffsetDateTime::now_utc();
     let now_systemtime = SystemTime::from(now_datetime);
-    assert_eq!(now_datetime, now_systemtime);
+    assert_eq!(now_systemtime, now_datetime);
 }
 
 #[test]

--- a/time-benchmarks/Cargo.toml
+++ b/time-benchmarks/Cargo.toml
@@ -11,7 +11,8 @@ description = "Benchmarks for the time crate."
 [dev-dependencies]
 criterion = "0.3"
 bench-util = { path = "./bench-util" }
-time = { path = "..", features = ["local-offset", "macros"] }
+rand = { version = "0.7", default-features = false }
+time = { path = "..", features = ["local-offset", "macros", "rand"] }
 
 [[bench]]
 name = "date"
@@ -31,4 +32,8 @@ harness = false
 
 [[bench]]
 name = "primitive_date_time"
+harness = false
+
+[[bench]]
+name = "rand"
 harness = false

--- a/time-benchmarks/Cargo.toml
+++ b/time-benchmarks/Cargo.toml
@@ -12,3 +12,7 @@ description = "Benchmarks for the time crate."
 criterion = "0.3"
 bench-util = { path = "./bench-util" }
 time = { path = "..", features = ["local-offset", "macros"] }
+
+[[bench]]
+name = "duration"
+harness = false

--- a/time-benchmarks/Cargo.toml
+++ b/time-benchmarks/Cargo.toml
@@ -24,6 +24,10 @@ name = "duration"
 harness = false
 
 [[bench]]
+name = "error"
+harness = false
+
+[[bench]]
 name = "instant"
 harness = false
 

--- a/time-benchmarks/Cargo.toml
+++ b/time-benchmarks/Cargo.toml
@@ -28,3 +28,7 @@ harness = false
 [[bench]]
 name = "offset_date_time"
 harness = false
+
+[[bench]]
+name = "primitive_date_time"
+harness = false

--- a/time-benchmarks/Cargo.toml
+++ b/time-benchmarks/Cargo.toml
@@ -20,3 +20,7 @@ harness = false
 [[bench]]
 name = "duration"
 harness = false
+
+[[bench]]
+name = "instant"
+harness = false

--- a/time-benchmarks/Cargo.toml
+++ b/time-benchmarks/Cargo.toml
@@ -12,7 +12,8 @@ description = "Benchmarks for the time crate."
 criterion = "0.3"
 bench-util = { path = "./bench-util" }
 rand = { version = "0.7", default-features = false }
-time = { path = "..", features = ["local-offset", "macros", "rand"] }
+serde_json = "1"
+time = { path = "..", features = ["local-offset", "macros", "rand", "serde"] }
 
 [[bench]]
 name = "date"
@@ -36,4 +37,8 @@ harness = false
 
 [[bench]]
 name = "rand"
+harness = false
+
+[[bench]]
+name = "serde"
 harness = false

--- a/time-benchmarks/Cargo.toml
+++ b/time-benchmarks/Cargo.toml
@@ -46,3 +46,7 @@ harness = false
 [[bench]]
 name = "time"
 harness = false
+
+[[bench]]
+name = "utc_offset"
+harness = false

--- a/time-benchmarks/Cargo.toml
+++ b/time-benchmarks/Cargo.toml
@@ -28,6 +28,18 @@ name = "error"
 harness = false
 
 [[bench]]
+name = "ext"
+harness = false
+
+[[bench]]
+name = "ext_std"
+harness = false
+
+[[bench]]
+name = "ext_std_short"
+harness = false
+
+[[bench]]
 name = "instant"
 harness = false
 

--- a/time-benchmarks/Cargo.toml
+++ b/time-benchmarks/Cargo.toml
@@ -42,3 +42,7 @@ harness = false
 [[bench]]
 name = "serde"
 harness = false
+
+[[bench]]
+name = "time"
+harness = false

--- a/time-benchmarks/Cargo.toml
+++ b/time-benchmarks/Cargo.toml
@@ -24,3 +24,7 @@ harness = false
 [[bench]]
 name = "instant"
 harness = false
+
+[[bench]]
+name = "offset_date_time"
+harness = false

--- a/time-benchmarks/Cargo.toml
+++ b/time-benchmarks/Cargo.toml
@@ -50,3 +50,7 @@ harness = false
 [[bench]]
 name = "utc_offset"
 harness = false
+
+[[bench]]
+name = "util"
+harness = false

--- a/time-benchmarks/Cargo.toml
+++ b/time-benchmarks/Cargo.toml
@@ -54,3 +54,7 @@ harness = false
 [[bench]]
 name = "util"
 harness = false
+
+[[bench]]
+name = "weekday"
+harness = false

--- a/time-benchmarks/Cargo.toml
+++ b/time-benchmarks/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "time-benchmarks"
+publish = false
+version = "0.0.0"
+authors = ["Jacob Pratt <the.z.cuber@gmail.com>", "Emil Lundberg <emil@emlun.se>"]
+edition = "2018"
+readme = "../README.md"
+license = "MIT OR Apache-2.0"
+description = "Benchmarks for the time crate."
+
+[dev-dependencies]
+criterion = "0.3"
+bench-util = { path = "./bench-util" }
+time = { path = "..", features = ["local-offset", "macros"] }

--- a/time-benchmarks/Cargo.toml
+++ b/time-benchmarks/Cargo.toml
@@ -14,5 +14,9 @@ bench-util = { path = "./bench-util" }
 time = { path = "..", features = ["local-offset", "macros"] }
 
 [[bench]]
+name = "date"
+harness = false
+
+[[bench]]
 name = "duration"
 harness = false

--- a/time-benchmarks/Cargo.toml
+++ b/time-benchmarks/Cargo.toml
@@ -36,6 +36,10 @@ name = "offset_date_time"
 harness = false
 
 [[bench]]
+name = "parse_error"
+harness = false
+
+[[bench]]
 name = "primitive_date_time"
 harness = false
 

--- a/time-benchmarks/LICENSE-Apache
+++ b/time-benchmarks/LICENSE-Apache
@@ -1,0 +1,1 @@
+../LICENSE-Apache

--- a/time-benchmarks/LICENSE-MIT
+++ b/time-benchmarks/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/time-benchmarks/bench-util/Cargo.toml
+++ b/time-benchmarks/bench-util/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "bench-util"
+publish = false
+version = "0.0.0"
+authors = ["Emil Lundberg <emil@emlun.se>"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+description = "Shared utilities for the time-benchmarks crate."
+
+[dependencies]
+criterion = "0.3"

--- a/time-benchmarks/bench-util/LICENSE-Apache
+++ b/time-benchmarks/bench-util/LICENSE-Apache
@@ -1,0 +1,1 @@
+../../LICENSE-Apache

--- a/time-benchmarks/bench-util/LICENSE-MIT
+++ b/time-benchmarks/bench-util/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/time-benchmarks/bench-util/src/lib.rs
+++ b/time-benchmarks/bench-util/src/lib.rs
@@ -1,0 +1,40 @@
+/// Helper macro that wraps code blocks in benchmark functions, and makes sure
+/// to add all those functions to the Criterion benchmark group.
+#[macro_export]
+macro_rules! setup_benchmark {
+    (
+        $group_prefix:literal,
+        $(
+            $(#[$fn_attr:meta])*
+            fn $fn_name:ident ($bencher:ident : &mut Bencher)
+            $code:block
+        )*
+    ) => {
+        $(
+            $(#[$fn_attr])*
+            pub fn $fn_name(c: &mut criterion::Criterion) {
+                c.bench_function(&format!("{}: {}", $group_prefix, stringify!($fn_name)), |$bencher| {
+                    $code
+                });
+            }
+        )*
+
+        criterion::criterion_group! {
+            name = benches;
+            config = criterion::Criterion::default()
+                // Set a stricter statistical significance threshold ("p-value")
+                // for deciding what's an actual performance change vs. noise.
+                // The more benchmarks, the lower this needs to be in order to
+                // not get lots of false positives.
+                .significance_level(0.0001)
+                // Ignore any performance change less than this (0.05 = 5%) as
+                // noise, regardless of statistical significance.
+                .noise_threshold(0.05)
+                // Reduce the time taken to run each benchmark
+                .warm_up_time(::std::time::Duration::from_millis(100))
+                .measurement_time(::std::time::Duration::from_millis(400));
+            targets = $($fn_name,)*
+        }
+        criterion::criterion_main!(benches);
+    };
+}

--- a/time-benchmarks/benches/date.rs
+++ b/time-benchmarks/benches/date.rs
@@ -1,0 +1,288 @@
+use bench_util::setup_benchmark;
+use criterion::{black_box, BatchSize};
+use time::{
+    date,
+    ext::{NumericalDuration, NumericalStdDuration},
+    time, util, Date, Weekday,
+};
+
+setup_benchmark! {
+    "Date",
+
+    fn debug(ben: &mut Bencher) {
+        let d = date!("2020-02-03");
+        ben.iter(|| format!("{:?}", d));
+    }
+
+    fn weeks_in_year_exhaustive(ben: &mut Bencher) {
+        ben.iter(|| {
+            for year in 0..400 {
+                black_box(util::weeks_in_year(year));
+            }
+        });
+    }
+
+    fn monday_based_week(ben: &mut Bencher) {
+        let d = date!("2023-01-01");
+        ben.iter(|| d.monday_based_week());
+    }
+
+    fn sunday_based_week(ben: &mut Bencher) {
+        let d = date!("2023-01-01");
+        ben.iter(|| d.sunday_based_week());
+    }
+
+    fn parse_monday_based_week(ben: &mut Bencher) {
+        ben.iter(|| Date::parse("Sun 00 2023", "%a %W %Y"));
+    }
+
+    fn parse_sunday_based_week(ben: &mut Bencher) {
+        ben.iter(|| Date::parse("Sun 01 2018", "%a %U %Y"));
+    }
+
+    fn from_iso_ywd(ben: &mut Bencher) {
+        use Weekday::*;
+        ben.iter(|| (
+            Date::from_iso_ywd(2019, 1, Monday),
+            Date::from_iso_ywd(2019, 1, Tuesday),
+            Date::from_iso_ywd(2020, 53, Friday),
+            Date::from_iso_ywd(2019, 53, Monday),
+        ));
+    }
+
+    fn year(ben: &mut Bencher) {
+        let d = date!("2019-002");
+        ben.iter(|| d.year());
+    }
+
+    fn month(ben: &mut Bencher) {
+        let d = date!("2019-002");
+        ben.iter(|| d.month());
+    }
+
+    fn day(ben: &mut Bencher) {
+        let d = date!("2019-002");
+        ben.iter(|| d.day());
+    }
+
+    fn iso_year_week(ben: &mut Bencher) {
+        let d = date!("2019-01-01");
+        ben.iter(|| d.iso_year_week());
+    }
+
+    fn week(ben: &mut Bencher) {
+        let d = date!("2019-01-01");
+        ben.iter(|| d.week());
+    }
+
+    fn as_ymd(ben: &mut Bencher) {
+        let d = date!("2019-01-02");
+        ben.iter(|| d.as_ymd());
+    }
+
+    fn as_yo(ben: &mut Bencher) {
+        let d = date!("2019-01-01");
+        ben.iter(|| d.as_yo());
+    }
+
+    fn next_day(ben: &mut Bencher) {
+        let d = date!("2019-01-01");
+        ben.iter(|| d.next_day());
+    }
+
+    fn previous_day(ben: &mut Bencher) {
+        let d = date!("2019-01-02");
+        ben.iter(|| d.previous_day());
+    }
+
+    fn julian_day(ben: &mut Bencher) {
+        let d = date!("-100_000-01-01");
+        ben.iter(|| d.julian_day());
+    }
+
+    fn from_julian_day(ben: &mut Bencher) {
+        ben.iter(|| Date::from_julian_day(-34_803_190));
+    }
+
+    fn midnight(ben: &mut Bencher) {
+        let d = date!("1970-01-01");
+        ben.iter(|| d.midnight());
+    }
+
+    fn with_time(ben: &mut Bencher) {
+        let d = date!("1970-01-01");
+        let t = time!("0:00");
+        ben.iter(|| d.with_time(t));
+    }
+
+    fn with_hms(ben: &mut Bencher) {
+        let d = date!("1970-01-01");
+        ben.iter(|| d.with_hms(0, 0, 0));
+    }
+
+    fn with_hms_milli(ben: &mut Bencher) {
+        let d = date!("1970-01-01");
+        ben.iter(|| d.with_hms_milli(0, 0, 0, 0));
+    }
+
+    fn with_hms_micro(ben: &mut Bencher) {
+        let d = date!("1970-01-01");
+        ben.iter(|| d.with_hms_micro(0, 0, 0, 0));
+    }
+
+    fn with_hms_nano(ben: &mut Bencher) {
+        let d = date!("1970-01-01");
+        ben.iter(|| d.with_hms_nano(0, 0, 0, 0));
+    }
+
+    fn format(ben: &mut Bencher) {
+        // Check all specifiers for date objects.
+        let date = date!("2019-01-02");
+        ben.iter(|| (
+            date.format("%a"),
+            date.format("%A"),
+            date.format("%b"),
+            date.format("%B"),
+            date.format("%C"),
+            date.format("%d"),
+            date.format("%D"),
+            date.format("%F"),
+            date.format("%g"),
+            date.format("%G"),
+            date.format("%j"),
+            date.format("%m"),
+            date.format("%u"),
+            date.format("%U"),
+            date.format("%V"),
+            date.format("%w"),
+            date.format("%W"),
+            date.format("%y"),
+            date.format("%Y"),
+        ));
+    }
+
+    fn parse(ben: &mut Bencher) {
+        ben.iter(|| (
+            Date::parse("2019-01-02 Wed", "%F %a"),
+            Date::parse("2019-01-02 Wednesday", "%F %A"),
+            Date::parse("2019-01-02 Jan", "%F %b"),
+            Date::parse("2019-01-02 January", "%F %B"),
+            Date::parse("2019-01-02 20", "%F %C"),
+            Date::parse("2019-01-02 02", "%F %d"),
+            Date::parse("2019-01-02 1/02/19", "%F %D"),
+            Date::parse("2019-01-02", "%F"),
+            Date::parse("2019-01-02 19", "%F %g"),
+            Date::parse("2019-01-02 2019", "%F %G"),
+            Date::parse("2019-01-02 002", "%F %j"),
+            Date::parse("2019-01-02 01", "%F %m"),
+            Date::parse("2019-01-02 3", "%F %u"),
+            Date::parse("2019-01-02 00", "%F %U"),
+            Date::parse("2019-01-02 01", "%F %V"),
+            Date::parse("2019-01-02 3", "%F %w"),
+            Date::parse("2019-01-02 00", "%F %W"),
+            Date::parse("2019-01-02 19", "%F %y"),
+            Date::parse("2019-01-02 2019", "%F %Y"),
+            Date::parse("", ""),
+        ));
+    }
+
+    fn display(ben: &mut Bencher) {
+        let d = date!("2019-01-01");
+        ben.iter(|| d.to_string());
+    }
+
+    fn add(ben: &mut Bencher) {
+        let d = date!("2019-01-01");
+        let dt = 5.days();
+        ben.iter(|| d + dt);
+    }
+
+    fn add_std(ben: &mut Bencher) {
+        let d = date!("2019-01-01");
+        let dt = 5.std_days();
+        ben.iter(|| d + dt);
+    }
+
+    fn add_assign(ben: &mut Bencher) {
+        let dt = 1.days();
+        ben.iter_batched_ref(
+            || date!("2019-12-31"),
+            |date| {
+                *date += dt;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn add_assign_std(ben: &mut Bencher) {
+        let dt = 1.std_days();
+        ben.iter_batched_ref(
+            || date!("2019-12-31"),
+            |date| {
+                *date += dt;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn sub(ben: &mut Bencher) {
+        let d = date!("2019-01-06");
+        let dt = 5.days();
+        ben.iter(|| d - dt);
+    }
+
+    fn sub_std(ben: &mut Bencher) {
+        let d = date!("2019-01-06");
+        let dt = 5.std_days();
+        ben.iter(|| d - dt);
+    }
+
+    fn sub_assign(ben: &mut Bencher) {
+        let dt = 1.days();
+        ben.iter_batched_ref(
+            || date!("2020-01-01"),
+            |date| {
+                *date -= dt;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn sub_assign_std(ben: &mut Bencher) {
+        let dt = 1.std_days();
+        ben.iter_batched_ref(
+            || date!("2020-01-01"),
+            |date| {
+                *date -= dt;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn sub_self(ben: &mut Bencher) {
+        let first = date!("2019-01-01");
+        let second = date!("2019-01-02");
+        ben.iter(|| second - first);
+    }
+
+    fn partial_ord(ben: &mut Bencher) {
+        let first = date!("2019-01-01");
+        let second = date!("2019-01-02");
+        ben.iter(|| (
+            first.partial_cmp(&first),
+            first.partial_cmp(&second),
+            second.partial_cmp(&first),
+        ));
+    }
+
+    fn ord(ben: &mut Bencher) {
+        let first = date!("2019-01-01");
+        let second = date!("2019-01-02");
+        ben.iter(|| (
+            first.cmp(&first),
+            first.cmp(&second),
+            second.cmp(&first),
+        ));
+    }
+
+}

--- a/time-benchmarks/benches/duration.rs
+++ b/time-benchmarks/benches/duration.rs
@@ -1,0 +1,696 @@
+use bench_util::setup_benchmark;
+use criterion::BatchSize;
+use std::{convert::TryFrom, time::Duration as StdDuration};
+use time::{
+    ext::{NumericalDuration, NumericalStdDuration},
+    Duration,
+};
+
+setup_benchmark! {
+    "Duration",
+
+    fn unit_values(ben: &mut Bencher) {
+        ben.iter(|| (
+            Duration::zero(),
+            Duration::nanosecond(),
+            Duration::microsecond(),
+            Duration::millisecond(),
+            Duration::second(),
+            Duration::minute(),
+            Duration::hour(),
+            Duration::day(),
+            Duration::week(),
+        ));
+    }
+
+    fn is_zero(ben: &mut Bencher) {
+        let a = (-1).nanoseconds();
+        let b = 0.seconds();
+        let c = 1.nanoseconds();
+        ben.iter(|| (
+            a.is_zero(),
+            b.is_zero(),
+            c.is_zero(),
+        ));
+    }
+
+    fn is_negative(ben: &mut Bencher) {
+        let a = (-1).seconds();
+        let b = 0.seconds();
+        let c = 1.seconds();
+        ben.iter(|| (
+            a.is_negative(),
+            b.is_negative(),
+            c.is_negative(),
+        ));
+    }
+
+    fn is_positive(ben: &mut Bencher) {
+        let a = (-1).seconds();
+        let b = 0.seconds();
+        let c = 1.seconds();
+        ben.iter(|| (
+            a.is_positive(),
+            b.is_positive(),
+            c.is_positive(),
+        ));
+    }
+
+    fn abs(ben: &mut Bencher) {
+        let a = 1.seconds();
+        let b = 0.seconds();
+        let c = (-1).seconds();
+        ben.iter(|| (
+            a.abs(),
+            b.abs(),
+            c.abs(),
+        ));
+    }
+
+    fn new(ben: &mut Bencher) {
+        ben.iter(|| (
+            Duration::new(1, 0),
+            Duration::new(-1, 0),
+            Duration::new(1, 2_000_000_000),
+
+            Duration::new(0, 0),
+            Duration::new(0, 1_000_000_000),
+            Duration::new(-1, 1_000_000_000),
+            Duration::new(-2, 1_000_000_000),
+
+            Duration::new(1, -1),
+            Duration::new(-1, 1),
+            Duration::new(1, 1),
+            Duration::new(-1, -1),
+            Duration::new(0, 1),
+            Duration::new(0, -1),
+
+            Duration::new(-1, 1_400_000_000),
+            Duration::new(-2, 1_400_000_000),
+            Duration::new(-3, 1_400_000_000),
+            Duration::new(1, -1_400_000_000),
+            Duration::new(2, -1_400_000_000),
+            Duration::new(3, -1_400_000_000),
+        ));
+    }
+
+    fn weeks(ben: &mut Bencher) {
+        ben.iter(|| (
+            Duration::weeks(1),
+            Duration::weeks(2),
+            Duration::weeks(-1),
+            Duration::weeks(-2),
+        ));
+    }
+
+    fn whole_weeks(ben: &mut Bencher) {
+        let a = Duration::weeks(1);
+        let b = Duration::weeks(-1);
+        let c = Duration::days(6);
+        let d = Duration::days(-6);
+        ben.iter(|| (
+            a.whole_weeks(),
+            b.whole_weeks(),
+            c.whole_weeks(),
+            d.whole_weeks(),
+        ));
+    }
+
+    fn days(ben: &mut Bencher) {
+        ben.iter(|| (
+            Duration::days(1),
+            Duration::days(2),
+            Duration::days(-1),
+            Duration::days(-2),
+        ));
+    }
+
+    fn whole_days(ben: &mut Bencher) {
+        let a = Duration::days(1);
+        let b = Duration::days(-1);
+        let c = Duration::hours(23);
+        let d = Duration::hours(-23);
+        ben.iter(|| (
+            a.whole_days(),
+            b.whole_days(),
+            c.whole_days(),
+            d.whole_days(),
+        ));
+    }
+
+    fn hours(ben: &mut Bencher) {
+        ben.iter(|| (
+            Duration::hours(1),
+            Duration::hours(2),
+            Duration::hours(-1),
+            Duration::hours(-2),
+        ));
+    }
+
+    fn whole_hours(ben: &mut Bencher) {
+        let a = Duration::hours(1);
+        let b = Duration::hours(-1);
+        let c = Duration::minutes(59);
+        let d = Duration::minutes(-59);
+        ben.iter(|| (
+            a.whole_hours(),
+            b.whole_hours(),
+            c.whole_hours(),
+            d.whole_hours(),
+        ));
+    }
+
+    fn minutes(ben: &mut Bencher) {
+        ben.iter(|| (
+            Duration::minutes(1),
+            Duration::minutes(2),
+            Duration::minutes(-1),
+            Duration::minutes(-2),
+        ));
+    }
+
+    fn whole_minutes(ben: &mut Bencher) {
+        let a = 1.minutes();
+        let b = (-1).minutes();
+        let c = 59.seconds();
+        let d = (-59).seconds();
+        ben.iter(|| (
+            a.whole_minutes(),
+            b.whole_minutes(),
+            c.whole_minutes(),
+            d.whole_minutes(),
+        ));
+    }
+
+    fn seconds(ben: &mut Bencher) {
+        ben.iter(|| (
+            Duration::seconds(1),
+            Duration::seconds(2),
+            Duration::seconds(-1),
+            Duration::seconds(-2),
+        ));
+    }
+
+    fn whole_seconds(ben: &mut Bencher) {
+        let a = 1.seconds();
+        let b = (-1).seconds();
+        let c = 1.minutes();
+        let d = (-1).minutes();
+        ben.iter(|| (
+            a.whole_seconds(),
+            b.whole_seconds(),
+            c.whole_seconds(),
+            d.whole_seconds(),
+        ));
+    }
+
+    fn seconds_f64(ben: &mut Bencher) {
+        ben.iter(|| (
+            Duration::seconds_f64(0.5),
+            Duration::seconds_f64(-0.5),
+        ));
+    }
+
+    fn as_seconds_f64(ben: &mut Bencher) {
+        let a = 1.seconds();
+        let b = (-1).seconds();
+        let c = 1.minutes();
+        let d = (-1).minutes();
+        let e = 1.5.seconds();
+        let f = (-1.5).seconds();
+        ben.iter(|| (
+            a.as_seconds_f64(),
+            b.as_seconds_f64(),
+            c.as_seconds_f64(),
+            d.as_seconds_f64(),
+            e.as_seconds_f64(),
+            f.as_seconds_f64(),
+        ));
+    }
+
+    fn seconds_f32(ben: &mut Bencher) {
+        ben.iter(|| (
+            Duration::seconds_f32(0.5),
+            Duration::seconds_f32(-0.5),
+        ));
+    }
+
+    fn as_seconds_f32(ben: &mut Bencher) {
+        let a = 1.seconds();
+        let b = (-1).seconds();
+        let c = 1.minutes();
+        let d = (-1).minutes();
+        let e = 1.5.seconds();
+        let f = (-1.5).seconds();
+        ben.iter(|| (
+            a.as_seconds_f32(),
+            b.as_seconds_f32(),
+            c.as_seconds_f32(),
+            d.as_seconds_f32(),
+            e.as_seconds_f32(),
+            f.as_seconds_f32(),
+        ));
+    }
+
+    fn milliseconds(ben: &mut Bencher) {
+        ben.iter(|| (
+            Duration::milliseconds(1),
+            Duration::milliseconds(-1),
+        ));
+    }
+
+    fn whole_milliseconds(ben: &mut Bencher) {
+        let a = 1.seconds();
+        let b = (-1).seconds();
+        let c = 1.milliseconds();
+        let d = (-1).milliseconds();
+        ben.iter(|| (
+            a.whole_milliseconds(),
+            b.whole_milliseconds(),
+            c.whole_milliseconds(),
+            d.whole_milliseconds(),
+        ));
+    }
+
+    fn subsec_milliseconds(ben: &mut Bencher) {
+        let a = 1.4.seconds();
+        let b = (-1.4).seconds();
+        ben.iter(|| (
+            a.subsec_milliseconds(),
+            b.subsec_milliseconds(),
+        ));
+    }
+
+    fn microseconds(ben: &mut Bencher) {
+        ben.iter(|| (
+            Duration::microseconds(1),
+            Duration::microseconds(-1),
+        ));
+    }
+
+    fn whole_microseconds(ben: &mut Bencher) {
+        let a = 1.milliseconds();
+        let b = (-1).milliseconds();
+        let c = 1.microseconds();
+        let d = (-1).microseconds();
+        ben.iter(|| (
+            a.whole_microseconds(),
+            b.whole_microseconds(),
+            c.whole_microseconds(),
+            d.whole_microseconds(),
+        ));
+    }
+
+    fn subsec_microseconds(ben: &mut Bencher) {
+        let a = 1.0004.seconds();
+        let b = (-1.0004).seconds();
+        ben.iter(|| (
+            a.subsec_microseconds(),
+            b.subsec_microseconds(),
+        ));
+    }
+
+    fn nanoseconds(ben: &mut Bencher) {
+        ben.iter(|| (
+            Duration::nanoseconds(1),
+            Duration::nanoseconds(-1),
+        ));
+    }
+
+    fn whole_nanoseconds(ben: &mut Bencher) {
+        let a = 1.microseconds();
+        let b = (-1).microseconds();
+        let c = 1.nanoseconds();
+        let d = (-1).nanoseconds();
+        ben.iter(|| (
+            a.whole_nanoseconds(),
+            b.whole_nanoseconds(),
+            c.whole_nanoseconds(),
+            d.whole_nanoseconds(),
+        ));
+    }
+
+    fn subsec_nanoseconds(ben: &mut Bencher) {
+        let a = 1.000_000_4.seconds();
+        let b = (-1.000_000_4).seconds();
+        ben.iter(|| (
+            a.subsec_nanoseconds(),
+            b.subsec_nanoseconds(),
+        ));
+    }
+
+    fn checked_add(ben: &mut Bencher) {
+        let a = 5.seconds();
+        let b = Duration::max_value();
+        let c = (-5).seconds();
+
+        let a2 = 5.seconds();
+        let b2 = 1.nanoseconds();
+        let c2 = 5.seconds();
+
+        ben.iter(|| (
+            a.checked_add(a2),
+            b.checked_add(b2),
+            c.checked_add(c2),
+        ));
+    }
+
+    fn checked_sub(ben: &mut Bencher) {
+        let a = 5.seconds();
+        let b = Duration::min_value();
+        let c = 5.seconds();
+
+        let a2 = 5.seconds();
+        let b2 = 1.nanoseconds();
+        let c2 = 10.seconds();
+
+        ben.iter(|| (
+            a.checked_sub(a2),
+            b.checked_sub(b2),
+            c.checked_sub(c2),
+        ));
+    }
+
+    fn checked_mul(ben: &mut Bencher) {
+        let d = 5.seconds();
+        ben.iter(|| d.checked_mul(2));
+    }
+
+    fn checked_div(ben: &mut Bencher) {
+        let d = 10.seconds();
+        ben.iter(|| d.checked_div(2));
+    }
+
+    fn try_from_std_duration(ben: &mut Bencher) {
+        let a = 0.std_seconds();
+        let b = 1.std_seconds();
+        ben.iter(|| (
+            Duration::try_from(a),
+            Duration::try_from(b),
+        ));
+    }
+
+    fn try_to_std_duration(ben: &mut Bencher) {
+        let a = 0.seconds();
+        let b = 1.seconds();
+        let c = (-1).seconds();
+        ben.iter(|| (
+            StdDuration::try_from(a),
+            StdDuration::try_from(b),
+            StdDuration::try_from(c),
+        ));
+    }
+
+    fn add(ben: &mut Bencher) {
+        let a = 1.seconds();
+        let b = 2.seconds();
+        let c = 500.milliseconds();
+        let d = (-1).seconds();
+        ben.iter(|| a + b + c + d);
+    }
+
+    fn add_std(ben: &mut Bencher) {
+        let a = 1.seconds();
+        let b = 2.std_seconds();
+        ben.iter(|| a + b);
+    }
+
+    fn std_add(ben: &mut Bencher) {
+        let a = 1.std_seconds();
+        let b = 2.seconds();
+        ben.iter(|| a + b);
+    }
+
+    fn add_assign(ben: &mut Bencher) {
+        let dta = 1.seconds();
+        let dtb = 500.milliseconds();
+        let dtc = (-1).seconds();
+        ben.iter_batched_ref(
+            || 1.seconds(),
+            |duration| {
+                *duration += dta;
+                *duration += dtb;
+                *duration += dtc;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn add_assign_std(ben: &mut Bencher) {
+        let dta = 1.std_seconds();
+        let dtb = 500.std_milliseconds();
+        ben.iter_batched_ref(
+            || 1.seconds(),
+            |duration| {
+                *duration += dta;
+                *duration += dtb;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn neg(ben: &mut Bencher) {
+        let a = 1.seconds();
+        let b = (-1).seconds();
+        let c = 0.seconds();
+        ben.iter(|| (-a, -b, -c));
+    }
+
+    fn sub(ben: &mut Bencher) {
+        let a = 1.seconds();
+        let b = 1.seconds();
+        let c = 1_500.milliseconds();
+        let d = 500.milliseconds();
+        let e = 1.seconds();
+        let f = (-1).seconds();
+        ben.iter(|| a - b - c - d - e - f);
+    }
+
+    fn sub_std(ben: &mut Bencher) {
+        let a = 1.seconds();
+        let b = 2.std_seconds();
+        ben.iter(|| a - b);
+    }
+
+    fn std_sub(ben: &mut Bencher) {
+        let a = 1.std_seconds();
+        let b = 2.seconds();
+        ben.iter(|| a - b);
+    }
+
+    fn sub_assign(ben: &mut Bencher) {
+        let dta = 1.seconds();
+        let dtb = 500.milliseconds();
+        let dtc = (-1).seconds();
+        ben.iter_batched_ref(
+            || 1.seconds(),
+            |duration| {
+                *duration -= dta;
+                *duration -= dtb;
+                *duration -= dtc;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn mul_int(ben: &mut Bencher) {
+        let d = 1.seconds();
+        ben.iter(|| (d * 2) * -2);
+    }
+
+    fn mul_int_assign(ben: &mut Bencher) {
+        ben.iter_batched_ref(
+            || 1.seconds(),
+            |duration| {
+                *duration *= 2;
+                *duration *= -2;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn int_mul(ben: &mut Bencher) {
+        let d = 1.seconds();
+        ben.iter(|| (-2) * (2 * d));
+    }
+
+    fn div_int(ben: &mut Bencher) {
+        let d = 1.seconds();
+        ben.iter(|| (d / 2) / -2);
+    }
+
+    fn div_int_assign(ben: &mut Bencher) {
+        ben.iter_batched_ref(
+            || 1.seconds(),
+            |duration| {
+                *duration /= 2;
+                *duration /= -2;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn div(ben: &mut Bencher) {
+        let a = 1.seconds();
+        let b = 0.5.seconds();
+        ben.iter(|| a / b);
+    }
+
+    fn mul_float(ben: &mut Bencher) {
+        let d = 1.seconds();
+        ben.iter(||
+            d * 1.5_f32 * 2.5_f32 * -1.5_f32 * 0_f32 * 1.5_f64 * 2.5_f64 * -1.5_f64 * 0_f64
+        );
+    }
+
+    fn float_mul(ben: &mut Bencher) {
+        let d = 1.seconds();
+        ben.iter(||
+            1.5_f32 * (2.5_f32 * (-1.5_f32 * (3.15_f32 * (1.5_f64 * (2.5_f64 * (-1.5_f64 * d))))))
+        );
+    }
+
+    fn mul_float_assign(ben: &mut Bencher) {
+        ben.iter_batched_ref(
+            || 1.seconds(),
+            |duration| {
+                *duration *= 1.5_f32;
+                *duration *= 2.5_f32;
+                *duration *= -1.5_f32;
+                *duration *= 3.15_f32;
+                *duration *= 1.5_f64;
+                *duration *= 2.5_f64;
+                *duration *= -1.5_f64;
+                *duration *= 0_f64;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn div_float(ben: &mut Bencher) {
+        let d = 1.seconds();
+        ben.iter(|| d / 1_f32 / 2_f32 / -1_f32 / 1_f64 / 2_f64 / -1_f64);
+    }
+
+    fn div_float_assign(ben: &mut Bencher) {
+        ben.iter_batched_ref(
+            || 10.seconds(),
+            |duration| {
+                *duration /= 1_f32;
+                *duration /= 2_f32;
+                *duration /= -1_f32;
+                *duration /= 1_f64;
+                *duration /= 2_f64;
+                *duration /= -1_f64;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn partial_eq(ben: &mut Bencher) {
+        let a = 1.minutes();
+        let b = (-1).minutes();
+        let c = 40.seconds();
+        ben.iter(|| (a == b, c == a));
+    }
+
+    fn partial_eq_std(ben: &mut Bencher) {
+        let a = (-1).seconds();
+        let b = 1.std_seconds();
+        let c = (-1).minutes();
+        let d = 1.std_minutes();
+        let e = 40.seconds();
+        ben.iter(|| (
+            a == b,
+            c == d,
+            e == d,
+        ));
+    }
+
+    fn std_partial_eq(ben: &mut Bencher) {
+        let a = 1.std_seconds();
+        let b = (-1).seconds();
+        let c = 1.std_minutes();
+        let d = (-1).minutes();
+        let e = 40.std_seconds();
+        let f = 1.minutes();
+        ben.iter(|| (
+            a == b,
+            c == d,
+            e == f,
+        ));
+    }
+
+    fn partial_ord(ben: &mut Bencher) {
+        let a = 0.seconds();
+        let b = 1.seconds();
+        let c = (-1).seconds();
+        let d = 1.minutes();
+        let e = (-1).minutes();
+        ben.iter(|| (
+            a.partial_cmp(&a),
+            b.partial_cmp(&a),
+            b.partial_cmp(&c),
+            c.partial_cmp(&b),
+            a.partial_cmp(&c),
+            a.partial_cmp(&b),
+            c.partial_cmp(&a),
+            d.partial_cmp(&b),
+            e.partial_cmp(&c),
+        ));
+    }
+
+    fn partial_ord_std(ben: &mut Bencher) {
+        let a = 0.seconds();
+        let b = 0.std_seconds();
+        let c = 1.seconds();
+        let d = (-1).seconds();
+        let e = 1.std_seconds();
+        let f = 1.minutes();
+        let g = u64::MAX.std_seconds();
+        ben.iter(|| (
+            a.partial_cmp(&b),
+            c.partial_cmp(&b),
+            d.partial_cmp(&e),
+            a.partial_cmp(&e),
+            d.partial_cmp(&b),
+            f.partial_cmp(&e),
+            a.partial_cmp(&g),
+        ));
+    }
+
+    fn std_partial_ord(ben: &mut Bencher) {
+        let a = 0.std_seconds();
+        let b = 0.seconds();
+        let c = 1.std_seconds();
+        let d = (-1).seconds();
+        let e = 1.seconds();
+        let f = 1.std_minutes();
+        ben.iter(|| (
+            a.partial_cmp(&b),
+            c.partial_cmp(&b),
+            c.partial_cmp(&d),
+            a.partial_cmp(&d),
+            a.partial_cmp(&e),
+            f.partial_cmp(&e),
+        ));
+    }
+
+    fn ord(ben: &mut Bencher) {
+        let a = 1.seconds();
+        let b = 0.seconds();
+        let c = (-1).seconds();
+        let d = 1.minutes();
+        let e = (-1).minutes();
+        ben.iter(|| (
+            a > b,
+            a > c,
+            c < a,
+            b > c,
+            b < a,
+            c < b,
+            d > a,
+            e < c,
+        ));
+    }
+}

--- a/time-benchmarks/benches/error.rs
+++ b/time-benchmarks/benches/error.rs
@@ -1,0 +1,68 @@
+use bench_util::setup_benchmark;
+use time::{error, Date, Error};
+
+fn component_range() -> error::ComponentRange {
+    Date::from_yo(0, 367).unwrap_err()
+}
+
+fn parse() -> error::Parse {
+    Date::parse("", " ").unwrap_err()
+}
+
+fn format_insufficient() -> error::Format {
+    error::Format::InsufficientTypeInformation
+}
+
+fn format_std() -> error::Format {
+    std::fmt::Error.into()
+}
+
+setup_benchmark! {
+    "Error",
+
+    fn display(ben: &mut Bencher) {
+        let a = error::ConversionRange;
+        let b = Error::ConversionRange;
+        let c = component_range();
+        let d = Error::ComponentRange(component_range().into());
+        let e = parse();
+        let f = Error::Parse(parse());
+        let g = format_insufficient();
+        let h = Error::Format(format_insufficient());
+        let i = format_std();
+        let j = Error::Format(format_std());
+
+        ben.iter(|| (
+            a.to_string(),
+            b.to_string(),
+            c.to_string(),
+            d.to_string(),
+            e.to_string(),
+            f.to_string(),
+            g.to_string(),
+            h.to_string(),
+            i.to_string(),
+            j.to_string(),
+        ));
+    }
+
+    fn source(ben: &mut Bencher) {
+        use std::error::Error as StdError;
+
+        let a = Error::from(error::ConversionRange);
+        let b = Error::from(component_range());
+        let c = Error::from(parse());
+        let d = Error::from(format_insufficient());
+        let e = format_insufficient();
+        let f = format_std();
+
+        ben.iter(|| (
+            a.source(),
+            b.source(),
+            c.source(),
+            d.source(),
+            e.source(),
+            f.source(),
+        ));
+    }
+}

--- a/time-benchmarks/benches/ext.rs
+++ b/time-benchmarks/benches/ext.rs
@@ -1,0 +1,69 @@
+use bench_util::setup_benchmark;
+use std::num::NonZeroU8;
+use time::ext::NumericalDuration;
+
+setup_benchmark! {
+    "Numerical durations",
+
+    fn unsigned(ben: &mut Bencher) {
+        ben.iter(|| (
+            5.nanoseconds(),
+            5.microseconds(),
+            5.milliseconds(),
+            5.seconds(),
+            5.minutes(),
+            5.hours(),
+            5.days(),
+            5.weeks(),
+        ));
+    }
+
+    fn signed(ben: &mut Bencher) {
+        ben.iter(|| (
+            (-5).nanoseconds(),
+            (-5).microseconds(),
+            (-5).milliseconds(),
+            (-5).seconds(),
+            (-5).minutes(),
+            (-5).hours(),
+            (-5).days(),
+            (-5).weeks(),
+        ));
+    }
+
+    fn nonzero(ben: &mut Bencher) {
+        let nz = NonZeroU8::new(5).unwrap();
+        ben.iter(|| (
+            nz.nanoseconds(),
+            nz.microseconds(),
+            nz.milliseconds(),
+            nz.seconds(),
+            nz.minutes(),
+            nz.hours(),
+            nz.days(),
+            nz.weeks(),
+        ));
+    }
+
+    fn float(ben: &mut Bencher) {
+        ben.iter(|| (
+            1.9.nanoseconds(),
+            1.0.nanoseconds(),
+            1.0.microseconds(),
+            1.0.milliseconds(),
+            1.0.seconds(),
+            1.0.minutes(),
+            1.0.hours(),
+            1.0.days(),
+            1.0.weeks(),
+            1.5.nanoseconds(),
+            1.5.microseconds(),
+            1.5.milliseconds(),
+            1.5.seconds(),
+            1.5.minutes(),
+            1.5.hours(),
+            1.5.days(),
+            1.5.weeks(),
+        ));
+    }
+}

--- a/time-benchmarks/benches/ext_std.rs
+++ b/time-benchmarks/benches/ext_std.rs
@@ -1,0 +1,69 @@
+use bench_util::setup_benchmark;
+use std::num::NonZeroU8;
+use time::ext::NumericalStdDuration;
+
+setup_benchmark! {
+    "Numerical durations (std)",
+
+    fn unsigned(ben: &mut Bencher) {
+        ben.iter(|| (
+            5.std_nanoseconds(),
+            5.std_microseconds(),
+            5.std_milliseconds(),
+            5.std_seconds(),
+            5.std_minutes(),
+            5.std_hours(),
+            5.std_days(),
+            5.std_weeks(),
+        ));
+    }
+
+    fn unsigned_typed(ben: &mut Bencher) {
+        ben.iter(|| (
+            5_u64.std_nanoseconds(),
+            5_u64.std_microseconds(),
+            5_u64.std_milliseconds(),
+            5_u64.std_seconds(),
+            5_u64.std_minutes(),
+            5_u64.std_hours(),
+            5_u64.std_days(),
+            5_u64.std_weeks(),
+        ));
+    }
+
+    fn nonzero(ben: &mut Bencher) {
+        let nz = NonZeroU8::new(5).unwrap();
+        ben.iter(|| (
+            nz.std_nanoseconds(),
+            nz.std_microseconds(),
+            nz.std_milliseconds(),
+            nz.std_seconds(),
+            nz.std_minutes(),
+            nz.std_hours(),
+            nz.std_days(),
+            nz.std_weeks(),
+        ));
+    }
+
+    fn float(ben: &mut Bencher) {
+        ben.iter(|| (
+            1.9.std_nanoseconds(),
+            1.0.std_nanoseconds(),
+            1.0.std_microseconds(),
+            1.0.std_milliseconds(),
+            1.0.std_seconds(),
+            1.0.std_minutes(),
+            1.0.std_hours(),
+            1.0.std_days(),
+            1.0.std_weeks(),
+            1.5.std_nanoseconds(),
+            1.5.std_microseconds(),
+            1.5.std_milliseconds(),
+            1.5.std_seconds(),
+            1.5.std_minutes(),
+            1.5.std_hours(),
+            1.5.std_days(),
+            1.5.std_weeks(),
+        ));
+    }
+}

--- a/time-benchmarks/benches/ext_std_short.rs
+++ b/time-benchmarks/benches/ext_std_short.rs
@@ -1,0 +1,41 @@
+use bench_util::setup_benchmark;
+use time::ext::NumericalStdDurationShort;
+
+setup_benchmark! {
+    "Numerical durations (std, short)",
+
+    fn unsigned(ben: &mut Bencher) {
+        ben.iter(|| (
+            5.nanoseconds(),
+            5.microseconds(),
+            5.milliseconds(),
+            5.seconds(),
+            5.minutes(),
+            5.hours(),
+            5.days(),
+            5.weeks(),
+        ));
+    }
+
+    fn float(ben: &mut Bencher) {
+        ben.iter(|| (
+            1.9.nanoseconds(),
+            1.0.nanoseconds(),
+            1.0.microseconds(),
+            1.0.milliseconds(),
+            1.0.seconds(),
+            1.0.minutes(),
+            1.0.hours(),
+            1.0.days(),
+            1.0.weeks(),
+            1.5.nanoseconds(),
+            1.5.microseconds(),
+            1.5.milliseconds(),
+            1.5.seconds(),
+            1.5.minutes(),
+            1.5.hours(),
+            1.5.days(),
+            1.5.weeks(),
+        ));
+    }
+}

--- a/time-benchmarks/benches/instant.rs
+++ b/time-benchmarks/benches/instant.rs
@@ -1,0 +1,183 @@
+use bench_util::setup_benchmark;
+use criterion::BatchSize;
+use std::time::{Duration as StdDuration, Instant as StdInstant};
+use time::{
+    ext::{NumericalDuration, NumericalStdDuration},
+    Duration, Instant,
+};
+
+setup_benchmark! {
+    "Instant",
+
+    fn checked_add(ben: &mut Bencher) {
+        let instant = Instant::now();
+        let dt = 5.seconds();
+        ben.iter(|| instant.checked_add(dt));
+    }
+
+    fn checked_sub(ben: &mut Bencher) {
+        let instant = Instant::now();
+        let dt = 5.seconds();
+        ben.iter(|| instant.checked_sub(dt));
+    }
+
+    fn from_std(ben: &mut Bencher) {
+        let std_instant = StdInstant::now();
+        ben.iter(|| Instant::from(std_instant));
+    }
+
+    fn to_std(ben: &mut Bencher) {
+        let instant = Instant::now();
+        ben.iter(|| StdInstant::from(instant));
+    }
+
+    fn sub(ben: &mut Bencher) {
+        let start: Instant = Instant::now();
+        let end: Instant = start + 1.milliseconds();
+        ben.iter(|| end - start);
+    }
+
+    fn sub_std(ben: &mut Bencher) {
+        let start = StdInstant::now();
+        let end: Instant = Instant::from(start + 1.milliseconds());
+        ben.iter(|| end - start);
+    }
+
+    fn std_sub(ben: &mut Bencher) {
+        let start = Instant::now();
+        let end: StdInstant = StdInstant::from(start + 1.std_milliseconds());
+        ben.iter(|| end - start);
+    }
+
+    fn add_duration(ben: &mut Bencher) {
+        let start = Instant::now();
+        let dt: Duration = 1.seconds();
+        ben.iter(|| start + dt);
+    }
+
+    fn std_add_duration(ben: &mut Bencher) {
+        let start = StdInstant::now();
+        let dt: Duration = 1.milliseconds();
+        ben.iter(|| start + dt);
+    }
+
+    fn add_std_duration(ben: &mut Bencher) {
+        let start = Instant::now();
+        let dt: StdDuration = 1.std_milliseconds();
+        ben.iter(|| start + dt);
+    }
+
+    fn add_assign_duration(ben: &mut Bencher) {
+        let dt: Duration = 1.milliseconds();
+        ben.iter_batched_ref(
+            Instant::now,
+            |start| {
+                *start += dt;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn std_add_assign_duration(ben: &mut Bencher) {
+        let dt: Duration = 1.milliseconds();
+        ben.iter_batched_ref(
+            StdInstant::now,
+            |start| {
+                *start += dt;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn add_assign_std_duration(ben: &mut Bencher) {
+        let dt: StdDuration = 1.std_milliseconds();
+        ben.iter_batched_ref(
+            Instant::now,
+            |start| {
+                *start += dt;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn sub_duration(ben: &mut Bencher) {
+        let instant = Instant::now();
+        let dt: Duration = 100.milliseconds();
+        ben.iter(|| instant - dt);
+    }
+
+    fn std_sub_duration(ben: &mut Bencher) {
+        let instant = StdInstant::now();
+        let dt: Duration = 100.milliseconds();
+        ben.iter(|| instant - dt);
+    }
+
+    fn sub_std_duration(ben: &mut Bencher) {
+        let instant = Instant::now();
+        let dt: StdDuration = 100.std_milliseconds();
+        ben.iter(|| instant - dt);
+    }
+
+    fn sub_assign_duration(ben: &mut Bencher) {
+        let dt: Duration = 100.milliseconds();
+        ben.iter_batched_ref(
+            Instant::now,
+            |instant| {
+                *instant -= dt;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn std_sub_assign_duration(ben: &mut Bencher) {
+        let dt: Duration = 100.milliseconds();
+        ben.iter_batched_ref(
+            StdInstant::now,
+            |instant| {
+                *instant -= dt;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn sub_assign_std_duration(ben: &mut Bencher) {
+        let dt: StdDuration = 100.std_milliseconds();
+        ben.iter_batched_ref(
+            Instant::now,
+            |instant| {
+                *instant -= dt;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn eq_std(ben: &mut Bencher) {
+        let instant = Instant::now();
+        let std_instant = StdInstant::from(instant);
+        ben.iter(|| instant == std_instant);
+    }
+
+    fn std_eq(ben: &mut Bencher) {
+        let instant = Instant::now();
+        let std_instant = StdInstant::from(instant);
+        ben.iter(|| std_instant == instant);
+    }
+
+    fn ord_std(ben: &mut Bencher) {
+        let instant = Instant::now();
+        let std_instant = StdInstant::from(instant) + 1.seconds();
+        ben.iter(|| (
+            instant < std_instant,
+            instant > std_instant,
+        ));
+    }
+
+    fn std_ord(ben: &mut Bencher) {
+        let instant = Instant::now();
+        let std_instant = StdInstant::from(instant) + 1.seconds();
+        ben.iter(|| (
+            std_instant > instant,
+            std_instant < instant,
+        ));
+    }
+}

--- a/time-benchmarks/benches/offset_date_time.rs
+++ b/time-benchmarks/benches/offset_date_time.rs
@@ -1,0 +1,649 @@
+use bench_util::setup_benchmark;
+use criterion::BatchSize;
+use std::time::SystemTime;
+use time::{
+    datetime,
+    ext::{NumericalDuration, NumericalStdDuration},
+    offset, Format, OffsetDateTime,
+};
+
+setup_benchmark! {
+    "OffsetDateTime",
+
+    fn now_utc(ben: &mut Bencher) {
+        ben.iter(OffsetDateTime::now_utc);
+    }
+
+    fn now_local(ben: &mut Bencher) {
+        ben.iter(OffsetDateTime::now_local);
+    }
+
+    fn to_offset(ben: &mut Bencher) {
+        let utc = datetime!("2000-01-01 0:00 UTC");
+        let offset = offset!("-1");
+        let sydney = datetime!("2000-01-01 0:00").assume_offset(offset!("+11"));
+        let new_york_offset = offset!("-5");
+        let los_angeles_offset = offset!("-8");
+
+        ben.iter(|| (
+            utc.to_offset(offset),
+            sydney.to_offset(new_york_offset),
+            sydney.to_offset(los_angeles_offset),
+        ));
+    }
+
+    fn unix_epoch(ben: &mut Bencher) {
+        ben.iter(OffsetDateTime::unix_epoch);
+    }
+
+    fn from_unix_timestamp(ben: &mut Bencher) {
+        ben.iter(|| (
+            OffsetDateTime::from_unix_timestamp(0),
+            OffsetDateTime::from_unix_timestamp(1_546_300_800),
+        ));
+    }
+
+    fn from_unix_timestamp_nanos(ben: &mut Bencher) {
+        ben.iter(|| (
+            OffsetDateTime::from_unix_timestamp_nanos(0),
+            OffsetDateTime::from_unix_timestamp_nanos(1_546_300_800_000_000_000),
+        ));
+    }
+
+    fn offset(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-01-01 0:00").assume_offset(offset!("+1"));
+        let c = datetime!("2019-01-01 0:00 UTC").to_offset(offset!("+1"));
+
+        ben.iter(|| (
+            a.offset(),
+            b.offset(),
+            c.offset(),
+        ));
+    }
+
+    fn unix_timestamp(ben: &mut Bencher) {
+        let a = OffsetDateTime::unix_epoch();
+        let b = OffsetDateTime::unix_epoch().to_offset(offset!("+1"));
+        let c = datetime!("1970-01-01 0:00").assume_offset(offset!("-1"));
+        ben.iter(|| (
+            a.unix_timestamp(),
+            b.unix_timestamp(),
+            c.unix_timestamp(),
+        ));
+    }
+
+    fn unix_timestamp_nanos(ben: &mut Bencher) {
+        let a = datetime!("1970-01-01 0:00 UTC");
+        let b = datetime!("1970-01-01 1:00 UTC").to_offset(offset!("-1"));
+        ben.iter(|| (
+            a.unix_timestamp_nanos(),
+            b.unix_timestamp_nanos(),
+        ));
+    }
+
+    fn date(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-01-01 0:00 UTC").to_offset(offset!("-1"));
+        ben.iter(|| (a.date(), b.date()));
+    }
+
+    fn time(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-01-01 0:00 UTC").to_offset(offset!("-1"));
+        ben.iter(|| (a.time(), b.time()));
+    }
+
+    fn year(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-12-31 23:00 UTC").to_offset(offset!("+1"));
+        let c = datetime!("2020-01-01 0:00 UTC");
+        ben.iter(|| (
+            a.year(),
+            b.year(),
+            c.year(),
+        ));
+    }
+
+    fn month(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-12-31 23:00 UTC").to_offset(offset!("+1"));
+        ben.iter(|| (a.month(), b.month()));
+    }
+
+    fn day(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-12-31 23:00 UTC").to_offset(offset!("+1"));
+        ben.iter(|| (a.day(), b.day()));
+    }
+
+    fn month_day(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-12-31 23:00 UTC").to_offset(offset!("+1"));
+        ben.iter(|| (a.month_day(), b.month_day()));
+    }
+
+    fn ordinal(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-12-31 23:00 UTC").to_offset(offset!("+1"));
+        ben.iter(|| (a.ordinal(), b.ordinal()));
+    }
+
+    fn iso_year_week(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-10-04 0:00 UTC");
+        let c = datetime!("2020-01-01 0:00 UTC");
+        let d = datetime!("2020-12-31 0:00 UTC");
+        let e = datetime!("2021-01-01 0:00 UTC");
+        ben.iter(|| (
+            a.iso_year_week(),
+            b.iso_year_week(),
+            c.iso_year_week(),
+            d.iso_year_week(),
+            e.iso_year_week(),
+        ));
+    }
+
+    fn week(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2020-01-01 0:00 UTC");
+        let c = datetime!("2020-12-31 0:00 UTC");
+        let d = datetime!("2021-01-01 0:00 UTC");
+        ben.iter(|| (
+            a.week(),
+            b.week(),
+            c.week(),
+            d.week(),
+        ));
+    }
+
+    fn weekday(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-02-01 0:00 UTC");
+        let c = datetime!("2019-03-01 0:00 UTC");
+        ben.iter(|| (
+            a.weekday(),
+            b.weekday(),
+            c.weekday(),
+        ));
+    }
+
+    fn hour(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-01-01 23:59:59 UTC").to_offset(offset!("-2"));
+        ben.iter(|| (a.hour(), b.hour()));
+    }
+
+    fn minute(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-01-01 23:59:59 UTC").to_offset(offset!("+0:30"));
+        ben.iter(|| (a.minute(), b.minute()));
+    }
+
+    fn second(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-01-01 23:59:59 UTC").to_offset(offset!("+0:00:30"));
+        ben.iter(|| (a.second(), b.second()));
+    }
+
+    fn millisecond(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-01-01 23:59:59.999 UTC");
+        ben.iter(|| (
+            a.millisecond(),
+            b.millisecond(),
+        ));
+    }
+
+    fn microsecond(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-01-01 23:59:59.999_999 UTC");
+        ben.iter(|| (
+            a.microsecond(),
+            b.microsecond(),
+        ));
+    }
+
+    fn nanosecond(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-01-01 23:59:59.999_999_999 UTC");
+        ben.iter(|| (
+            a.nanosecond(),
+            b.nanosecond(),
+        ));
+    }
+
+    fn format(ben: &mut Bencher) {
+        let a = datetime!("2019-01-02 0:00 UTC");
+        let b = datetime!("2019-01-02 3:04:05.678_901_234").assume_offset(offset!("+6:07"));
+        ben.iter(|| (
+            a.format("%F %r %z"),
+            b.format(Format::Rfc3339),
+        ));
+    }
+
+    fn parse(ben: &mut Bencher) {
+        ben.iter(|| (
+            OffsetDateTime::parse("2019-01-02 00:00:00 +0000", "%F %T %z"),
+            OffsetDateTime::parse("2019-002 23:59:59 +0000", "%Y-%j %T %z"),
+            OffsetDateTime::parse("2019-W01-3 12:00:00 pm +0000", "%G-W%V-%u %r %z"),
+            OffsetDateTime::parse("2019-01-02 03:04:05 +0600", "%F %T %z"),
+            OffsetDateTime::parse("2020-09-08T08:44:31+02:30", Format::Rfc3339),
+            OffsetDateTime::parse("2019-01-02T03:04:05.678901234+05:06", Format::Rfc3339),
+            OffsetDateTime::parse("2019-01-02T03:04:05.678901234Z", Format::Rfc3339),
+            OffsetDateTime::parse("2019-01-02T03:04:05/", Format::Rfc3339),
+            OffsetDateTime::parse("2019-01-02T03:04:05", Format::Rfc3339),
+            OffsetDateTime::parse("2019-01-02T03:04:05.", Format::Rfc3339),
+        ));
+    }
+
+    fn partial_eq(ben: &mut Bencher) {
+        let a = datetime!("2000-01-01 0:00 UTC").to_offset(offset!("-1"));
+        let b = datetime!("2000-01-01 0:00 UTC");
+        ben.iter(|| a == b);
+    }
+
+    fn partial_ord(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-01-01 0:00 UTC").to_offset(offset!("-1"));
+        ben.iter(|| a.partial_cmp(&b));
+    }
+
+    fn ord(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-01-01 0:00 UTC").to_offset(offset!("-1"));
+        let c = datetime!("2019-01-01 0:00:00.000_000_001 UTC");
+        ben.iter(|| (a == b, c > a));
+    }
+
+    fn hash(ben: &mut Bencher) {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::Hash;
+
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b = datetime!("2019-01-01 0:00 UTC").to_offset(offset!("-1"));
+        let c = datetime!("2019-01-01 0:00");
+
+        ben.iter_batched_ref(
+            DefaultHasher::new,
+            |hasher| {
+                a.hash(hasher);
+                b.hash(hasher);
+                c.hash(hasher);
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn add_duration(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let dta = 5.days();
+        let b = datetime!("2019-12-31 0:00 UTC");
+        let dtb = 1.days();
+        let c = datetime!("2019-12-31 23:59:59 UTC");
+        let dtc = 2.seconds();
+        let d = datetime!("2020-01-01 0:00:01 UTC");
+        let dtd = (-2).seconds();
+        let e = datetime!("1999-12-31 23:00 UTC");
+        let dte = 1.hours();
+
+        ben.iter(|| (
+            a + dta,
+            b + dtb,
+            c + dtc,
+            d + dtd,
+            e + dte,
+        ));
+    }
+
+    fn add_std_duration(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let dta = 5.std_days();
+        let b = datetime!("2019-12-31 0:00 UTC");
+        let dtb = 1.std_days();
+        let c = datetime!("2019-12-31 23:59:59 UTC");
+        let dtc = 2.std_seconds();
+
+        ben.iter(|| (
+            a + dta,
+            b + dtb,
+            c + dtc,
+        ));
+    }
+
+    fn add_assign_duration(ben: &mut Bencher) {
+        let dta = 1.days();
+        let dtb = 1.seconds();
+        ben.iter_batched_ref(
+            || datetime!("2019-01-01 0:00 UTC"),
+            |datetime| {
+                *datetime += dta;
+                *datetime += dtb;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn add_assign_std_duration(ben: &mut Bencher) {
+        let dta = 1.std_days();
+        let dtb = 1.std_seconds();
+        ben.iter_batched_ref(
+            || datetime!("2019-01-01 0:00 UTC"),
+            |datetime| {
+                *datetime += dta;
+                *datetime += dtb;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn sub_duration(ben: &mut Bencher) {
+        let a = datetime!("2019-01-06 0:00 UTC");
+        let dta = 5.days();
+        let b = datetime!("2020-01-01 0:00 UTC");
+        let dtb = 1.days();
+        let c = datetime!("2020-01-01 0:00:01 UTC");
+        let dtc = 2.seconds();
+
+        ben.iter(|| (
+            a - dta,
+            b - dtb,
+            c - dtc,
+        ));
+    }
+
+    fn sub_std_duration(ben: &mut Bencher) {
+        let a = datetime!("2019-01-06 0:00 UTC");
+        let dta = 5.std_days();
+        let b = datetime!("2020-01-01 0:00 UTC");
+        let dtb = 1.std_days();
+        let c = datetime!("2020-01-01 0:00:01 UTC");
+        let dtc = 2.std_seconds();
+
+        ben.iter(|| (
+            a - dta,
+            b - dtb,
+            c - dtc,
+        ));
+    }
+
+    fn sub_assign_duration(ben: &mut Bencher) {
+        let dta = 1.days();
+        let dtb = 1.seconds();
+        ben.iter_batched_ref(
+            || datetime!("2019-01-01 0:00 UTC"),
+            |datetime| {
+                *datetime -= dta;
+                *datetime -= dtb;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn sub_assign_std_duration(ben: &mut Bencher) {
+        let dta = 1.std_days();
+        let dtb = 1.std_seconds();
+        ben.iter_batched_ref(
+            || datetime!("2019-01-01 0:00 UTC"),
+            |datetime| {
+                *datetime -= dta;
+                *datetime -= dtb;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn std_add_duration(ben: &mut Bencher) {
+        let a = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let dta = 0.seconds();
+        let b = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let dtb = 5.days();
+        let c = SystemTime::from(datetime!("2019-12-31 0:00 UTC"));
+        let dtc = 1.days();
+        let d = SystemTime::from(datetime!("2019-12-31 23:59:59 UTC"));
+        let dtd = 2.seconds();
+        let e = SystemTime::from(datetime!("2020-01-01 0:00:01 UTC"));
+        let dte = (-2).seconds();
+        ben.iter(|| (
+            a + dta,
+            b + dtb,
+            c + dtc,
+            d + dtd,
+            e + dte,
+        ));
+    }
+
+    fn std_add_assign_duration(ben: &mut Bencher) {
+        let dta = 1.days();
+        let dtb = 1.seconds();
+        ben.iter_batched_ref(
+            || SystemTime::from(datetime!("2019-01-01 0:00 UTC")),
+            |datetime| {
+                *datetime += dta;
+                *datetime += dtb;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn std_sub_duration(ben: &mut Bencher) {
+        let a = SystemTime::from(datetime!("2019-01-06 0:00 UTC"));
+        let dta = 5.days();
+        let b = SystemTime::from(datetime!("2020-01-01 0:00 UTC"));
+        let dtb = 1.days();
+        let c = SystemTime::from(datetime!("2020-01-01 0:00:01 UTC"));
+        let dtc = 2.seconds();
+        let d = SystemTime::from(datetime!("2019-12-31 23:59:59 UTC"));
+        let dtd = (-2).seconds();
+        ben.iter(|| (
+            a - dta,
+            b - dtb,
+            c - dtc,
+            d - dtd,
+        ));
+    }
+
+    fn std_sub_assign_duration(ben: &mut Bencher) {
+        let dta = 1.days();
+        let dtb = 1.seconds();
+        ben.iter_batched_ref(
+            || SystemTime::from(datetime!("2019-01-01 0:00 UTC")),
+            |datetime| {
+                *datetime -= dta;
+                *datetime -= dtb;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn sub_self(ben: &mut Bencher) {
+        let a = datetime!("2019-01-02 0:00 UTC");
+        let b = datetime!("2019-01-01 0:00 UTC");
+        let c = datetime!("2020-01-01 0:00 UTC");
+        let d = datetime!("2019-12-31 0:00 UTC");
+
+        ben.iter(|| (
+            a - b,
+            b - a,
+            c - d,
+            d - c,
+        ));
+    }
+
+    fn std_sub(ben: &mut Bencher) {
+        let a_std = SystemTime::from(datetime!("2019-01-02 0:00 UTC"));
+        let a = datetime!("2019-01-01 0:00 UTC");
+        let b_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let b = datetime!("2019-01-02 0:00 UTC");
+        let c_std = SystemTime::from(datetime!("2020-01-01 0:00 UTC"));
+        let c = datetime!("2019-12-31 0:00 UTC");
+        let d_std = SystemTime::from(datetime!("2019-12-31 0:00 UTC"));
+        let d = datetime!("2020-01-01 0:00 UTC");
+
+        ben.iter(|| (
+            a_std - a,
+            b_std - b,
+            c_std - c,
+            d_std - d,
+        ));
+    }
+
+    fn sub_std(ben: &mut Bencher) {
+        let a = datetime!("2019-01-02 0:00 UTC");
+        let a_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let b = datetime!("2019-01-01 0:00 UTC");
+        let b_std = SystemTime::from(datetime!("2019-01-02 0:00 UTC"));
+        let c = datetime!("2020-01-01 0:00 UTC");
+        let c_std = SystemTime::from(datetime!("2019-12-31 0:00 UTC"));
+        let d = datetime!("2019-12-31 0:00 UTC");
+        let d_std = SystemTime::from(datetime!("2020-01-01 0:00 UTC"));
+
+        ben.iter(|| (
+            a - a_std,
+            b - b_std,
+            c - c_std,
+            d - d_std,
+        ));
+    }
+
+    fn eq_std(ben: &mut Bencher) {
+        let a = OffsetDateTime::now_utc();
+        let b_std = SystemTime::from(a);
+        ben.iter(|| a == b_std);
+    }
+
+    fn std_eq(ben: &mut Bencher) {
+        let a = OffsetDateTime::now_utc();
+        let b_std = SystemTime::from(a);
+        ben.iter(|| b_std == a)
+    }
+
+    fn ord_std(ben: &mut Bencher) {
+        let d1 = datetime!("2019-01-01 0:00 UTC");
+        let d1_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let d2 = datetime!("2019-01-01 0:00 UTC");
+        let d2_std = SystemTime::from(datetime!("2020-01-01 0:00 UTC"));
+        let d3 = datetime!("2019-01-01 0:00 UTC");
+        let d3_std = SystemTime::from(datetime!("2019-02-01 0:00 UTC"));
+        let d4 = datetime!("2019-01-01 0:00 UTC");
+        let d4_std = SystemTime::from(datetime!("2019-01-02 0:00 UTC"));
+        let d5 = datetime!("2019-01-01 0:00 UTC");
+        let d5_std = SystemTime::from(datetime!("2019-01-01 1:00:00 UTC"));
+        let d6 = datetime!("2019-01-01 0:00 UTC");
+        let d6_std = SystemTime::from(datetime!("2019-01-01 0:01:00 UTC"));
+        let d7 = datetime!("2019-01-01 0:00 UTC");
+        let d7_std = SystemTime::from(datetime!("2019-01-01 0:00:01 UTC"));
+        let d8 = datetime!("2019-01-01 0:00 UTC");
+        let d8_std = SystemTime::from(datetime!("2019-01-01 0:00:00.001 UTC"));
+        let d9 = datetime!("2020-01-01 0:00 UTC");
+        let d9_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let d10 = datetime!("2019-02-01 0:00 UTC");
+        let d10_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let d11 = datetime!("2019-01-02 0:00 UTC");
+        let d11_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let d12 = datetime!("2019-01-01 1:00:00 UTC");
+        let d12_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let d13 = datetime!("2019-01-01 0:01:00 UTC");
+        let d13_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let d14 = datetime!("2019-01-01 0:00:01 UTC");
+        let d14_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let d15 = datetime!("2019-01-01 0:00:00.000_000_001 UTC");
+        let d15_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+
+        ben.iter(|| (
+            d1 == d1_std,
+            d2 < d2_std,
+            d3 < d3_std,
+            d4 < d4_std,
+            d5 < d5_std,
+            d6 < d6_std,
+            d7 < d7_std,
+            d8 < d8_std,
+            d9 > d9_std,
+            d10 > d10_std,
+            d11 > d11_std,
+            d12 > d12_std,
+            d13 > d13_std,
+            d14 > d14_std,
+            d15 > d15_std,
+        ));
+    }
+
+    fn std_ord(ben: &mut Bencher) {
+        let d1_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let d1 = datetime!("2019-01-01 0:00 UTC");
+        let d2_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let d2 = datetime!("2020-01-01 0:00 UTC");
+        let d3_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let d3 = datetime!("2019-02-01 0:00 UTC");
+        let d4_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let d4 = datetime!("2019-01-02 0:00 UTC");
+        let d5_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let d5 = datetime!("2019-01-01 1:00:00 UTC");
+        let d6_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let d6 = datetime!("2019-01-01 0:01:00 UTC");
+        let d7_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let d7 = datetime!("2019-01-01 0:00:01 UTC");
+        let d8_std = SystemTime::from(datetime!("2019-01-01 0:00 UTC"));
+        let d8 = datetime!("2019-01-01 0:00:00.000_000_001 UTC");
+        let d9_std = SystemTime::from(datetime!("2020-01-01 0:00 UTC"));
+        let d9 = datetime!("2019-01-01 0:00 UTC");
+        let d10_std = SystemTime::from(datetime!("2019-02-01 0:00 UTC"));
+        let d10 = datetime!("2019-01-01 0:00 UTC");
+        let d11_std = SystemTime::from(datetime!("2019-01-02 0:00 UTC"));
+        let d11 = datetime!("2019-01-01 0:00 UTC");
+        let d12_std = SystemTime::from(datetime!("2019-01-01 1:00:00 UTC"));
+        let d12 = datetime!("2019-01-01 0:00 UTC");
+        let d13_std = SystemTime::from(datetime!("2019-01-01 0:01:00 UTC"));
+        let d13 = datetime!("2019-01-01 0:00 UTC");
+        let d14_std = SystemTime::from(datetime!("2019-01-01 0:00:01 UTC"));
+        let d14 = datetime!("2019-01-01 0:00 UTC");
+        let d15_std = SystemTime::from(datetime!("2019-01-01 0:00:00.001 UTC"));
+        let d15 = datetime!("2019-01-01 0:00 UTC");
+
+        ben.iter(|| (
+            d1_std == d1,
+            d2_std < d2,
+            d3_std < d3,
+            d4_std < d4,
+            d5_std < d5,
+            d6_std < d6,
+            d7_std < d7,
+            d8_std < d8,
+            d9_std > d9,
+            d10_std > d10,
+            d11_std > d11,
+            d12_std > d12,
+            d13_std > d13,
+            d14_std > d14,
+            d15_std > d15,
+        ));
+    }
+
+    fn from_std(ben: &mut Bencher) {
+        let a = SystemTime::UNIX_EPOCH;
+        let b = SystemTime::UNIX_EPOCH - 1.std_days();
+        let c = SystemTime::UNIX_EPOCH + 1.std_days();
+        ben.iter(|| (
+            OffsetDateTime::from(a),
+            OffsetDateTime::from(b),
+            OffsetDateTime::from(c),
+        ));
+    }
+
+    fn to_std(ben: &mut Bencher) {
+        let a = OffsetDateTime::unix_epoch();
+        let b = OffsetDateTime::unix_epoch() + 1.days();
+        let c = OffsetDateTime::unix_epoch() - 1.days();
+        ben.iter(|| (
+            SystemTime::from(a),
+            SystemTime::from(b),
+            SystemTime::from(c),
+        ));
+    }
+
+    fn display(ben: &mut Bencher) {
+        let a = datetime!("1970-01-01 0:00 UTC");
+        ben.iter(|| a.to_string());
+    }
+}

--- a/time-benchmarks/benches/parse_error.rs
+++ b/time-benchmarks/benches/parse_error.rs
@@ -1,0 +1,66 @@
+use bench_util::setup_benchmark;
+use time::error;
+
+fn component_range() -> error::ComponentRange {
+    time::Date::from_yo(0, 367).unwrap_err()
+}
+
+setup_benchmark! {
+    "Parse error",
+
+    fn display(ben: &mut Bencher) {
+        let a = error::Parse::InvalidNanosecond;
+        let b = error::Parse::InvalidSecond;
+        let c = error::Parse::InvalidMinute;
+        let d = error::Parse::InvalidHour;
+        let e = error::Parse::InvalidAmPm;
+        let f = error::Parse::InvalidMonth;
+        let g = error::Parse::InvalidYear;
+        let h = error::Parse::InvalidWeek;
+        let i = error::Parse::InvalidDayOfWeek;
+        let j = error::Parse::InvalidDayOfMonth;
+        let k = error::Parse::InvalidDayOfYear;
+        let l = error::Parse::InvalidOffset;
+        let m = error::Parse::MissingFormatSpecifier;
+        let n = error::Parse::InvalidFormatSpecifier('!');
+        let o = error::Parse::UnexpectedCharacter {
+            expected: 'a',
+            actual: 'b',
+        };
+        let p = error::Parse::UnexpectedEndOfString;
+        let q = error::Parse::InsufficientInformation;
+        let r = error::Parse::ComponentOutOfRange(Box::new(component_range()));
+
+        ben.iter(|| (
+            a.to_string(),
+            b.to_string(),
+            c.to_string(),
+            d.to_string(),
+            e.to_string(),
+            f.to_string(),
+            g.to_string(),
+            h.to_string(),
+            i.to_string(),
+            j.to_string(),
+            k.to_string(),
+            l.to_string(),
+            m.to_string(),
+            n.to_string(),
+            o.to_string(),
+            p.to_string(),
+            q.to_string(),
+            r.to_string(),
+        ));
+    }
+
+    fn source(ben: &mut Bencher) {
+        use std::error::Error as StdError;
+        let a = error::Parse::from(component_range());
+        let b = error::Parse::InvalidNanosecond;
+
+        ben.iter(|| (
+            a.source(),
+            b.source(),
+        ));
+    }
+}

--- a/time-benchmarks/benches/primitive_date_time.rs
+++ b/time-benchmarks/benches/primitive_date_time.rs
@@ -1,0 +1,428 @@
+use bench_util::setup_benchmark;
+use criterion::BatchSize;
+use time::{
+    date, datetime,
+    ext::{NumericalDuration, NumericalStdDuration},
+    offset, time, PrimitiveDateTime,
+};
+
+setup_benchmark! {
+    "PrimitiveDateTime",
+
+    fn new(ben: &mut Bencher) {
+        let d = date!("2019-01-01");
+        let t = time!("0:00");
+        ben.iter(|| PrimitiveDateTime::new(d, t));
+    }
+
+    fn date(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        ben.iter(|| a.date());
+    }
+
+    fn time(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        ben.iter(|| a.time());
+    }
+
+    fn year(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2019-12-31 0:00");
+        let c = datetime!("2020-01-01 0:00");
+        ben.iter(|| (
+            a.year(),
+            b.year(),
+            c.year(),
+        ));
+    }
+
+    fn month(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2019-12-31 0:00");
+        ben.iter(|| (a.month(), b.month()));
+    }
+
+    fn day(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2019-12-31 0:00");
+        ben.iter(|| (a.day(), b.day()));
+    }
+
+    fn month_day(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2019-12-31 0:00");
+        ben.iter(|| (
+            a.month_day(),
+            b.month_day(),
+        ));
+    }
+
+    fn ordinal(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2019-12-31 0:00");
+        ben.iter(|| (
+            a.ordinal(),
+            b.ordinal(),
+        ));
+    }
+
+    fn iso_year_week(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2019-10-04 0:00");
+        let c = datetime!("2020-01-01 0:00");
+        let d = datetime!("2020-12-31 0:00");
+        let e = datetime!("2021-01-01 0:00");
+        ben.iter(|| (
+            a.iso_year_week(),
+            b.iso_year_week(),
+            c.iso_year_week(),
+            d.iso_year_week(),
+            e.iso_year_week(),
+        ));
+    }
+
+    fn week(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2019-10-04 0:00");
+        let c = datetime!("2020-01-01 0:00");
+        let d = datetime!("2020-12-31 0:00");
+        let e = datetime!("2021-01-01 0:00");
+        ben.iter(|| (
+            a.week(),
+            b.week(),
+            c.week(),
+            d.week(),
+            e.week(),
+        ));
+    }
+
+    fn sunday_based_week(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2020-01-01 0:00");
+        let c = datetime!("2020-12-31 0:00");
+        let d = datetime!("2021-01-01 0:00");
+        ben.iter(|| (
+            a.sunday_based_week(),
+            b.sunday_based_week(),
+            c.sunday_based_week(),
+            d.sunday_based_week(),
+        ));
+    }
+
+    fn monday_based_week(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2020-01-01 0:00");
+        let c = datetime!("2020-12-31 0:00");
+        let d = datetime!("2021-01-01 0:00");
+        ben.iter(|| (
+            a.monday_based_week(),
+            b.monday_based_week(),
+            c.monday_based_week(),
+            d.monday_based_week(),
+        ));
+    }
+
+    fn weekday(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2019-02-01 0:00");
+        let c = datetime!("2019-03-01 0:00");
+        let d = datetime!("2019-04-01 0:00");
+        let e = datetime!("2019-05-01 0:00");
+        let f = datetime!("2019-06-01 0:00");
+        let g = datetime!("2019-07-01 0:00");
+        let h = datetime!("2019-08-01 0:00");
+        let i = datetime!("2019-09-01 0:00");
+        let j = datetime!("2019-10-01 0:00");
+        let k = datetime!("2019-11-01 0:00");
+        let l = datetime!("2019-12-01 0:00");
+
+        ben.iter(|| (
+            a.weekday(),
+            b.weekday(),
+            c.weekday(),
+            d.weekday(),
+            e.weekday(),
+            f.weekday(),
+            g.weekday(),
+            h.weekday(),
+            i.weekday(),
+            j.weekday(),
+            k.weekday(),
+            l.weekday(),
+        ));
+    }
+
+    fn hour(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2019-01-01 23:59:59");
+        ben.iter(|| (
+            a.hour(),
+            b.hour(),
+        ));
+    }
+
+    fn minute(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2019-01-01 23:59:59");
+        ben.iter(|| (
+            a.minute(),
+            b.minute(),
+        ));
+    }
+
+    fn second(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2019-01-01 23:59:59");
+        ben.iter(|| (
+            a.second(),
+            b.second(),
+        ));
+    }
+
+    fn millisecond(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2019-01-01 23:59:59.999");
+        ben.iter(|| (
+            a.millisecond(),
+            b.millisecond(),
+        ));
+    }
+
+    fn microsecond(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2019-01-01 23:59:59.999_999");
+        ben.iter(|| (
+            a.microsecond(),
+            b.microsecond(),
+        ));
+    }
+
+    fn nanosecond(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2019-01-01 23:59:59.999_999_999");
+        ben.iter(|| (
+            a.nanosecond(),
+            b.nanosecond(),
+        ));
+    }
+
+    fn assume_offset(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let b = datetime!("2019-01-01 0:00");
+        ben.iter(|| (
+            a.assume_offset(offset!("UTC")),
+            b.assume_offset(offset!("-1")),
+        ));
+    }
+
+    fn assume_utc(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        ben.iter(|| a.assume_utc());
+    }
+
+    fn format(ben: &mut Bencher) {
+        let a = datetime!("2019-01-02 3:04:05");
+        ben.iter(|| a.format("%c"));
+    }
+
+    fn parse(ben: &mut Bencher) {
+        ben.iter(|| (
+            PrimitiveDateTime::parse("Wed Jan 2 3:04:05 2019", "%c"),
+            PrimitiveDateTime::parse("2019-002 23:59:59", "%Y-%j %T"),
+            PrimitiveDateTime::parse("2019-W01-3 12:00:00 pm", "%G-W%V-%u %r"),
+        ));
+    }
+
+    fn add_duration(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let dta = 5.days();
+        let b = datetime!("2019-12-31 0:00");
+        let dtb = 1.days();
+        let c = datetime!("2019-12-31 23:59:59");
+        let dtc = 2.seconds();
+        let d = datetime!("2020-01-01 0:00:01");
+        let dtd = (-2).seconds();
+        let e = datetime!("1999-12-31 23:00");
+        let dte = 1.hours();
+
+        ben.iter(|| (
+            a + dta,
+            b + dtb,
+            c + dtc,
+            d + dtd,
+            e + dte,
+        ));
+    }
+
+    fn add_std_duration(ben: &mut Bencher) {
+        let a = datetime!("2019-01-01 0:00");
+        let dta = 5.std_days();
+        let b = datetime!("2019-12-31 0:00");
+        let dtb = 1.std_days();
+        let c = datetime!("2019-12-31 23:59:59");
+        let dtc = 2.std_seconds();
+
+        ben.iter(|| (
+            a + dta,
+            b + dtb,
+            c + dtc,
+        ));
+    }
+
+    fn add_assign_duration(ben: &mut Bencher) {
+        let dta = 1.days();
+        let dtb = 1.seconds();
+        ben.iter_batched_ref(
+            || datetime!("2019-01-01 0:00"),
+            |datetime| {
+                *datetime += dta;
+                *datetime += dtb;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn add_assign_std_duration(ben: &mut Bencher) {
+        let dta = 1.std_days();
+        let dtb = 1.std_seconds();
+        ben.iter_batched_ref(
+            || datetime!("2019-01-01 0:00"),
+            |datetime| {
+                *datetime += dta;
+                *datetime += dtb;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn sub_duration(ben: &mut Bencher) {
+        let a = datetime!("2019-01-06 0:00");
+        let dta = 5.days();
+        let b = datetime!("2020-01-01 0:00");
+        let dtb = 1.days();
+        let c = datetime!("2020-01-01 0:00:01");
+        let dtc = 2.seconds();
+        let d = datetime!("2019-12-31 23:59:59");
+        let dtd = (-2).seconds();
+        let e = datetime!("1999-12-31 23:00");
+        let dte = (-1).hours();
+
+        ben.iter(|| (
+            a - dta,
+            b - dtb,
+            c - dtc,
+            d - dtd,
+            e - dte,
+        ));
+    }
+
+    fn sub_std_duration(ben: &mut Bencher) {
+        let a = datetime!("2019-01-06 0:00");
+        let dta = 5.std_days();
+        let b = datetime!("2020-01-01 0:00");
+        let dtb = 1.std_days();
+        let c = datetime!("2020-01-01 0:00:01");
+        let dtc = 2.std_seconds();
+
+        ben.iter(|| (
+            a - dta,
+            b - dtb,
+            c - dtc,
+        ));
+    }
+
+    fn sub_assign_duration(ben: &mut Bencher) {
+        let dta = 1.days();
+        let dtb = 1.seconds();
+        ben.iter_batched_ref(
+            || datetime!("2019-01-01 0:00"),
+            |datetime| {
+                *datetime -= dta;
+                *datetime -= dtb;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn sub_assign_std_duration(ben: &mut Bencher) {
+        let dta = 1.std_days();
+        let dtb = 1.std_seconds();
+        ben.iter_batched_ref(
+            || datetime!("2019-01-01 0:00"),
+            |datetime| {
+                *datetime -= dta;
+                *datetime -= dtb;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn sub_datetime(ben: &mut Bencher) {
+        let a = datetime!("2019-01-02 0:00");
+        let b = datetime!("2019-01-01 0:00");
+        let c = datetime!("2020-01-01 0:00");
+        let d = datetime!("2019-12-31 0:00");
+        ben.iter(|| (
+            a - b,
+            b - a,
+            c - d,
+            d - c,
+        ));
+    }
+
+    fn ord(ben: &mut Bencher) {
+        let d1a = datetime!("2019-01-01 0:00");
+        let d1b = datetime!("2019-01-01 0:00");
+        let d2a = datetime!("2019-01-01 0:00");
+        let d2b = datetime!("2020-01-01 0:00");
+        let d3a = datetime!("2019-01-01 0:00");
+        let d3b = datetime!("2019-02-01 0:00");
+        let d4a = datetime!("2019-01-01 0:00");
+        let d4b = datetime!("2019-01-02 0:00");
+        let d5a = datetime!("2019-01-01 0:00");
+        let d5b = datetime!("2019-01-01 1:00");
+        let d6a = datetime!("2019-01-01 0:00");
+        let d6b = datetime!("2019-01-01 0:01");
+        let d7a = datetime!("2019-01-01 0:00");
+        let d7b = datetime!("2019-01-01 0:00:01");
+        let d8a = datetime!("2019-01-01 0:00");
+        let d8b = datetime!("2019-01-01 0:00:00.000_000_001");
+        let d9a = datetime!("2020-01-01 0:00");
+        let d9b = datetime!("2019-01-01 0:00");
+        let d10a = datetime!("2019-02-01 0:00");
+        let d10b = datetime!("2019-01-01 0:00");
+        let d11a = datetime!("2019-01-02 0:00");
+        let d11b = datetime!("2019-01-01 0:00");
+        let d12a = datetime!("2019-01-01 1:00");
+        let d12b = datetime!("2019-01-01 0:00");
+        let d13a = datetime!("2019-01-01 0:01");
+        let d13b = datetime!("2019-01-01 0:00");
+        let d14a = datetime!("2019-01-01 0:00:01");
+        let d14b = datetime!("2019-01-01 0:00");
+        let d15a = datetime!("2019-01-01 0:00:00.000_000_001");
+        let d15b = datetime!("2019-01-01 0:00");
+
+        ben.iter(|| (
+            d1a.partial_cmp(&d1b),
+            d2a.partial_cmp(&d2b),
+            d3a.partial_cmp(&d3b),
+            d4a.partial_cmp(&d4b),
+            d5a.partial_cmp(&d5b),
+            d6a.partial_cmp(&d6b),
+            d7a.partial_cmp(&d7b),
+            d8a.partial_cmp(&d8b),
+            d9a.partial_cmp(&d9b),
+            d10a.partial_cmp(&d10b),
+            d11a.partial_cmp(&d11b),
+            d12a.partial_cmp(&d12b),
+            d13a.partial_cmp(&d13b),
+            d14a.partial_cmp(&d14b),
+            d15a.partial_cmp(&d15b),
+        ));
+    }
+
+    fn display(ben: &mut Bencher) {
+        let a = datetime!("1970-01-01 0:00");
+        ben.iter(|| a.to_string());
+    }
+}

--- a/time-benchmarks/benches/rand.rs
+++ b/time-benchmarks/benches/rand.rs
@@ -1,0 +1,24 @@
+use bench_util::setup_benchmark;
+use criterion::BatchSize;
+use rand::Rng;
+use time::{Date, Duration, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset, Weekday};
+
+setup_benchmark! {
+    "Random",
+
+    fn rng(ben: &mut Bencher) {
+        ben.iter_batched_ref(
+            || rand::rngs::mock::StepRng::new(0, 1),
+            |rng| {
+                let _ = rng.gen::<Time>();
+                let _ = rng.gen::<Date>();
+                let _ = rng.gen::<UtcOffset>();
+                let _ = rng.gen::<PrimitiveDateTime>();
+                let _ = rng.gen::<OffsetDateTime>();
+                let _ = rng.gen::<Duration>();
+                let _ = rng.gen::<Weekday>();
+            },
+            BatchSize::SmallInput
+        );
+    }
+}

--- a/time-benchmarks/benches/serde.rs
+++ b/time-benchmarks/benches/serde.rs
@@ -1,0 +1,88 @@
+use bench_util::setup_benchmark;
+use time::{
+    date, datetime, offset, time, Date, Duration, OffsetDateTime, PrimitiveDateTime, Time,
+    UtcOffset, Weekday,
+};
+
+setup_benchmark! {
+    "Serde",
+
+    fn time(ben: &mut Bencher) {
+        let original = [Time::midnight(), time!("23:59:59.999_999_999")];
+        let serialized = "[[0,0,0,0],[23,59,59,999999999]]";
+        ben.iter(|| (
+            serde_json::to_string(&original),
+            serde_json::from_str::<[Time; 2]>(serialized),
+        ));
+    }
+
+    fn date(ben: &mut Bencher) {
+        let original = [date!("-999_999-001"), date!("+999_999-365")];
+        let serialized = "[[-999999,1],[999999,365]]";
+        ben.iter(|| (
+            serde_json::to_string(&original),
+            serde_json::from_str::<[Date; 2]>(serialized),
+        ));
+    }
+
+    fn primitive_date_time(ben: &mut Bencher) {
+        let original = [
+            datetime!("-999_999-001 0:00"),
+            datetime!("+999_999-365 23:59:59.999_999_999"),
+        ];
+        let serialized = "[[-999999,1,0,0,0,0],[999999,365,23,59,59,999999999]]";
+
+        ben.iter(|| (
+            serde_json::to_string(&original),
+            serde_json::from_str::<[PrimitiveDateTime; 2]>(serialized),
+        ));
+    }
+
+    fn offset_date_time(ben: &mut Bencher) {
+        let original = [
+            datetime!("-999_999-001 0:00 UTC").to_offset(offset!("+23:59:59")),
+            datetime!("+999_999-365 23:59:59.999_999_999 UTC").to_offset(offset!("-23:59:59")),
+        ];
+        let serialized = "[[-999999,1,23,59,59,0,86399],[999999,365,0,0,0,999999999,-86399]]";
+        ben.iter(|| (
+            serde_json::to_string(&original),
+            serde_json::from_str::<[OffsetDateTime; 2]>(serialized),
+        ));
+    }
+
+    fn utc_offset(ben: &mut Bencher) {
+        let original = [offset!("-23:59:59"), offset!("+23:59:59")];
+        let serialized = "[-86399,86399]";
+        ben.iter(|| (
+            serde_json::to_string(&original),
+            serde_json::from_str::<[UtcOffset; 2]>(serialized),
+        ));
+    }
+
+    fn duration(ben: &mut Bencher) {
+        let original = [Duration::min_value(), Duration::max_value()];
+        let serialized = "[[-9223372036854775808,-999999999],[9223372036854775807,999999999]]";
+        ben.iter(|| (
+            serde_json::to_string(&original),
+            serde_json::from_str::<[Duration; 2]>(serialized),
+        ));
+    }
+
+    fn weekday(ben: &mut Bencher) {
+        let original = [
+            Weekday::Monday,
+            Weekday::Tuesday,
+            Weekday::Wednesday,
+            Weekday::Thursday,
+            Weekday::Friday,
+            Weekday::Saturday,
+            Weekday::Sunday,
+        ];
+        let serialized = "[1,2,3,4,5,6,7]";
+
+        ben.iter(|| (
+            serde_json::to_string(&original),
+            serde_json::from_str::<[Weekday; 7]>(serialized),
+        ));
+    }
+}

--- a/time-benchmarks/benches/time.rs
+++ b/time-benchmarks/benches/time.rs
@@ -1,0 +1,358 @@
+use bench_util::setup_benchmark;
+use criterion::BatchSize;
+use time::{
+    ext::{NumericalDuration, NumericalStdDuration},
+    time, Time,
+};
+
+setup_benchmark! {
+    "Time",
+
+    fn midnight(ben: &mut Bencher) {
+        ben.iter(Time::midnight);
+    }
+
+    fn from_hms(ben: &mut Bencher) {
+        ben.iter(|| (
+            Time::from_hms(1, 2, 3),
+            Time::from_hms(24, 0, 0),
+            Time::from_hms(0, 60, 0),
+            Time::from_hms(0, 0, 60),
+        ));
+    }
+
+    fn from_hms_milli(ben: &mut Bencher) {
+        ben.iter(|| (
+            Time::from_hms_milli(1, 2, 3, 4),
+            Time::from_hms_milli(24, 0, 0, 0),
+            Time::from_hms_milli(0, 60, 0, 0),
+            Time::from_hms_milli(0, 0, 60, 0),
+            Time::from_hms_milli(0, 0, 0, 1_000),
+        ));
+    }
+
+    fn from_hms_micro(ben: &mut Bencher) {
+        ben.iter(|| (
+            Time::from_hms_micro(1, 2, 3, 4),
+            Time::from_hms_micro(24, 0, 0, 0),
+            Time::from_hms_micro(0, 60, 0, 0),
+            Time::from_hms_micro(0, 0, 60, 0),
+            Time::from_hms_micro(0, 0, 0, 1_000_000),
+        ));
+    }
+
+    fn from_hms_nano(ben: &mut Bencher) {
+        ben.iter(|| (
+            Time::from_hms_nano(1, 2, 3, 4),
+            Time::from_hms_nano(24, 0, 0, 0),
+            Time::from_hms_nano(0, 60, 0, 0),
+            Time::from_hms_nano(0, 0, 60, 0),
+            Time::from_hms_nano(0, 0, 0, 1_000_000_000),
+        ))
+    }
+
+    fn hour(ben: &mut Bencher) {
+        let a = Time::from_hms(0, 0, 0).unwrap();
+        let b = Time::from_hms(0, 59, 59).unwrap();
+        let c = Time::from_hms(23, 0, 0).unwrap();
+        let d = Time::from_hms(23, 59, 59).unwrap();
+        ben.iter(|| (
+            a.hour(),
+            b.hour(),
+            c.hour(),
+            d.hour(),
+        ));
+    }
+
+    fn minute(ben: &mut Bencher) {
+        let a = Time::from_hms(0, 0, 0).unwrap();
+        let b = Time::from_hms(23, 0, 59).unwrap();
+        let c = Time::from_hms(0, 23, 0).unwrap();
+        let d = Time::from_hms(23, 23, 59).unwrap();
+        ben.iter(|| (
+            a.minute(),
+            b.minute(),
+            c.minute(),
+            d.minute(),
+        ));
+    }
+
+    fn second(ben: &mut Bencher) {
+        let a = Time::from_hms(0, 0, 0).unwrap();
+        let b = Time::from_hms(23, 59, 0).unwrap();
+        let c = Time::from_hms(0, 0, 23).unwrap();
+        let d = Time::from_hms(23, 59, 23).unwrap();
+        ben.iter(|| (
+            a.second(),
+            b.second(),
+            c.second(),
+            d.second(),
+        ));
+    }
+
+    fn millisecond(ben: &mut Bencher) {
+        let a = Time::from_hms_milli(0, 0, 0, 0).unwrap();
+        let b = Time::from_hms_milli(23, 59, 59, 0).unwrap();
+        let c = Time::from_hms_milli(0, 0, 0, 999).unwrap();
+        let d = Time::from_hms_milli(23, 59, 59, 999).unwrap();
+        ben.iter(|| (
+            a.millisecond(),
+            b.millisecond(),
+            c.millisecond(),
+            d.millisecond(),
+        ));
+    }
+
+    fn microsecond(ben: &mut Bencher) {
+        let a = Time::from_hms_micro(0, 0, 0, 0).unwrap();
+        let b = Time::from_hms_micro(23, 59, 59, 0).unwrap();
+        let c = Time::from_hms_micro(0, 0, 0, 999_999).unwrap();
+        let d = Time::from_hms_micro(23, 59, 59, 999_999).unwrap();
+        ben.iter(|| (
+            a.microsecond(),
+            b.microsecond(),
+            c.microsecond(),
+            d.microsecond(),
+        ));
+    }
+
+    fn nanosecond(ben: &mut Bencher) {
+        let a = Time::from_hms_nano(0, 0, 0, 0).unwrap();
+        let b = Time::from_hms_nano(23, 59, 59, 0).unwrap();
+        let c = Time::from_hms_nano(0, 0, 0, 999_999_999).unwrap();
+        let d = Time::from_hms_nano(23, 59, 59, 999_999_999).unwrap();
+        ben.iter(|| (
+            a.nanosecond(),
+            b.nanosecond(),
+            c.nanosecond(),
+            d.nanosecond(),
+        ));
+    }
+
+    fn format(ben: &mut Bencher) {
+        let time = time!("0:01:02.345_678_901");
+        let time_12h = time!("12:01:02");
+        ben.iter(|| (
+            time.format("%H"),
+            time.format("%I"),
+            time.format("%M"),
+            time.format("%N"),
+            time.format("%p"),
+            time.format("%P"),
+            time.format("%r"),
+            time.format("%R"),
+            time.format("%S"),
+            time.format("%T"),
+            time_12h.format("%p"),
+            time_12h.format("%P"),
+        ));
+    }
+
+    fn parse(ben: &mut Bencher) {
+        ben.iter(|| (
+            Time::parse("0:01:02.345678901 00", "%T.%N %H"),
+            Time::parse("0:01:02.345678901 12", "%T.%N %I"),
+            Time::parse("0:01:02.345678901 01", "%T.%N %M"),
+            Time::parse("0:01:02.345678901 345678901", "%T.%N %N"),
+            Time::parse("0:01:02.345678901 am", "%T.%N %p"),
+            Time::parse("0:01:02.345678901 AM", "%T.%N %P"),
+            Time::parse("0:01:02.345678901 12:01:02 am", "%T.%N %r"),
+            Time::parse("0:01:02.345678901 0:01", "%T.%N %R"),
+            Time::parse("0:01:02.345678901 02", "%T.%N %S"),
+            Time::parse("0:01:02.345678901 0:01:02", "%T.%N %T"),
+            Time::parse("1:00 am", "%-I:%M %p"),
+            Time::parse("1:00 pm", "%-I:%M %p"),
+            Time::parse(" 1:00 am", "%_I:%M %p"),
+            Time::parse(" 1:00 pm", "%_I:%M %p"),
+            Time::parse("01:00 am", "%0I:%M %p"),
+            Time::parse("01:00 pm", "%0I:%M %p"),
+            Time::parse("1:02:03.456789012 pm", "%-I:%M:%S.%N %p"),
+            Time::parse("", ""),
+        ));
+    }
+
+    fn parse_missing_seconds(ben: &mut Bencher) {
+        ben.iter(|| (
+            Time::parse("0:00", "%-H:%M"),
+            Time::parse("23:59", "%H:%M"),
+            Time::parse("12:00 am", "%I:%M %p"),
+            Time::parse("12:00 pm", "%I:%M %p"),
+        ));
+    }
+
+    fn parse_missing_minutes(ben: &mut Bencher) {
+        ben.iter(|| (
+            Time::parse("0", "%-H"),
+            Time::parse("23", "%H"),
+            Time::parse("12am", "%I%p"),
+            Time::parse("12pm", "%I%p"),
+        ));
+    }
+
+    fn display(ben: &mut Bencher) {
+        let a = time!("0:00");
+        let b = time!("23:59");
+        let c = time!("23:59:59");
+        let d = time!("0:00:01");
+        let e = time!("0:00:00.001");
+        let f = time!("0:00:00.000_001");
+        let g = time!("0:00:00.000_000_001");
+
+        ben.iter(|| (
+            a.to_string(),
+            b.to_string(),
+            c.to_string(),
+            d.to_string(),
+            e.to_string(),
+            f.to_string(),
+            g.to_string(),
+        ));
+    }
+
+    fn add_duration(ben: &mut Bencher) {
+        let t = time!("0:00");
+        let dta = 1.milliseconds();
+        let dtb = 1.seconds();
+        let dtc = 1.minutes();
+        let dtd = 1.hours();
+        let dte = 1.days();
+        ben.iter(|| t + dta + dtb + dtc + dtd + dte);
+    }
+
+    fn add_assign_duration(ben: &mut Bencher) {
+        let dta = 1.milliseconds();
+        let dtb = 1.seconds();
+        let dtc = 1.minutes();
+        let dtd = 1.hours();
+        let dte = 1.days();
+        ben.iter_batched_ref(
+            || time!("0:00"),
+            |time| {
+                *time += dta;
+                *time += dtb;
+                *time += dtc;
+                *time += dtd;
+                *time += dte;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn sub_duration(ben: &mut Bencher) {
+        let t = time!("12:00");
+
+        let dta = 1.milliseconds();
+        let dtb = 1.seconds();
+        let dtc = 1.minutes();
+        let dtd = 1.hours();
+        let dte = 1.days();
+
+        ben.iter(|| t - dta - dtb - dtc - dtd - dte);
+    }
+
+    fn sub_assign_duration(ben: &mut Bencher) {
+        let dta = 1.milliseconds();
+        let dtb = 1.seconds();
+        let dtc = 1.minutes();
+        let dtd = 1.hours();
+        let dte = 1.days();
+
+        ben.iter_batched_ref(
+            || time!("0:00"),
+            |time| {
+                *time -= dta;
+                *time -= dtb;
+                *time -= dtc;
+                *time -= dtd;
+                *time -= dte;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn add_std_duration(ben: &mut Bencher) {
+        let t = time!("0:00");
+        let dta = 1.std_milliseconds();
+        let dtb = 1.std_seconds();
+        let dtc = 1.std_minutes();
+        let dtd = 1.std_hours();
+        let dte = 1.std_days();
+        ben.iter(|| t + dta + dtb + dtc + dtd + dte);
+    }
+
+    fn add_assign_std_duration(ben: &mut Bencher) {
+        let dta = 1.std_milliseconds();
+        let dtb = 1.std_seconds();
+        let dtc = 1.std_minutes();
+        let dtd = 1.std_hours();
+        let dte = 1.std_days();
+        ben.iter_batched_ref(
+            || time!("0:00"),
+            |time| {
+                *time += dta;
+                *time += dtb;
+                *time += dtc;
+                *time += dtd;
+                *time += dte;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn sub_std_duration(ben: &mut Bencher) {
+        let t = time!("12:00");
+
+        let dta = 1.std_milliseconds();
+        let dtb = 1.std_seconds();
+        let dtc = 1.std_minutes();
+        let dtd = 1.std_hours();
+        let dte = 1.std_days();
+
+        ben.iter(|| t - dta - dtb - dtc - dtd - dte);
+    }
+
+    fn sub_assign_std_duration(ben: &mut Bencher) {
+        let dta = 1.std_milliseconds();
+        let dtb = 1.std_seconds();
+        let dtc = 1.std_minutes();
+        let dtd = 1.std_hours();
+        let dte = 1.std_days();
+
+        ben.iter_batched_ref(
+            || time!("0:00"),
+            |time| {
+                *time -= dta;
+                *time -= dtb;
+                *time -= dtc;
+                *time -= dtd;
+                *time -= dte;
+            },
+            BatchSize::SmallInput
+        );
+    }
+
+    fn sub_time(ben: &mut Bencher) {
+        let a = time!("0:00");
+        let b = time!("1:00");
+        let c = time!("0:00:01");
+        ben.iter(|| (
+            a - c,
+            b - a,
+            b - c,
+        ));
+    }
+
+    fn ordering(ben: &mut Bencher) {
+        let a = time!("0:00");
+        let b = time!("0:00:00.000_000_001");
+        let c = time!("0:00:01");
+        let d = time!("12:00");
+        let e = time!("11:00");
+        ben.iter(|| (
+            a < b,
+            a < c,
+            d > e,
+            a == b,
+        ));
+    }
+}

--- a/time-benchmarks/benches/utc_offset.rs
+++ b/time-benchmarks/benches/utc_offset.rs
@@ -1,0 +1,167 @@
+use bench_util::setup_benchmark;
+use time::{offset, OffsetDateTime, UtcOffset};
+
+setup_benchmark! {
+    "UtcOffset",
+
+    fn hours(ben: &mut Bencher) {
+        ben.iter(|| (
+            UtcOffset::hours(1),
+            UtcOffset::hours(-1),
+            UtcOffset::hours(23),
+            UtcOffset::hours(-23),
+        ));
+    }
+
+    fn directional_hours(ben: &mut Bencher) {
+        ben.iter(|| (
+            UtcOffset::east_hours(1),
+            UtcOffset::west_hours(1),
+        ));
+    }
+
+    fn minutes(ben: &mut Bencher) {
+        ben.iter(|| (
+            UtcOffset::minutes(1),
+            UtcOffset::minutes(-1),
+            UtcOffset::minutes(1_439),
+            UtcOffset::minutes(-1_439),
+        ));
+    }
+
+    fn directional_minutes(ben: &mut Bencher) {
+        ben.iter(|| (
+            UtcOffset::east_minutes(1),
+            UtcOffset::west_minutes(1),
+        ));
+    }
+
+    fn seconds(ben: &mut Bencher) {
+        ben.iter(|| (
+            UtcOffset::seconds(1),
+            UtcOffset::seconds(-1),
+            UtcOffset::seconds(86_399),
+            UtcOffset::seconds(-86_399),
+        ));
+    }
+
+    fn directional_seconds(ben: &mut Bencher) {
+        ben.iter(|| (
+            UtcOffset::east_seconds(1),
+            UtcOffset::west_seconds(1),
+        ));
+    }
+
+    fn as_hours(ben: &mut Bencher) {
+        let a = offset!("+1");
+        let b = offset!("+0:59");
+        let c = offset!("-1");
+        let d = offset!("-0:59");
+        ben.iter(|| (
+            a.as_hours(),
+            b.as_hours(),
+            c.as_hours(),
+            d.as_hours(),
+        ));
+    }
+
+    fn as_minutes(ben: &mut Bencher) {
+        let a = offset!("+1");
+        let b = offset!("+0:01");
+        let c = offset!("+0:00:59");
+        let d = offset!("-1");
+        let e = offset!("-0:01");
+        let f = offset!("-0:00:59");
+        ben.iter(|| (
+            a.as_minutes(),
+            b.as_minutes(),
+            c.as_minutes(),
+            d.as_minutes(),
+            e.as_minutes(),
+            f.as_minutes(),
+        ));
+    }
+
+    fn as_seconds(ben: &mut Bencher) {
+        let a = offset!("+1");
+        let b = offset!("+0:01");
+        let c = offset!("+0:00:01");
+        let d = offset!("-1");
+        let e = offset!("-0:01");
+        let f = offset!("-0:00:01");
+        ben.iter(|| (
+            a.as_seconds(),
+            b.as_seconds(),
+            c.as_seconds(),
+            d.as_seconds(),
+            e.as_seconds(),
+            f.as_seconds(),
+        ));
+    }
+
+    fn format(ben: &mut Bencher) {
+        let a = offset!("+1");
+        let b = offset!("-1");
+        let c = offset!("+0");
+        let d = offset!("-0");
+        let e = offset!("+0:01");
+        let f = offset!("-0:01");
+        let g = offset!("+0:00:01");
+        let h = offset!("-0:00:01");
+
+        ben.iter(|| (
+            a.format("%z"),
+            b.format("%z"),
+            c.format("%z"),
+            d.format("%z"),
+            e.format("%z"),
+            f.format("%z"),
+            g.format("%z"),
+            h.format("%z"),
+        ));
+    }
+
+    fn parse(ben: &mut Bencher) {
+        ben.iter(|| (
+            UtcOffset::parse("+0100", "%z"),
+            UtcOffset::parse("-0100", "%z"),
+            UtcOffset::parse("+0000", "%z"),
+            UtcOffset::parse("-0000", "%z"),
+            UtcOffset::parse("+0001", "%z"),
+            UtcOffset::parse("-0001", "%z"),
+        ));
+    }
+
+    fn display(ben: &mut Bencher) {
+        let a = offset!("UTC");
+        let b = offset!("+0:00:01");
+        let c = offset!("-0:00:01");
+        let d = offset!("+1");
+        let e = offset!("-1");
+        let f = offset!("+23:59");
+        let g = offset!("-23:59");
+        let h = offset!("+23:59:59");
+        let i = offset!("-23:59:59");
+
+        ben.iter(|| (
+            a.to_string(),
+            b.to_string(),
+            c.to_string(),
+            d.to_string(),
+            e.to_string(),
+            f.to_string(),
+            g.to_string(),
+            h.to_string(),
+            i.to_string(),
+        ));
+    }
+
+    fn local_offset_at(ben: &mut Bencher) {
+        let epoch = OffsetDateTime::unix_epoch();
+        ben.iter(|| UtcOffset::local_offset_at(epoch));
+    }
+
+    fn current_local_offset(ben: &mut Bencher) {
+        ben.iter(UtcOffset::current_local_offset);
+    }
+}

--- a/time-benchmarks/benches/util.rs
+++ b/time-benchmarks/benches/util.rs
@@ -1,0 +1,41 @@
+use bench_util::setup_benchmark;
+use time::util;
+
+setup_benchmark! {
+    "Utils",
+
+    fn is_leap_year(ben: &mut Bencher) {
+        ben.iter(|| (
+            util::is_leap_year(1900),
+            util::is_leap_year(2000),
+            util::is_leap_year(2004),
+            util::is_leap_year(2005),
+            util::is_leap_year(2100),
+        ));
+    }
+
+    fn days_in_year(ben: &mut Bencher) {
+        ben.iter(|| (
+            util::days_in_year(1900),
+            util::days_in_year(2000),
+            util::days_in_year(2004),
+            util::days_in_year(2005),
+            util::days_in_year(2100),
+        ));
+    }
+
+    fn weeks_in_year(ben: &mut Bencher) {
+        ben.iter(|| (
+            util::weeks_in_year(2019),
+            util::weeks_in_year(2020),
+        ));
+    }
+
+    fn validate_format_string(ben: &mut Bencher) {
+        ben.iter(|| (
+            util::validate_format_string("%H foo"),
+            util::validate_format_string("%H%%"),
+            util::validate_format_string("%"),
+        ));
+    }
+}

--- a/time-benchmarks/benches/weekday.rs
+++ b/time-benchmarks/benches/weekday.rs
@@ -1,0 +1,102 @@
+use bench_util::setup_benchmark;
+use time::Weekday::*;
+
+setup_benchmark! {
+    "Weekday",
+
+    fn previous(ben: &mut Bencher) {
+        ben.iter(|| (
+            Sunday.previous(),
+            Monday.previous(),
+            Tuesday.previous(),
+            Wednesday.previous(),
+            Thursday.previous(),
+            Friday.previous(),
+            Saturday.previous(),
+        ));
+    }
+
+    fn next(ben: &mut Bencher) {
+        ben.iter(|| (
+            Sunday.next(),
+            Monday.next(),
+            Tuesday.next(),
+            Wednesday.next(),
+            Thursday.next(),
+            Friday.next(),
+            Saturday.next(),
+        ));
+    }
+
+    fn iso_weekday_number(ben: &mut Bencher) {
+        ben.iter(|| (
+            Monday.iso_weekday_number(),
+            Tuesday.iso_weekday_number(),
+            Wednesday.iso_weekday_number(),
+            Thursday.iso_weekday_number(),
+            Friday.iso_weekday_number(),
+            Saturday.iso_weekday_number(),
+            Sunday.iso_weekday_number(),
+        ));
+    }
+
+    fn number_from_monday(ben: &mut Bencher) {
+        ben.iter(|| (
+            Monday.number_from_monday(),
+            Tuesday.number_from_monday(),
+            Wednesday.number_from_monday(),
+            Thursday.number_from_monday(),
+            Friday.number_from_monday(),
+            Saturday.number_from_monday(),
+            Sunday.number_from_monday(),
+        ));
+    }
+
+    fn number_from_sunday(ben: &mut Bencher) {
+        ben.iter(|| (
+            Sunday.number_from_sunday(),
+            Monday.number_from_sunday(),
+            Tuesday.number_from_sunday(),
+            Wednesday.number_from_sunday(),
+            Thursday.number_from_sunday(),
+            Friday.number_from_sunday(),
+            Saturday.number_from_sunday(),
+        ));
+    }
+
+    fn number_days_from_monday(ben: &mut Bencher) {
+        ben.iter(|| (
+            Monday.number_days_from_monday(),
+            Tuesday.number_days_from_monday(),
+            Wednesday.number_days_from_monday(),
+            Thursday.number_days_from_monday(),
+            Friday.number_days_from_monday(),
+            Saturday.number_days_from_monday(),
+            Sunday.number_days_from_monday(),
+        ));
+    }
+
+    fn number_days_from_sunday(ben: &mut Bencher) {
+        ben.iter(|| (
+            Sunday.number_days_from_sunday(),
+            Monday.number_days_from_sunday(),
+            Tuesday.number_days_from_sunday(),
+            Wednesday.number_days_from_sunday(),
+            Thursday.number_days_from_sunday(),
+            Friday.number_days_from_sunday(),
+            Saturday.number_days_from_sunday(),
+        ));
+    }
+
+    fn display(ben: &mut Bencher) {
+        ben.iter(|| (
+            Monday.to_string(),
+            Tuesday.to_string(),
+            Wednesday.to_string(),
+            Thursday.to_string(),
+            Friday.to_string(),
+            Saturday.to_string(),
+            Sunday.to_string(),
+        ));
+    }
+}


### PR DESCRIPTION
Hello and happy Hacktoberfest!

Here's a stab at adding some benchmarks as requested in #218. This doesn't cover everything yet, but I'm submitting this first step so people can take a look and see that this looks like a good direction. Basically what I've done is copy the tests and massage them a bit to make them benchmarks instead of checks. If this looks like a good start, I'll continue with adding more coverage.

Running all of the benchmarks takes quite a long time, so it might be desirable to group them into larger chunks to reduce Criterion's warmup overhead. You can also select a subset of benchmarks on the command line, for example

```
$ cargo bench Date
```
will run all the benchmarks whose name contains "Date", and
```
$ cargo bench add_assign_duration
```
will run only the `Instant: add_assign_duration` and `Instant: std_add_assign_duration` benchmarks.