### PR TITLE
Add no-alloc support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning].
 - `OffsetDateTime::replace_date`
 - `OffsetDateTime::replace_date_time`
 - `OffsetDateTime::replace_offset`
+- `#![no_alloc]` support
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ rustdoc-args = ["--cfg", "__time_02_docs"]
 default = ["std"]
 macros = ["time-macros"]
 local-offset = ["std", "libc", "winapi"]
-std = ["standback/std"]
+std = ["standback/std", "alloc"]
+alloc = []
 
 [dependencies]
 const_fn = "0.4.2"

--- a/src/date.rs
+++ b/src/date.rs
@@ -17,10 +17,9 @@ use core::{
     time::Duration as StdDuration,
 };
 #[cfg(feature = "std")]
-use core::{
-    cmp::{Ord, PartialOrd},
-    fmt::Display,
-};
+use core::cmp::{Ord, PartialOrd};
+#[cfg(feature = "alloc")]
+use core::fmt::Display;
 
 /// The minimum valid year.
 pub(crate) const MIN_YEAR: i32 = -999_999;

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,15 +1,25 @@
 use crate::{
     error,
-    format::parse::{parse, ParsedItems},
     util::{days_in_year, days_in_year_month, is_leap_year, weeks_in_year},
-    DeferredFormat, Duration, Format, ParseResult, PrimitiveDateTime, Time, Weekday,
+    Duration, PrimitiveDateTime, Time, Weekday,
 };
+#[cfg(feature = "alloc")]
+use crate::{
+    format::parse::{parse, ParsedItems},
+    DeferredFormat, Format, ParseResult,
+};
+#[cfg(feature = "alloc")]
 use alloc::string::{String, ToString};
 use const_fn::const_fn;
 use core::{
-    fmt::{self, Display},
+    fmt,
     ops::{Add, AddAssign, Sub, SubAssign},
     time::Duration as StdDuration,
+};
+#[cfg(feature = "alloc")]
+use core::{
+    cmp::{Ord, PartialOrd},
+    fmt::Display,
 };
 
 /// The minimum valid year.
@@ -718,6 +728,7 @@ impl Date {
 }
 
 /// Methods that allow formatting the `Date`.
+#[cfg(feature = "alloc")]
 impl Date {
     /// Format the `Date` using the provided string.
     ///
@@ -797,6 +808,7 @@ impl Date {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Display for Date {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use crate::format::{date, Padding};

--- a/src/date.rs
+++ b/src/date.rs
@@ -16,8 +16,6 @@ use core::{
     ops::{Add, AddAssign, Sub, SubAssign},
     time::Duration as StdDuration,
 };
-#[cfg(feature = "serde")]
-use core::cmp::{Ord, PartialOrd};
 #[cfg(feature = "alloc")]
 use core::fmt::Display;
 

--- a/src/date.rs
+++ b/src/date.rs
@@ -16,7 +16,7 @@ use core::{
     ops::{Add, AddAssign, Sub, SubAssign},
     time::Duration as StdDuration,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 use core::cmp::{Ord, PartialOrd};
 #[cfg(feature = "alloc")]
 use core::fmt::Display;

--- a/src/date.rs
+++ b/src/date.rs
@@ -16,7 +16,7 @@ use core::{
     ops::{Add, AddAssign, Sub, SubAssign},
     time::Duration as StdDuration,
 };
-#[cfg(feature = "alloc")]
+#[cfg(feature = "std")]
 use core::{
     cmp::{Ord, PartialOrd},
     fmt::Display,

--- a/src/date.rs
+++ b/src/date.rs
@@ -11,13 +11,13 @@ use crate::{
 #[cfg(feature = "alloc")]
 use alloc::string::{String, ToString};
 use const_fn::const_fn;
+#[cfg(feature = "alloc")]
+use core::fmt::Display;
 use core::{
     fmt,
     ops::{Add, AddAssign, Sub, SubAssign},
     time::Duration as StdDuration,
 };
-#[cfg(feature = "alloc")]
-use core::fmt::Display;
 
 /// The minimum valid year.
 pub(crate) const MIN_YEAR: i32 = -999_999;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
+#[cfg(feature = "alloc")]
 pub use crate::format::parse::Error as Parse;
-use alloc::boxed::Box;
 use core::fmt;
 
 /// A unified error type for anything returned by a method in the time crate.
@@ -12,7 +12,8 @@ use core::fmt;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
     ConversionRange,
-    ComponentRange(Box<ComponentRange>),
+    ComponentRange(ComponentRange),
+    #[cfg(feature = "alloc")]
     Parse(Parse),
     IndeterminateOffset,
     Format(Format),
@@ -26,6 +27,7 @@ impl fmt::Display for Error {
         match self {
             Error::ConversionRange => ConversionRange.fmt(f),
             Error::ComponentRange(e) => e.fmt(f),
+            #[cfg(feature = "alloc")]
             Error::Parse(e) => e.fmt(f),
             Error::IndeterminateOffset => IndeterminateOffset.fmt(f),
             Error::Format(e) => e.fmt(f),
@@ -40,7 +42,7 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Error::ConversionRange => Some(&ConversionRange),
-            Error::ComponentRange(box_err) => Some(box_err.as_ref()),
+            Error::ComponentRange(err) => Some(err),
             Error::Parse(err) => Some(err),
             Error::IndeterminateOffset => Some(&IndeterminateOffset),
             Error::Format(err) => Some(err),
@@ -111,13 +113,14 @@ impl fmt::Display for ComponentRange {
 
 impl From<ComponentRange> for Error {
     fn from(original: ComponentRange) -> Self {
-        Error::ComponentRange(Box::new(original))
+        Error::ComponentRange(original)
     }
 }
 
 #[cfg(feature = "std")]
 impl std::error::Error for ComponentRange {}
 
+#[cfg(feature = "alloc")]
 impl From<Parse> for Error {
     fn from(original: Parse) -> Self {
         Error::Parse(original)

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,7 @@ use core::fmt;
 // Boxing the `ComponentRange` reduces the size of `Error` from 72 bytes to 16.
 #[allow(clippy::missing_docs_in_private_items)] // variants only
 #[cfg_attr(__time_02_supports_non_exhaustive, non_exhaustive)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub enum Error {
     ConversionRange,
     ComponentRange(ComponentRange),

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,10 +6,10 @@ use core::fmt;
 ///
 /// This can be used when you either don't know or don't care about the exact
 /// error returned. `Result<_, time::Error>` will work in these situations.
-// Boxing the `ComponentRange` reduces the size of `Error` from 72 bytes to 16.
+#[allow(missing_copy_implementations, variant_size_differences)]
 #[allow(clippy::missing_docs_in_private_items)] // variants only
 #[cfg_attr(__time_02_supports_non_exhaustive, non_exhaustive)]
-#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
     ConversionRange,
     ComponentRange(ComponentRange),

--- a/src/format/date.rs
+++ b/src/format/date.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     Date, Weekday,
 };
+#[cfg(feature = "alloc")]
 use alloc::string::ToString;
 use core::{
     fmt::{self, Formatter},
@@ -232,6 +233,7 @@ pub(crate) fn fmt_u(f: &mut Formatter<'_>, date: Date) -> fmt::Result {
 }
 
 /// ISO weekday (Monday = `1`, Sunday = `7`)
+#[cfg(feature = "alloc")]
 pub(crate) fn parse_u(items: &mut ParsedItems, s: &mut &str) -> ParseResult<()> {
     items.weekday = Some(
         try_consume_first_match(
@@ -276,6 +278,7 @@ pub(crate) fn fmt_w(f: &mut Formatter<'_>, date: Date) -> fmt::Result {
 }
 
 /// Weekday number (Sunday = `0`, Saturday = `6`)
+#[cfg(feature = "alloc")]
 pub(crate) fn parse_w(items: &mut ParsedItems, s: &mut &str) -> ParseResult<()> {
     let mut weekdays = WEEKDAYS;
     weekdays.rotate_left(1);

--- a/src/format/deferred_format.rs
+++ b/src/format/deferred_format.rs
@@ -1,12 +1,12 @@
 //! The [`DeferredFormat`] struct, acting as an intermediary between a request
 //! to format and the final output.
 
+#[cfg(feature = "alloc")]
+use crate::format::parse_fmt_string;
 use crate::{
     format::{format_specifier, well_known, Format, FormatItem},
     Date, Time, UtcOffset,
 };
-#[cfg(feature = "alloc")]
-use crate::format::parse_fmt_string;
 use core::fmt::{self, Display, Formatter};
 
 /// A struct containing all the necessary information to display the inner type.

--- a/src/format/deferred_format.rs
+++ b/src/format/deferred_format.rs
@@ -2,9 +2,11 @@
 //! to format and the final output.
 
 use crate::{
-    format::{format_specifier, parse_fmt_string, well_known, Format, FormatItem},
+    format::{format_specifier, well_known, Format, FormatItem},
     Date, Time, UtcOffset,
 };
+#[cfg(feature = "alloc")]
+use crate::format::parse_fmt_string;
 use core::fmt::{self, Display, Formatter};
 
 /// A struct containing all the necessary information to display the inner type.
@@ -65,6 +67,7 @@ impl<'a> DeferredFormat<'a> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Display for DeferredFormat<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match &self.format {

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -26,7 +26,10 @@ use core::fmt::Formatter;
 pub(crate) use deferred_format::DeferredFormat;
 #[allow(unreachable_pub)] // rust-lang/rust#64762
 pub use format::Format;
-pub(crate) use parse::{parse, ParseResult, ParsedItems};
+pub(crate) use parse::{ParseResult, ParsedItems};
+#[cfg(feature = "alloc")]
+pub(crate) use parse::parse;
+#[cfg(feature = "alloc")]
 pub(crate) use parse_items::{parse_fmt_string, try_parse_fmt_string};
 
 /// The type of padding to use when formatting.

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -26,9 +26,9 @@ use core::fmt::Formatter;
 pub(crate) use deferred_format::DeferredFormat;
 #[allow(unreachable_pub)] // rust-lang/rust#64762
 pub use format::Format;
-pub(crate) use parse::{ParseResult, ParsedItems};
 #[cfg(feature = "alloc")]
 pub(crate) use parse::parse;
+pub(crate) use parse::{ParseResult, ParsedItems};
 #[cfg(feature = "alloc")]
 pub(crate) use parse_items::{parse_fmt_string, try_parse_fmt_string};
 

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -1,12 +1,12 @@
 //! Parsing for various types.
 
+#[cfg(feature = "alloc")]
+use crate::format::parse_fmt_string;
 use crate::{
     error,
     format::{well_known, FormatItem, Padding, Specifier},
     Format, UtcOffset, Weekday,
-};    
-#[cfg(feature = "alloc")]
-use crate::format::parse_fmt_string;
+};
 use core::{
     fmt::{self, Display, Formatter},
     num::{NonZeroU16, NonZeroU8},
@@ -17,8 +17,9 @@ use core::{
 pub(crate) type ParseResult<T> = Result<T, Error>;
 
 /// An error occurred while parsing.
+#[allow(variant_size_differences)]
 #[cfg_attr(__time_02_supports_non_exhaustive, non_exhaustive)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Error {
     /// The nanosecond present was not valid.
     InvalidNanosecond,

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -2,10 +2,11 @@
 
 use crate::{
     error,
-    format::{parse_fmt_string, well_known, FormatItem, Padding, Specifier},
+    format::{well_known, FormatItem, Padding, Specifier},
     Format, UtcOffset, Weekday,
-};
-use alloc::boxed::Box;
+};    
+#[cfg(feature = "alloc")]
+use crate::format::parse_fmt_string;
 use core::{
     fmt::{self, Display, Formatter},
     num::{NonZeroU16, NonZeroU8},
@@ -59,7 +60,7 @@ pub enum Error {
     /// There was not enough information provided to create the requested type.
     InsufficientInformation,
     /// A component was out of range.
-    ComponentOutOfRange(Box<error::ComponentRange>),
+    ComponentOutOfRange(error::ComponentRange),
     #[cfg(not(__time_02_supports_non_exhaustive))]
     #[doc(hidden)]
     __NonExhaustive,
@@ -67,7 +68,7 @@ pub enum Error {
 
 impl From<error::ComponentRange> for Error {
     fn from(error: error::ComponentRange) -> Self {
-        Error::ComponentOutOfRange(Box::new(error))
+        Error::ComponentOutOfRange(error)
     }
 }
 
@@ -107,7 +108,7 @@ impl Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::ComponentOutOfRange(e) => Some(e.as_ref()),
+            Error::ComponentOutOfRange(e) => Some(e),
             _ => None,
         }
     }
@@ -324,6 +325,7 @@ pub(crate) fn consume_padding(s: &mut &str, padding: Padding, max_chars: usize) 
 
 /// Attempt to parse the string with the provided format, returning a struct
 /// containing all information found.
+#[cfg(feature = "alloc")]
 #[allow(clippy::too_many_lines)]
 pub(crate) fn parse(s: &str, format: &Format<'_>) -> ParseResult<ParsedItems> {
     use super::{date, offset, time};

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -18,7 +18,7 @@ pub(crate) type ParseResult<T> = Result<T, Error>;
 
 /// An error occurred while parsing.
 #[cfg_attr(__time_02_supports_non_exhaustive, non_exhaustive)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
 pub enum Error {
     /// The nanosecond present was not valid.
     InvalidNanosecond,

--- a/src/format/parse_items.rs
+++ b/src/format/parse_items.rs
@@ -1,9 +1,11 @@
 //! Parse formats used in the `format` and `parse` methods.
 
 use crate::format::{FormatItem, Padding, Specifier};
+#[cfg(feature = "alloc")]
 use alloc::{format, string::String, vec::Vec};
 
 /// Parse the formatting string. Panics if not valid.
+#[cfg(feature = "alloc")]
 pub(crate) fn parse_fmt_string<'a>(s: &'a str) -> Vec<FormatItem<'a>> {
     match try_parse_fmt_string(s) {
         Ok(items) => items,
@@ -12,6 +14,7 @@ pub(crate) fn parse_fmt_string<'a>(s: &'a str) -> Vec<FormatItem<'a>> {
 }
 
 /// Attempt to parse the formatting string.
+#[cfg(feature = "alloc")]
 #[allow(clippy::too_many_lines)]
 pub(crate) fn try_parse_fmt_string<'a>(s: &'a str) -> Result<Vec<FormatItem<'a>>, String> {
     let mut items = Vec::new();

--- a/src/format/well_known.rs
+++ b/src/format/well_known.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     DeferredFormat, ParseResult,
 };
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 use core::fmt::Formatter;
 #[allow(unused_imports)]
@@ -50,6 +51,7 @@ pub(crate) mod rfc3339 {
     }
 
     /// Parse `s` as specified by RFC3339.
+    #[cfg(feature = "alloc")]
     pub(crate) fn parse(items: &mut ParsedItems, s: &mut &str) -> ParseResult<()> {
         items.year = try_consume_exact_digits::<i32>(s, 4, Padding::None)
             .ok_or(error::Parse::InvalidYear)?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,7 @@
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/55999857")]
 #![doc(test(attr(deny(warnings))))]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 /// Returns `Err(error::ComponentRange)` if the value is not in range.
@@ -239,6 +240,7 @@ mod duration;
 pub mod error;
 /// Extension traits.
 pub mod ext;
+#[cfg(feature = "alloc")]
 mod format;
 /// The [`Instant`] struct and its associated `impl`s.
 #[cfg(feature = "std")]
@@ -359,7 +361,9 @@ pub mod macros {
 pub use date::Date;
 pub use duration::Duration;
 pub use error::Error;
+#[cfg(feature = "alloc")]
 pub use format::Format;
+#[cfg(feature = "alloc")]
 use format::{DeferredFormat, ParseResult};
 #[cfg(feature = "std")]
 pub use instant::Instant;
@@ -392,6 +396,7 @@ pub mod prelude {
     pub use crate::macros::{date, datetime, offset, time};
 }
 
+#[cfg(feature = "alloc")]
 #[allow(clippy::missing_docs_in_private_items)]
 mod private {
     use super::*;
@@ -431,6 +436,7 @@ mod private {
 /// println!("{:?}", foo);
 /// # Ok::<_, time::Error>(())
 /// ```
+#[cfg(feature = "alloc")]
 pub fn parse<'a, T: private::Parsable>(
     s: impl AsRef<str>,
     format: impl Into<Format<'a>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,16 @@
 //! Reliance on a given feature is always indicated alongside the item
 //! definition.
 //!
-//! - `std` (_enabled by default_)
+//! - `std` (_enabled by default, implicitly enables `alloc`_)
 //!
 //!   This enables a number of features that depend on the standard library.
 //!   [`Instant`] is the primary item that requires this feature, though some
 //!   others methods may rely on [`Instant`] internally.
 //!
-//!   This crate currently requires a global allocator be present even if this
-//!   feature is disabled.
+//! - `alloc` (_enabled by default via `std`_)
+//!
+//!   Enables a number of features that require the ability to dynamically
+//!   allocate memory.
 //!
 //! - `macros`
 //!

--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -1,26 +1,22 @@
-use crate::{
-    error,
-    Date, Duration, PrimitiveDateTime, Time, UtcOffset,
-    Weekday,
-};
-#[cfg(feature = "alloc")]
-use alloc::string::{String, ToString};
-use const_fn::const_fn;
+use crate::{error, Date, Duration, PrimitiveDateTime, Time, UtcOffset, Weekday};
 #[cfg(feature = "alloc")]
 use crate::{
     format::parse::{parse, ParsedItems},
     DeferredFormat, Format, ParseResult,
 };
+#[cfg(feature = "alloc")]
+use alloc::string::{String, ToString};
+use const_fn::const_fn;
 #[cfg(feature = "std")]
 use core::convert::{From, TryFrom};
+#[cfg(feature = "alloc")]
+use core::fmt::{self, Display};
 use core::{
     cmp::Ordering,
     hash::{Hash, Hasher},
     ops::{Add, AddAssign, Sub, SubAssign},
     time::Duration as StdDuration,
 };
-#[cfg(feature = "alloc")]
-use core::fmt::{self, Display};
 #[cfg(feature = "std")]
 use std::time::SystemTime;
 

--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -1,20 +1,26 @@
 use crate::{
     error,
-    format::parse::{parse, ParsedItems},
-    Date, DeferredFormat, Duration, Format, ParseResult, PrimitiveDateTime, Time, UtcOffset,
+    Date, Duration, PrimitiveDateTime, Time, UtcOffset,
     Weekday,
 };
+#[cfg(feature = "alloc")]
 use alloc::string::{String, ToString};
 use const_fn::const_fn;
+#[cfg(feature = "alloc")]
+use crate::{
+    format::parse::{parse, ParsedItems},
+    DeferredFormat, Format, ParseResult,
+};
 #[cfg(feature = "std")]
 use core::convert::{From, TryFrom};
 use core::{
     cmp::Ordering,
-    fmt::{self, Display},
     hash::{Hash, Hasher},
     ops::{Add, AddAssign, Sub, SubAssign},
     time::Duration as StdDuration,
 };
+#[cfg(feature = "alloc")]
+use core::fmt::{self, Display};
 #[cfg(feature = "std")]
 use std::time::SystemTime;
 
@@ -673,6 +679,7 @@ impl OffsetDateTime {
 }
 
 /// Methods that allow formatting the `OffsetDateTime`.
+#[cfg(feature = "alloc")]
 impl OffsetDateTime {
     /// Format the `OffsetDateTime` using the provided string.
     ///
@@ -720,6 +727,7 @@ impl OffsetDateTime {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Display for OffsetDateTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {} {}", self.date(), self.time(), self.offset())

--- a/src/primitive_date_time.rs
+++ b/src/primitive_date_time.rs
@@ -1,21 +1,19 @@
-use crate::{
-    util, Date, Duration, OffsetDateTime, Time, UtcOffset, Weekday,
-};
-#[cfg(feature = "alloc")]
-use alloc::string::{String, ToString};
 #[cfg(feature = "alloc")]
 use crate::{
     format::parse::{parse, ParsedItems},
     DeferredFormat, Format, ParseResult,
 };
+use crate::{util, Date, Duration, OffsetDateTime, Time, UtcOffset, Weekday};
+#[cfg(feature = "alloc")]
+use alloc::string::{String, ToString};
 use const_fn::const_fn;
+#[cfg(feature = "alloc")]
+use core::fmt::{self, Display};
 use core::{
     cmp::Ordering,
     ops::{Add, AddAssign, Sub, SubAssign},
     time::Duration as StdDuration,
 };
-#[cfg(feature = "alloc")]
-use core::fmt::{self, Display};
 
 /// Combined date and time.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/primitive_date_time.rs
+++ b/src/primitive_date_time.rs
@@ -1,16 +1,21 @@
 use crate::{
-    format::parse::{parse, ParsedItems},
-    util, Date, DeferredFormat, Duration, Format, OffsetDateTime, ParseResult, Time, UtcOffset,
-    Weekday,
+    Date, Duration, OffsetDateTime, Time, UtcOffset, Weekday,
 };
+#[cfg(feature = "alloc")]
 use alloc::string::{String, ToString};
+#[cfg(feature = "alloc")]
+use crate::{
+    format::parse::{parse, ParsedItems},
+    DeferredFormat, Format, ParseResult,
+};
 use const_fn::const_fn;
 use core::{
     cmp::Ordering,
-    fmt::{self, Display},
     ops::{Add, AddAssign, Sub, SubAssign},
     time::Duration as StdDuration,
 };
+#[cfg(feature = "alloc")]
+use core::fmt::{self, Display};
 
 /// Combined date and time.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -465,6 +470,7 @@ impl PrimitiveDateTime {
 }
 
 /// Methods that allow formatting the `PrimitiveDateTime`.
+#[cfg(feature = "alloc")]
 impl PrimitiveDateTime {
     /// Format the `PrimitiveDateTime` using the provided string.
     ///
@@ -513,6 +519,7 @@ impl PrimitiveDateTime {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Display for PrimitiveDateTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", self.date(), self.time())

--- a/src/primitive_date_time.rs
+++ b/src/primitive_date_time.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Date, Duration, OffsetDateTime, Time, UtcOffset, Weekday,
+    util, Date, Duration, OffsetDateTime, Time, UtcOffset, Weekday,
 };
 #[cfg(feature = "alloc")]
 use alloc::string::{String, ToString};

--- a/src/time_mod.rs
+++ b/src/time_mod.rs
@@ -1,13 +1,11 @@
-use crate::{
-    error, Duration,
-};
-#[cfg(feature = "alloc")]
-use alloc::string::{String, ToString};
+use crate::{error, Duration};
 #[cfg(feature = "alloc")]
 use crate::{
     format::{parse, parse::AmPm, ParsedItems},
     DeferredFormat, Format, ParseResult,
 };
+#[cfg(feature = "alloc")]
+use alloc::string::{String, ToString};
 use const_fn::const_fn;
 use core::{
     convert::TryFrom,

--- a/src/time_mod.rs
+++ b/src/time_mod.rs
@@ -1,16 +1,23 @@
 use crate::{
-    error,
-    format::{parse, parse::AmPm, ParsedItems},
-    DeferredFormat, Duration, Format, ParseResult,
+    error, Duration,
 };
+#[cfg(feature = "alloc")]
 use alloc::string::{String, ToString};
+#[cfg(feature = "alloc")]
+use crate::{
+    format::{parse, parse::AmPm, ParsedItems},
+    DeferredFormat, Format, ParseResult,
+};
 use const_fn::const_fn;
 use core::{
     convert::TryFrom,
-    fmt::{self, Display},
-    num::NonZeroU8,
     ops::{Add, AddAssign, Sub, SubAssign},
     time::Duration as StdDuration,
+};
+#[cfg(feature = "alloc")]
+use core::{
+    fmt::{self, Display},
+    num::NonZeroU8,
 };
 #[allow(unused_imports)]
 use standback::prelude::*; // rem_euclid (1.38)
@@ -360,6 +367,7 @@ impl Time {
 }
 
 /// Methods that allow formatting the `Time`.
+#[cfg(feature = "alloc")]
 impl Time {
     /// Format the `Time` using the provided string.
     ///
@@ -435,6 +443,7 @@ impl Time {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Display for Time {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use crate::format::{time, Padding};

--- a/src/utc_offset.rs
+++ b/src/utc_offset.rs
@@ -1,11 +1,15 @@
 #[cfg(feature = "local-offset")]
 use crate::OffsetDateTime;
 use crate::{
-    error,
-    format::{parse, ParsedItems},
-    DeferredFormat, Duration, Format, ParseResult,
+    error, Duration, 
 };
+#[cfg(feature = "alloc")]
 use alloc::string::{String, ToString};
+#[cfg(feature = "alloc")]
+use crate::{
+    format::{parse, ParsedItems},
+    DeferredFormat, Format, ParseResult,
+};
 use const_fn::const_fn;
 use core::fmt::{self, Display};
 
@@ -274,6 +278,7 @@ impl UtcOffset {
 }
 
 /// Methods that allow parsing and formatting the `UtcOffset`.
+#[cfg(feature = "alloc")]
 impl UtcOffset {
     /// Format the `UtcOffset` using the provided string.
     ///

--- a/src/utc_offset.rs
+++ b/src/utc_offset.rs
@@ -1,14 +1,12 @@
 #[cfg(feature = "local-offset")]
 use crate::OffsetDateTime;
-use crate::{
-    error, Duration, 
-};
+use crate::error;
 #[cfg(feature = "alloc")]
 use alloc::string::{String, ToString};
 #[cfg(feature = "alloc")]
 use crate::{
     format::{parse, ParsedItems},
-    DeferredFormat, Format, ParseResult,
+    DeferredFormat, Format, ParseResult, Duration,
 };
 use const_fn::const_fn;
 use core::fmt::{self, Display};
@@ -242,6 +240,7 @@ impl UtcOffset {
     }
 
     /// Convert a `UtcOffset` to ` Duration`. Useful for implementing operators.
+    #[cfg(feature = "alloc")]
     pub(crate) const fn as_duration(self) -> Duration {
         Duration::seconds(self.seconds as i64)
     }

--- a/src/utc_offset.rs
+++ b/src/utc_offset.rs
@@ -1,13 +1,13 @@
+use crate::error;
 #[cfg(feature = "local-offset")]
 use crate::OffsetDateTime;
-use crate::error;
-#[cfg(feature = "alloc")]
-use alloc::string::{String, ToString};
 #[cfg(feature = "alloc")]
 use crate::{
     format::{parse, ParsedItems},
-    DeferredFormat, Format, ParseResult, Duration,
+    DeferredFormat, Duration, Format, ParseResult,
 };
+#[cfg(feature = "alloc")]
+use alloc::string::{String, ToString};
 use const_fn::const_fn;
 use core::fmt::{self, Display};
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,9 @@
 //! Utility functions.
 
-#[cfg(feature = "alloc")]
-use crate::{format::try_parse_fmt_string, Date};
 #[cfg(not(feature = "alloc"))]
 use crate::Date;
+#[cfg(feature = "alloc")]
+use crate::{format::try_parse_fmt_string, Date};
 #[cfg(feature = "alloc")]
 use alloc::string::String;
 use const_fn::const_fn;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,11 +1,16 @@
 //! Utility functions.
 
+#[cfg(feature = "alloc")]
 use crate::{format::try_parse_fmt_string, Date};
+#[cfg(not(feature = "alloc"))]
+use crate::Date;
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 use const_fn::const_fn;
 
 /// Checks if a user-provided formatting string is valid. If it isn't, a
 /// description of the error is returned.
+#[cfg(feature = "alloc")]
 pub fn validate_format_string(s: impl AsRef<str>) -> Result<(), String> {
     try_parse_fmt_string(s.as_ref()).map(|_| ())
 }

--- a/tests/parse_error.rs
+++ b/tests/parse_error.rs
@@ -28,7 +28,7 @@ fn display() {
     .to_string();
     let _ = error::Parse::UnexpectedEndOfString.to_string();
     let _ = error::Parse::InsufficientInformation.to_string();
-    let _ = error::Parse::ComponentOutOfRange(Box::new(component_range())).to_string();
+    let _ = error::Parse::ComponentOutOfRange(component_range()).to_string();
 }
 
 #[test]


### PR DESCRIPTION
Solve #249 

Add `alloc` feature to support no_std targets.
Confirmed that the build passed in my no_std application