### PR TITLE
Implement quickcheck::Arbitrary for data types

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,7 @@ jobs:
             --feature-powerset
             --optional-deps
             --group-features serde,rand
-            --exclude-features default,libc,winapi,std,local-offset,time-macros
+            --exclude-features default,libc,winapi,std,local-offset,time-macros,quickcheck,quickcheck-dep
             --exclude-all-features
             --target ${{ matrix.target.triple }}
         if: matrix.target.std == false
@@ -89,8 +89,8 @@ jobs:
             --no-dev-deps
             --feature-powerset
             --optional-deps
-            --group-features serde,rand
-            --exclude-features default,libc,winapi,time-macros
+            --group-features serde,rand,quickcheck
+            --exclude-features default,libc,winapi,time-macros,quickcheck-dep
             --target ${{ matrix.target.triple }}
         if: matrix.target.std == true
 
@@ -187,8 +187,8 @@ jobs:
             check
             --feature-powerset
             --optional-deps
-            --group-features serde,rand
-            --exclude-features default,libc,winapi,time-macros
+            --group-features serde,rand,quickcheck
+            --exclude-features default,libc,winapi,time-macros,quickcheck-dep
 
       - name: Test (--all-features)
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,12 @@ rustdoc-args = ["--cfg", "__time_02_docs"]
 default = ["std"]
 macros = ["time-macros"]
 local-offset = ["std", "libc", "winapi"]
+quickcheck = ["quickcheck-dep", "rand", "std"]
 std = ["standback/std"]
 
 [dependencies]
 const_fn = "0.4.2"
+quickcheck-dep = { package = "quickcheck", version = "0.9", optional = true }
 rand = { version = "0.7", optional = true, default-features = false }
 serde = { version = "1", optional = true, default-features = false, features = ["derive"] }
 standback = { version = "0.2.5", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,10 @@
 //!
 //!   Enables [rand](https://docs.rs/rand) support for all types.
 //!
+//! - `quickcheck` (_implicitly enables `rand`_)
+//!
+//!   Enables [quickcheck](https://docs.rs/quickcheck) support for all types except [`Instant`].
+//!
 //! # Formatting
 //!
 //! Time's formatting behavior is based on `strftime` in C, though it is
@@ -247,6 +251,8 @@ mod instant;
 mod offset_date_time;
 /// The `PrimitiveDateTime` struct and its associated `impl`s.
 mod primitive_date_time;
+#[cfg(feature = "quickcheck")]
+mod quickcheck;
 #[cfg(feature = "rand")]
 mod rand;
 #[cfg(feature = "serde")]

--- a/src/quickcheck.rs
+++ b/src/quickcheck.rs
@@ -36,3 +36,46 @@
 //! An implementation for `Instant` is intentionally omitted since its values
 //! are only meaningful in relation to a [`Duration`], and obtaining an
 //! `Instant` from a [`Duration`] is very simple anyway.
+
+use crate::{
+    date::{MAX_YEAR, MIN_YEAR},
+    util::days_in_year,
+    Date,
+};
+use core::{cmp, convert::TryInto};
+use quickcheck_dep::{Arbitrary, Gen};
+use rand::Rng;
+#[allow(unused_imports)]
+use standback::prelude::*; // assoc_int_consts (1.43)
+
+impl Arbitrary for Date {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        let year_size = g.size().try_into().unwrap_or(i32::MAX);
+        let year = if year_size == 0 {
+            0
+        } else {
+            g.gen_range(
+                cmp::max(MIN_YEAR, -year_size),
+                cmp::min(MAX_YEAR, year_size),
+            )
+        };
+
+        let ordinal_size = cmp::min(g.size().try_into().unwrap_or(u16::MAX), days_in_year(year));
+        let ordinal = g.gen_range(1, cmp::max(2, ordinal_size + 1));
+
+        Self::from_yo_unchecked(year, ordinal)
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        let (year, ordinal) = self.as_yo();
+
+        let shrunk_year = year
+            .shrink()
+            .flat_map(move |year| Self::from_yo(year, ordinal));
+        let shrunk_ordinal = ordinal
+            .shrink()
+            .flat_map(move |ordinal| Self::from_yo(year, ordinal));
+
+        Box::new(shrunk_year.chain(shrunk_ordinal))
+    }
+}

--- a/src/quickcheck.rs
+++ b/src/quickcheck.rs
@@ -40,9 +40,9 @@
 use crate::{
     date::{MAX_YEAR, MIN_YEAR},
     util::days_in_year,
-    Date, Duration, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset,
+    Date, Duration, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset, Weekday,
 };
-use core::{cmp, convert::TryInto};
+use core::{cmp, convert::TryInto, iter};
 use quickcheck_dep::{Arbitrary, Gen};
 use rand::Rng;
 #[allow(unused_imports)]
@@ -228,5 +228,27 @@ impl Arbitrary for OffsetDateTime {
             .map(move |offset| datetime.assume_offset(offset));
 
         Box::new(shrunk_datetime.chain(shrunk_offset))
+    }
+}
+
+impl Arbitrary for Weekday {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        use Weekday::*;
+        match g.gen_range(0, g.size().clamp(1, 7)) {
+            0 => Monday,
+            1 => Tuesday,
+            2 => Wednesday,
+            3 => Thursday,
+            4 => Friday,
+            5 => Saturday,
+            _ => Sunday,
+        }
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        match self {
+            Weekday::Monday => Box::new(iter::empty()),
+            _ => Box::new(iter::once(self.previous())),
+        }
     }
 }

--- a/src/quickcheck.rs
+++ b/src/quickcheck.rs
@@ -1,0 +1,38 @@
+//! Implementations of the [`quickcheck::Arbitrary`] trait.
+//!
+//! This enables users to write tests such as this, and have test values
+//! provided automatically:
+//!
+//! ```
+//! # #![allow(dead_code)]
+//! # use quickcheck_dep::quickcheck;
+//! # #[cfg(pretend_we_didnt_rename_the_dependency)]
+//! use quickcheck::quickcheck;
+//! use time::Date;
+//!
+//! struct DateRange {
+//!     from: Date,
+//!     to: Date,
+//! }
+//!
+//! impl DateRange {
+//!     fn new(from: Date, to: Date) -> Result<Self, ()> {
+//!         Ok(DateRange { from, to })
+//!     }
+//! }
+//!
+//! quickcheck! {
+//!     fn date_range_is_well_defined(from: Date, to: Date) -> bool {
+//!         let r = DateRange::new(from, to);
+//!         if from <= to {
+//!             r.is_ok()
+//!         } else {
+//!             r.is_err()
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! An implementation for `Instant` is intentionally omitted since its values
+//! are only meaningful in relation to a [`Duration`], and obtaining an
+//! `Instant` from a [`Duration`] is very simple anyway.

--- a/src/quickcheck.rs
+++ b/src/quickcheck.rs
@@ -40,7 +40,7 @@
 use crate::{
     date::{MAX_YEAR, MIN_YEAR},
     util::days_in_year,
-    Date, Duration, Time,
+    Date, Duration, PrimitiveDateTime, Time,
 };
 use core::{cmp, convert::TryInto};
 use quickcheck_dep::{Arbitrary, Gen};
@@ -174,5 +174,21 @@ impl Arbitrary for Time {
                 .chain(shrunk_second)
                 .chain(shrunk_nanos),
         )
+    }
+}
+
+impl Arbitrary for PrimitiveDateTime {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        Self::new(Date::arbitrary(g), Time::arbitrary(g))
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        let date = self.date;
+        let time = self.time;
+
+        let shrunk_date = date.shrink().map(move |date| Self::new(date, time));
+        let shrunk_time = time.shrink().map(move |time| Self::new(date, time));
+
+        Box::new(shrunk_date.chain(shrunk_time))
     }
 }

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -3,7 +3,7 @@
 use quickcheck_dep::{quickcheck, Arbitrary, QuickCheck, StdGen, TestResult};
 use rand::{rngs::StdRng, SeedableRng};
 use std::convert::TryFrom;
-use time::Date;
+use time::{Date, Duration};
 
 /// Returns a statically seeded generator to ensure tests are deterministic
 fn make_generator(size: usize) -> StdGen<StdRng> {
@@ -106,4 +106,27 @@ fn arbitrary_date_respects_generator_size() {
     test_generator_size!(Date, ordinal(), 10);
     test_generator_size!(Date, ordinal(), 100);
     test_generator_size!(Date, ordinal(), 366);
+}
+
+quickcheck! {
+    fn duration_supports_arbitrary(d: Duration) -> bool {
+        Duration::new(d.whole_seconds(), d.subsec_nanoseconds()) == d
+    }
+}
+test_shrink!(Duration, duration_can_shrink_seconds, whole_seconds().abs());
+test_shrink!(Duration, duration_can_shrink_ns, subsec_nanoseconds().abs());
+
+#[test]
+fn arbitrary_duration_respects_generator_size() {
+    test_generator_size!(Duration, whole_seconds().abs(), 0);
+    test_generator_size!(Duration, whole_seconds().abs(), 1);
+    test_generator_size!(Duration, whole_seconds().abs(), 1000);
+    test_generator_size!(Duration, whole_seconds().abs(), 1_000_000);
+    test_generator_size!(Duration, whole_seconds().abs(), 1_000_000_000);
+
+    test_generator_size!(Duration, subsec_nanoseconds().abs(), 0);
+    test_generator_size!(Duration, subsec_nanoseconds().abs(), 1);
+    test_generator_size!(Duration, subsec_nanoseconds().abs(), 1000);
+    test_generator_size!(Duration, subsec_nanoseconds().abs(), 1_000_000);
+    test_generator_size!(Duration, subsec_nanoseconds().abs(), 1_000_000_000);
 }

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1,0 +1,1 @@
+#![cfg(feature = "quickcheck")]

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1,1 +1,109 @@
 #![cfg(feature = "quickcheck")]
+
+use quickcheck_dep::{quickcheck, Arbitrary, QuickCheck, StdGen, TestResult};
+use rand::{rngs::StdRng, SeedableRng};
+use std::convert::TryFrom;
+use time::Date;
+
+/// Returns a statically seeded generator to ensure tests are deterministic
+fn make_generator(size: usize) -> StdGen<StdRng> {
+    StdGen::new(StdRng::from_seed([0; 32]), size)
+}
+
+macro_rules! test_generator_size {
+    ($type:ty,
+     $($($method:ident()).+ $(min=$min_value:literal)?),+,
+     $size:literal
+    ) => {{
+        let mut q = QuickCheck::with_gen(make_generator($size));
+        let mut g = make_generator($size);
+
+        $(
+            // Check that size sets upper bound.
+            // We check that the generated value is bounded by the requested
+            // size. If $min_value is present, then that is also an accepted
+            // value even if numerically greater than the size.
+            q.quickcheck((|v: $type| {
+                let value = v.$($method()).+;
+                value <= $size $(|| value == $min_value)?
+            }) as fn($type) -> bool);
+
+            // Check that full range is used
+            let mut found_small_value = false;
+            let mut found_large_value = false;
+            let mut iterations = 0;
+
+            while !(found_small_value && found_large_value) && iterations <= $size * 2 {
+                iterations += 1;
+
+                let v = <$type>::arbitrary(&mut g);
+                let value = v$(.$method())+;
+                if value <= $size / 4 $(|| value == $min_value)? {
+                    found_small_value = true;
+                }
+                if value >= $size / 2 {
+                    found_large_value = true;
+                }
+            }
+
+            assert!(
+                found_small_value,
+                "Found no small value for {} {} at size {}",
+                stringify!($type),
+                stringify!($(.$method())+),
+                stringify!($size),
+            );
+            assert!(
+                found_large_value,
+                "Found no large value for {} {} at size {}",
+                stringify!($type),
+                stringify!($(.$method())+),
+                stringify!($size),
+            );
+        )+
+    }};
+}
+
+macro_rules! test_shrink {
+    ($type:ty,
+     $fn_name:ident,
+     $($method:ident()).+
+     $(, min=$min_value:literal)?
+    ) => {
+        quickcheck! {
+            fn $fn_name(v: $type) -> TestResult {
+                let method_value = v.$($method()).+;
+                if method_value == 0 $(|| method_value == $min_value)? {
+                    TestResult::discard()
+                } else {
+                    TestResult::from_bool(
+                        v.shrink()
+                            .any(|shrunk|
+                                 shrunk.$($method()).+ < v.$($method()).+))
+                }
+            }
+        }
+    };
+}
+
+quickcheck! {
+    fn date_supports_arbitrary(d: Date) -> bool {
+        Date::from_ymd(d.year(), d.month(), d.day()) == Ok(d)
+    }
+}
+test_shrink!(Date, date_can_shrink_year, year().abs());
+test_shrink!(Date, date_can_shrink_ordinal, ordinal(), min = 1);
+
+#[test]
+fn arbitrary_date_respects_generator_size() {
+    test_generator_size!(Date, year().abs(), 0);
+    test_generator_size!(Date, year().abs(), 1);
+    test_generator_size!(Date, year().abs(), 100);
+    test_generator_size!(Date, year().abs(), 10_000);
+    test_generator_size!(Date, year().abs(), 100_000);
+
+    test_generator_size!(Date, ordinal() min=1, 1);
+    test_generator_size!(Date, ordinal(), 10);
+    test_generator_size!(Date, ordinal(), 100);
+    test_generator_size!(Date, ordinal(), 366);
+}

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -3,7 +3,7 @@
 use quickcheck_dep::{quickcheck, Arbitrary, QuickCheck, StdGen, TestResult};
 use rand::{rngs::StdRng, SeedableRng};
 use std::convert::TryFrom;
-use time::{Date, Duration, Time, UtcOffset};
+use time::{Date, Duration, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
 
 /// Returns a statically seeded generator to ensure tests are deterministic
 fn make_generator(size: usize) -> StdGen<StdRng> {
@@ -231,4 +231,63 @@ fn arbitrary_utc_offset_respects_generator_size() {
     test_generator_size!(UtcOffset, as_seconds().abs(), 1);
     test_generator_size!(UtcOffset, as_seconds().abs(), 1_000);
     test_generator_size!(UtcOffset, as_seconds().abs(), 100_000);
+}
+
+quickcheck! {
+    fn offset_date_time_supports_arbitrary(a: OffsetDateTime) -> bool {
+        PrimitiveDateTime::new(a.date(), a.time()).assume_offset(a.offset()) == a
+    }
+}
+test_shrink!(
+    OffsetDateTime,
+    offset_date_time_can_shrink_offset,
+    offset().as_seconds().abs()
+);
+test_shrink!(
+    OffsetDateTime,
+    offset_date_time_can_shrink_year,
+    year().abs()
+);
+test_shrink!(
+    OffsetDateTime,
+    offset_date_time_can_shrink_ordinal,
+    ordinal(),
+    min = 1
+);
+test_shrink!(OffsetDateTime, offset_date_time_can_shrink_hour, hour());
+test_shrink!(OffsetDateTime, offset_date_time_can_shrink_minute, minute());
+test_shrink!(OffsetDateTime, offset_date_time_can_shrink_second, second());
+test_shrink!(
+    OffsetDateTime,
+    offset_date_time_can_shrink_nanosecond,
+    nanosecond()
+);
+
+#[test]
+fn arbitrary_offset_date_time_respects_generator_size() {
+    test_generator_size!(OffsetDateTime, year().abs(), 0);
+    test_generator_size!(OffsetDateTime, year().abs(), 1);
+    test_generator_size!(OffsetDateTime, year().abs(), 100);
+    test_generator_size!(OffsetDateTime, year().abs(), 10_000);
+    test_generator_size!(OffsetDateTime, year().abs(), 100_000);
+
+    test_generator_size!(OffsetDateTime, ordinal() min=1, 0);
+    test_generator_size!(OffsetDateTime, ordinal() min=1, 1);
+    test_generator_size!(OffsetDateTime, ordinal() min=1, 10);
+    test_generator_size!(OffsetDateTime, ordinal() min=1, 100);
+    test_generator_size!(OffsetDateTime, ordinal() min=1, 366);
+
+    test_generator_size!(OffsetDateTime, second(), minute(), hour(), 0);
+    test_generator_size!(OffsetDateTime, second(), minute(), hour(), 1);
+    test_generator_size!(OffsetDateTime, second(), minute(), hour(), 10);
+    test_generator_size!(OffsetDateTime, second(), minute(), 100);
+    test_generator_size!(OffsetDateTime, nanosecond(), 1);
+    test_generator_size!(OffsetDateTime, nanosecond(), 1000);
+    test_generator_size!(OffsetDateTime, nanosecond(), 1_000_000);
+    test_generator_size!(OffsetDateTime, nanosecond(), 1_000_000_000);
+
+    test_generator_size!(OffsetDateTime, offset().as_seconds().abs(), 0);
+    test_generator_size!(OffsetDateTime, offset().as_seconds().abs(), 1);
+    test_generator_size!(OffsetDateTime, offset().as_seconds().abs(), 1000);
+    test_generator_size!(OffsetDateTime, offset().as_seconds().abs(), 100_000);
 }

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -3,7 +3,7 @@
 use quickcheck_dep::{quickcheck, Arbitrary, QuickCheck, StdGen, TestResult};
 use rand::{rngs::StdRng, SeedableRng};
 use std::convert::TryFrom;
-use time::{Date, Duration};
+use time::{Date, Duration, Time};
 
 /// Returns a statically seeded generator to ensure tests are deterministic
 fn make_generator(size: usize) -> StdGen<StdRng> {
@@ -129,4 +129,25 @@ fn arbitrary_duration_respects_generator_size() {
     test_generator_size!(Duration, subsec_nanoseconds().abs(), 1000);
     test_generator_size!(Duration, subsec_nanoseconds().abs(), 1_000_000);
     test_generator_size!(Duration, subsec_nanoseconds().abs(), 1_000_000_000);
+}
+
+quickcheck! {
+    fn time_supports_arbitrary(t: Time) -> bool {
+        Time::from_hms_nano(t.hour(), t.minute(), t.second(), t.nanosecond()) == Ok(t)
+    }
+}
+test_shrink!(Time, time_can_shrink_hour, hour());
+test_shrink!(Time, time_can_shrink_minute, minute());
+test_shrink!(Time, time_can_shrink_second, second());
+test_shrink!(Time, time_can_shrink_nanosecond, nanosecond());
+
+#[test]
+fn arbitrary_time_respects_generator_size() {
+    test_generator_size!(Time, nanosecond(), second(), minute(), hour(), 0);
+    test_generator_size!(Time, nanosecond(), second(), minute(), hour(), 1);
+    test_generator_size!(Time, nanosecond(), second(), minute(), hour(), 10);
+    test_generator_size!(Time, nanosecond(), second(), minute(), 100);
+    test_generator_size!(Time, nanosecond(), 1000);
+    test_generator_size!(Time, nanosecond(), 1_000_000);
+    test_generator_size!(Time, nanosecond(), 1_000_000_000);
 }

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -151,3 +151,64 @@ fn arbitrary_time_respects_generator_size() {
     test_generator_size!(Time, nanosecond(), 1_000_000);
     test_generator_size!(Time, nanosecond(), 1_000_000_000);
 }
+
+quickcheck! {
+    fn primitive_date_time_supports_arbitrary(a: PrimitiveDateTime) -> bool {
+        PrimitiveDateTime::new(a.date(), a.time()) == a
+    }
+}
+test_shrink!(
+    PrimitiveDateTime,
+    primitive_date_time_can_shrink_year,
+    year().abs()
+);
+test_shrink!(
+    PrimitiveDateTime,
+    primitive_date_time_can_shrink_ordinal,
+    ordinal(),
+    min = 1
+);
+test_shrink!(
+    PrimitiveDateTime,
+    primitive_date_time_can_shrink_hour,
+    hour()
+);
+test_shrink!(
+    PrimitiveDateTime,
+    primitive_date_time_can_shrink_minute,
+    minute()
+);
+test_shrink!(
+    PrimitiveDateTime,
+    primitive_date_time_can_shrink_second,
+    second()
+);
+test_shrink!(
+    PrimitiveDateTime,
+    primitive_date_time_can_shrink_nanosecond,
+    nanosecond()
+);
+
+#[test]
+fn arbitrary_primitive_date_time_respects_generator_size() {
+    test_generator_size!(PrimitiveDateTime, year().abs(), 0);
+    test_generator_size!(PrimitiveDateTime, year().abs(), 1);
+    test_generator_size!(PrimitiveDateTime, year().abs(), 100);
+    test_generator_size!(PrimitiveDateTime, year().abs(), 10_000);
+    test_generator_size!(PrimitiveDateTime, year().abs(), 100_000);
+
+    test_generator_size!(PrimitiveDateTime, ordinal() min=1, 0);
+    test_generator_size!(PrimitiveDateTime, ordinal() min=1, 1);
+    test_generator_size!(PrimitiveDateTime, ordinal() min=1, 10);
+    test_generator_size!(PrimitiveDateTime, ordinal() min=1, 100);
+    test_generator_size!(PrimitiveDateTime, ordinal() min=1, 366);
+
+    test_generator_size!(PrimitiveDateTime, second(), minute(), hour(), 0);
+    test_generator_size!(PrimitiveDateTime, second(), minute(), hour(), 1);
+    test_generator_size!(PrimitiveDateTime, second(), minute(), hour(), 10);
+    test_generator_size!(PrimitiveDateTime, second(), minute(), 100);
+    test_generator_size!(PrimitiveDateTime, nanosecond(), 1);
+    test_generator_size!(PrimitiveDateTime, nanosecond(), 1000);
+    test_generator_size!(PrimitiveDateTime, nanosecond(), 1_000_000);
+    test_generator_size!(PrimitiveDateTime, nanosecond(), 1_000_000_000);
+}

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -3,7 +3,7 @@
 use quickcheck_dep::{quickcheck, Arbitrary, QuickCheck, StdGen, TestResult};
 use rand::{rngs::StdRng, SeedableRng};
 use std::convert::TryFrom;
-use time::{Date, Duration, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
+use time::{Date, Duration, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset, Weekday};
 
 /// Returns a statically seeded generator to ensure tests are deterministic
 fn make_generator(size: usize) -> StdGen<StdRng> {
@@ -290,4 +290,29 @@ fn arbitrary_offset_date_time_respects_generator_size() {
     test_generator_size!(OffsetDateTime, offset().as_seconds().abs(), 1);
     test_generator_size!(OffsetDateTime, offset().as_seconds().abs(), 1000);
     test_generator_size!(OffsetDateTime, offset().as_seconds().abs(), 100_000);
+}
+
+quickcheck! {
+    fn weekday_supports_arbitrary(w: Weekday) -> bool {
+        w.iso_weekday_number() >= 1 && w.iso_weekday_number() <= 7
+    }
+
+    fn weekday_can_shrink(w: Weekday) -> bool {
+        match w {
+            Weekday::Monday => w.shrink().next() == None,
+            _ => w.shrink().next() == Some(w.previous())
+        }
+    }
+}
+
+#[test]
+fn arbitrary_weekday_respects_generator_size() {
+    test_generator_size!(Weekday, iso_weekday_number() min=1, 0);
+    test_generator_size!(Weekday, iso_weekday_number() min=1, 1);
+    test_generator_size!(Weekday, iso_weekday_number() min=1, 2);
+    test_generator_size!(Weekday, iso_weekday_number() min=1, 3);
+    test_generator_size!(Weekday, iso_weekday_number() min=1, 4);
+    test_generator_size!(Weekday, iso_weekday_number() min=1, 5);
+    test_generator_size!(Weekday, iso_weekday_number() min=1, 6);
+    test_generator_size!(Weekday, iso_weekday_number() min=1, 7);
 }


### PR DESCRIPTION
Alright, here's a go at #286. This adds a `quickcheck-gen` feature (it can't be just `quickcheck` because it also needs to enable `rand` - unless you require the user to also enable `rand` explicitly) and a subcrate `time-quickcheck-tests` that tests that feature.

I've intentionally left `Instant` out since it seems like values of that type aren't intrinsically meaningful on their own. It also seems quite easy to obtain an `Instant` from a `Duration` if needed, and that type does get an `Arbitrary` implementation.