### PR TITLE
Add more cross-links throughout documentation

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -594,9 +594,9 @@ impl Date {
     }
 }
 
-/// Methods to add a `Time` component, resulting in a `PrimitiveDateTime`.
+/// Methods to add a [`Time`] component, resulting in a [`PrimitiveDateTime`].
 impl Date {
-    /// Create a `PrimitiveDateTime` using the existing date. The `Time` component will
+    /// Create a [`PrimitiveDateTime`] using the existing date. The [`Time`] component will
     /// be set to midnight.
     ///
     /// ```rust
@@ -607,7 +607,7 @@ impl Date {
         PrimitiveDateTime::new(self, Time::midnight())
     }
 
-    /// Create a `PrimitiveDateTime` using the existing date and the provided `Time`.
+    /// Create a [`PrimitiveDateTime`] using the existing date and the provided [`Time`].
     ///
     /// ```rust
     /// # use time_macros::{date, datetime, time};
@@ -620,7 +620,7 @@ impl Date {
         PrimitiveDateTime::new(self, time)
     }
 
-    /// Attempt to create a `PrimitiveDateTime` using the existing date and the
+    /// Attempt to create a [`PrimitiveDateTime`] using the existing date and the
     /// provided time.
     ///
     /// ```rust
@@ -643,7 +643,7 @@ impl Date {
         ))
     }
 
-    /// Attempt to create a `PrimitiveDateTime` using the existing date and the provided time.
+    /// Attempt to create a [`PrimitiveDateTime`] using the existing date and the provided time.
     ///
     /// ```rust
     /// # use time_macros::date;
@@ -666,7 +666,7 @@ impl Date {
         ))
     }
 
-    /// Attempt to create a `PrimitiveDateTime` using the existing date and the
+    /// Attempt to create a [`PrimitiveDateTime`] using the existing date and the
     /// provided time.
     ///
     /// ```rust
@@ -690,7 +690,7 @@ impl Date {
         ))
     }
 
-    /// Attempt to create a `PrimitiveDateTime` using the existing date and the provided time.
+    /// Attempt to create a [`PrimitiveDateTime`] using the existing date and the provided time.
     ///
     /// ```rust
     /// # use time_macros::date;

--- a/src/date.rs
+++ b/src/date.rs
@@ -596,8 +596,8 @@ impl Date {
 
 /// Methods to add a [`Time`] component, resulting in a [`PrimitiveDateTime`].
 impl Date {
-    /// Create a [`PrimitiveDateTime`] using the existing date. The [`Time`] component will
-    /// be set to midnight.
+    /// Create a [`PrimitiveDateTime`] using the existing date. The [`Time`]
+    /// component will be set to midnight.
     ///
     /// ```rust
     /// # use time_macros::{date, datetime};
@@ -607,7 +607,8 @@ impl Date {
         PrimitiveDateTime::new(self, Time::midnight())
     }
 
-    /// Create a [`PrimitiveDateTime`] using the existing date and the provided [`Time`].
+    /// Create a [`PrimitiveDateTime`] using the existing date and the provided
+    /// [`Time`].
     ///
     /// ```rust
     /// # use time_macros::{date, datetime, time};
@@ -620,8 +621,8 @@ impl Date {
         PrimitiveDateTime::new(self, time)
     }
 
-    /// Attempt to create a [`PrimitiveDateTime`] using the existing date and the
-    /// provided time.
+    /// Attempt to create a [`PrimitiveDateTime`] using the existing date and
+    /// the provided time.
     ///
     /// ```rust
     /// # use time_macros::date;
@@ -643,7 +644,8 @@ impl Date {
         ))
     }
 
-    /// Attempt to create a [`PrimitiveDateTime`] using the existing date and the provided time.
+    /// Attempt to create a [`PrimitiveDateTime`] using the existing date and
+    /// the provided time.
     ///
     /// ```rust
     /// # use time_macros::date;
@@ -666,8 +668,8 @@ impl Date {
         ))
     }
 
-    /// Attempt to create a [`PrimitiveDateTime`] using the existing date and the
-    /// provided time.
+    /// Attempt to create a [`PrimitiveDateTime`] using the existing date and
+    /// the provided time.
     ///
     /// ```rust
     /// # use time_macros::date;
@@ -690,7 +692,8 @@ impl Date {
         ))
     }
 
-    /// Attempt to create a [`PrimitiveDateTime`] using the existing date and the provided time.
+    /// Attempt to create a [`PrimitiveDateTime`] using the existing date and
+    /// the provided time.
     ///
     /// ```rust
     /// # use time_macros::date;

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -3,7 +3,7 @@
 use crate::Duration;
 use core::time::Duration as StdDuration;
 
-/// Create `Duration`s from primitive and core numeric types.
+/// Create [`Duration`]s from primitive and core numeric types.
 ///
 /// This trait can be imported with `use time::prelude::*`.
 ///
@@ -12,7 +12,7 @@ use core::time::Duration as StdDuration;
 ///
 /// # Examples
 ///
-/// Basic construction of `Duration`s.
+/// Basic construction of [`Duration`]s.
 ///
 /// ```rust
 /// # use time::{Duration, ext::NumericalDuration};
@@ -40,7 +40,7 @@ use core::time::Duration as StdDuration;
 /// assert_eq!((-5).weeks(), Duration::weeks(-5));
 /// ```
 ///
-/// Just like any other `Duration`, they can be added, subtracted, etc.
+/// Just like any other [`Duration`], they can be added, subtracted, etc.
 ///
 /// ```rust
 /// # use time::ext::NumericalDuration;
@@ -52,21 +52,21 @@ use core::time::Duration as StdDuration;
 /// value will be truncated. Keep in mind that floating point numbers are
 /// inherently imprecise and have limited capacity.
 pub trait NumericalDuration {
-    /// Create a `Duration` from the number of nanoseconds.
+    /// Create a [`Duration`] from the number of nanoseconds.
     fn nanoseconds(self) -> Duration;
-    /// Create a `Duration` from the number of microseconds.
+    /// Create a [`Duration`] from the number of microseconds.
     fn microseconds(self) -> Duration;
-    /// Create a `Duration` from the number of milliseconds.
+    /// Create a [`Duration`] from the number of milliseconds.
     fn milliseconds(self) -> Duration;
-    /// Create a `Duration` from the number of seconds.
+    /// Create a [`Duration`] from the number of seconds.
     fn seconds(self) -> Duration;
-    /// Create a `Duration` from the number of minutes.
+    /// Create a [`Duration`] from the number of minutes.
     fn minutes(self) -> Duration;
-    /// Create a `Duration` from the number of hours.
+    /// Create a [`Duration`] from the number of hours.
     fn hours(self) -> Duration;
-    /// Create a `Duration` from the number of days.
+    /// Create a [`Duration`] from the number of days.
     fn days(self) -> Duration;
-    /// Create a `Duration` from the number of weeks.
+    /// Create a [`Duration`] from the number of weeks.
     fn weeks(self) -> Duration;
 }
 
@@ -205,7 +205,7 @@ impl_numerical_duration_nonzero![
 ];
 impl_numerical_duration_float![f32, f64];
 
-/// Create `std::time::Duration`s from primitive and core numeric types.
+/// Create [`std::time::Duration`]s from primitive and core numeric types.
 ///
 /// This trait can be imported (alongside others) with `use time::prelude::*`.
 ///
@@ -214,7 +214,7 @@ impl_numerical_duration_float![f32, f64];
 ///
 /// # Examples
 ///
-/// Basic construction of `std::time::Duration`s.
+/// Basic construction of [`std::time::Duration`]s.
 ///
 /// ```rust
 /// # use time::ext::NumericalStdDuration;
@@ -229,7 +229,7 @@ impl_numerical_duration_float![f32, f64];
 /// assert_eq!(5.std_weeks(), Duration::from_secs(5 * 604_800));
 /// ```
 ///
-/// Just like any other `std::time::Duration`, they can be added, subtracted,
+/// Just like any other [`std::time::Duration`], they can be added, subtracted,
 /// etc.
 ///
 /// ```rust
@@ -248,21 +248,21 @@ impl_numerical_duration_float![f32, f64];
 /// value will be truncated. Keep in mind that floating point numbers are
 /// inherently imprecise and have limited capacity.
 pub trait NumericalStdDuration {
-    /// Create a `std::time::Duration` from the number of nanoseconds.
+    /// Create a [`std::time::Duration`] from the number of nanoseconds.
     fn std_nanoseconds(self) -> StdDuration;
-    /// Create a `std::time::Duration` from the number of microseconds.
+    /// Create a [`std::time::Duration`] from the number of microseconds.
     fn std_microseconds(self) -> StdDuration;
-    /// Create a `std::time::Duration` from the number of milliseconds.
+    /// Create a [`std::time::Duration`] from the number of milliseconds.
     fn std_milliseconds(self) -> StdDuration;
-    /// Create a `std::time::Duration` from the number of seconds.
+    /// Create a [`std::time::Duration`] from the number of seconds.
     fn std_seconds(self) -> StdDuration;
-    /// Create a `std::time::Duration` from the number of minutes.
+    /// Create a [`std::time::Duration`] from the number of minutes.
     fn std_minutes(self) -> StdDuration;
-    /// Create a `std::time::Duration` from the number of hours.
+    /// Create a [`std::time::Duration`] from the number of hours.
     fn std_hours(self) -> StdDuration;
-    /// Create a `std::time::Duration` from the number of days.
+    /// Create a [`std::time::Duration`] from the number of days.
     fn std_days(self) -> StdDuration;
-    /// Create a `std::time::Duration` from the number of weeks.
+    /// Create a [`std::time::Duration`] from the number of weeks.
     fn std_weeks(self) -> StdDuration;
 }
 
@@ -442,8 +442,8 @@ impl NumericalStdDuration for f64 {
     }
 }
 
-/// Create `std::time::Duration`s from primitive and core numeric types. Unless
-/// you are always expecting a `std::time::Duration`, you should prefer to use
+/// Create [`std::time::Duration`]s from primitive and core numeric types. Unless
+/// you are always expecting a [`std::time::Duration`], you should prefer to use
 /// [`NumericalStdDuration`] for clarity.
 ///
 /// Due to limitations in rustc, these methods are currently _not_ `const fn`.
@@ -451,7 +451,7 @@ impl NumericalStdDuration for f64 {
 ///
 /// # Examples
 ///
-/// Basic construction of `std::time::Duration`s.
+/// Basic construction of [`std::time::Duration`]s.
 ///
 /// ```rust
 /// # use time::ext::NumericalStdDurationShort;
@@ -466,7 +466,7 @@ impl NumericalStdDuration for f64 {
 /// assert_eq!(5.weeks(), Duration::from_secs(5 * 604_800));
 /// ```
 ///
-/// Just like any other `std::time::Duration`, they can be added, subtracted,
+/// Just like any other [`std::time::Duration`], they can be added, subtracted,
 /// etc.
 ///
 /// ```rust
@@ -479,21 +479,21 @@ impl NumericalStdDuration for f64 {
 /// value will be truncated. Keep in mind that floating point numbers are
 /// inherently imprecise and have limited capacity.
 pub trait NumericalStdDurationShort {
-    /// Create a `std::time::Duration` from the number of nanoseconds.
+    /// Create a [`std::time::Duration`] from the number of nanoseconds.
     fn nanoseconds(self) -> StdDuration;
-    /// Create a `std::time::Duration` from the number of microseconds.
+    /// Create a [`std::time::Duration`] from the number of microseconds.
     fn microseconds(self) -> StdDuration;
-    /// Create a `std::time::Duration` from the number of milliseconds.
+    /// Create a [`std::time::Duration`] from the number of milliseconds.
     fn milliseconds(self) -> StdDuration;
-    /// Create a `std::time::Duration` from the number of seconds.
+    /// Create a [`std::time::Duration`] from the number of seconds.
     fn seconds(self) -> StdDuration;
-    /// Create a `std::time::Duration` from the number of minutes.
+    /// Create a [`std::time::Duration`] from the number of minutes.
     fn minutes(self) -> StdDuration;
-    /// Create a `std::time::Duration` from the number of hours.
+    /// Create a [`std::time::Duration`] from the number of hours.
     fn hours(self) -> StdDuration;
-    /// Create a `std::time::Duration` from the number of days.
+    /// Create a [`std::time::Duration`] from the number of days.
     fn days(self) -> StdDuration;
-    /// Create a `std::time::Duration` from the number of weeks.
+    /// Create a [`std::time::Duration`] from the number of weeks.
     fn weeks(self) -> StdDuration;
 }
 

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -442,9 +442,9 @@ impl NumericalStdDuration for f64 {
     }
 }
 
-/// Create [`std::time::Duration`]s from primitive and core numeric types. Unless
-/// you are always expecting a [`std::time::Duration`], you should prefer to use
-/// [`NumericalStdDuration`] for clarity.
+/// Create [`std::time::Duration`]s from primitive and core numeric types.
+/// Unless you are always expecting a [`std::time::Duration`], you should prefer
+/// to use [`NumericalStdDuration`] for clarity.
 ///
 /// Due to limitations in rustc, these methods are currently _not_ `const fn`.
 /// See [this RFC](https://github.com/rust-lang/rfcs/pull/2632) for details.

--- a/src/format/date.rs
+++ b/src/format/date.rs
@@ -1,4 +1,4 @@
-//! Formatting helpers for a `Date`.
+//! Formatting helpers for a [`Date`].
 
 #![allow(non_snake_case)]
 

--- a/src/format/deferred_format.rs
+++ b/src/format/deferred_format.rs
@@ -1,5 +1,5 @@
-//! The [`DeferredFormat`] struct, acting as an intermediary between a request to
-//! format and the final output.
+//! The [`DeferredFormat`] struct, acting as an intermediary between a request
+//! to format and the final output.
 
 use crate::{
     format::{format_specifier, parse_fmt_string, well_known, Format, FormatItem},

--- a/src/format/deferred_format.rs
+++ b/src/format/deferred_format.rs
@@ -1,4 +1,4 @@
-//! The `DeferredFormat` struct, acting as an intermediary between a request to
+//! The [`DeferredFormat`] struct, acting as an intermediary between a request to
 //! format and the final output.
 
 use crate::{
@@ -10,11 +10,11 @@ use core::fmt::{self, Display, Formatter};
 /// A struct containing all the necessary information to display the inner type.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct DeferredFormat<'a> {
-    /// The `Date` to use for formatting.
+    /// The [`Date`] to use for formatting.
     date: Option<Date>,
-    /// The `Time` to use for formatting.
+    /// The [`Time`] to use for formatting.
     time: Option<Time>,
-    /// The `UtcOffset` to use for formatting.
+    /// The [`UtcOffset`] to use for formatting.
     offset: Option<UtcOffset>,
     /// The list of items used to display the item.
     format: Format<'a>,
@@ -31,35 +31,35 @@ impl<'a> DeferredFormat<'a> {
         }
     }
 
-    /// Provide the `Date` component.
+    /// Provide the [`Date`] component.
     pub(crate) fn with_date(&mut self, date: Date) -> &mut Self {
         self.date = Some(date);
         self
     }
 
-    /// Provide the `Time` component.
+    /// Provide the [`Time`] component.
     pub(crate) fn with_time(&mut self, time: Time) -> &mut Self {
         self.time = Some(time);
         self
     }
 
-    /// Provide the `UtcOffset` component.
+    /// Provide the [`UtcOffset`] component.
     pub(crate) fn with_offset(&mut self, offset: UtcOffset) -> &mut Self {
         self.offset = Some(offset);
         self
     }
 
-    /// Obtain the `Date` component.
+    /// Obtain the [`Date`] component.
     pub(crate) const fn date(&self) -> Option<Date> {
         self.date
     }
 
-    /// Obtain the `Time` component.
+    /// Obtain the [`Time`] component.
     pub(crate) const fn time(&self) -> Option<Time> {
         self.time
     }
 
-    /// Obtain the `UtcOffset` component.
+    /// Obtain the [`UtcOffset`] component.
     pub(crate) const fn offset(&self) -> Option<UtcOffset> {
         self.offset
     }

--- a/src/format/format.rs
+++ b/src/format/format.rs
@@ -1,4 +1,4 @@
-//! The `Format` struct and its implementations.
+//! The [`Format`] struct and its implementations.
 
 /// Various well-known formats, along with the possibility for a custom format
 /// (provided either at compile-time or runtime).

--- a/src/format/offset.rs
+++ b/src/format/offset.rs
@@ -1,4 +1,4 @@
-//! Formatting helpers for a `UtcOffset`.
+//! Formatting helpers for a [`UtcOffset`].
 
 #![allow(non_snake_case)]
 

--- a/src/format/time.rs
+++ b/src/format/time.rs
@@ -1,4 +1,4 @@
-//! Formatting helpers for a `Time`.
+//! Formatting helpers for a [`Time`].
 
 #![allow(non_snake_case)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,30 +231,30 @@ macro_rules! const_try_opt {
     };
 }
 
-/// The `Date` struct and its associated `impl`s.
+/// The [`Date`] struct and its associated `impl`s.
 mod date;
-/// The `Duration` struct and its associated `impl`s.
+/// The [`Duration`] struct and its associated `impl`s.
 mod duration;
 /// Various error types returned by methods in the time crate.
 pub mod error;
 /// Extension traits.
 pub mod ext;
 mod format;
-/// The `Instant` struct and its associated `impl`s.
+/// The [`Instant`] struct and its associated `impl`s.
 #[cfg(feature = "std")]
 mod instant;
-/// The `OffsetDateTime` struct and its associated `impl`s.
+/// The [`OffsetDateTime`] struct and its associated `impl`s.
 mod offset_date_time;
-/// The `PrimitiveDateTime` struct and its associated `impl`s.
+/// The [`PrimitiveDateTime`] struct and its associated `impl`s.
 mod primitive_date_time;
 #[cfg(feature = "rand")]
 mod rand;
 #[cfg(feature = "serde")]
 #[allow(missing_copy_implementations, missing_debug_implementations)]
 pub mod serde;
-/// The `Time` struct and its associated `impl`s.
+/// The [`Time`] struct and its associated `impl`s.
 mod time_mod;
-/// The `UtcOffset` struct and its associated `impl`s.
+/// The [`UtcOffset`] struct and its associated `impl`s.
 mod utc_offset;
 pub mod util;
 /// Days of the week.
@@ -369,7 +369,8 @@ pub use time_mod::Time;
 pub use utc_offset::UtcOffset;
 pub use weekday::Weekday;
 
-/// An alias for `Result` with a generic error from the time crate.
+/// An alias for [`std::result::Result`] with a generic error from the time
+/// crate.
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// A collection of imports that are widely useful.

--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -35,15 +35,15 @@ use std::time::SystemTime;
 )]
 #[derive(Debug, Clone, Copy, Eq)]
 pub struct OffsetDateTime {
-    /// The `PrimitiveDateTime`, which is _always_ UTC.
+    /// The [`PrimitiveDateTime`], which is _always_ UTC.
     utc_datetime: PrimitiveDateTime,
-    /// The `UtcOffset`, which will be added to the `PrimitiveDateTime` as necessary.
+    /// The [`UtcOffset`], which will be added to the [`PrimitiveDateTime`] as necessary.
     offset: UtcOffset,
 }
 
 impl OffsetDateTime {
-    /// Create a new `OffsetDateTime` from the provided `PrimitiveDateTime` and
-    /// `UtcOffset`. The `PrimitiveDateTime` is assumed to be in the provided
+    /// Create a new `OffsetDateTime` from the provided [`PrimitiveDateTime`] and
+    /// [`UtcOffset`]. The [`PrimitiveDateTime`] is assumed to be in the provided
     /// offset.
     // TODO Should this be made public?
     pub(crate) fn new_assuming_offset(utc_datetime: PrimitiveDateTime, offset: UtcOffset) -> Self {
@@ -53,8 +53,8 @@ impl OffsetDateTime {
         }
     }
 
-    /// Create a new `OffsetDateTime` from the provided `PrimitiveDateTime` and
-    /// `UtcOffset`. The `PrimitiveDateTime` is assumed to be in UTC.
+    /// Create a new `OffsetDateTime` from the provided [`PrimitiveDateTime`] and
+    /// [`UtcOffset`]. The [`PrimitiveDateTime`] is assumed to be in UTC.
     // TODO Should this be made public?
     pub(crate) const fn new_assuming_utc(utc_datetime: PrimitiveDateTime) -> Self {
         Self {
@@ -92,8 +92,8 @@ impl OffsetDateTime {
         Ok(t.to_offset(UtcOffset::local_offset_at(t)?))
     }
 
-    /// Convert the `OffsetDateTime` from the current `UtcOffset` to the
-    /// provided `UtcOffset`.
+    /// Convert the `OffsetDateTime` from the current [`UtcOffset`] to the
+    /// provided [`UtcOffset`].
     ///
     /// ```rust
     /// # use time_macros::{datetime, offset};
@@ -239,7 +239,7 @@ impl OffsetDateTime {
         Ok(PrimitiveDateTime::new(date, time).assume_utc())
     }
 
-    /// Get the `UtcOffset`.
+    /// Get the [`UtcOffset`].
     ///
     /// ```rust
     /// # use time_macros::{datetime, offset};
@@ -275,7 +275,7 @@ impl OffsetDateTime {
         (self - Self::unix_epoch()).whole_nanoseconds()
     }
 
-    /// Get the `Date` in the stored offset.
+    /// Get the [`Date`] in the stored offset.
     ///
     /// ```rust
     /// # use time_macros::{date, datetime, offset};
@@ -291,7 +291,7 @@ impl OffsetDateTime {
         (self.utc_datetime + self.offset.as_duration()).date()
     }
 
-    /// Get the `Time` in the stored offset.
+    /// Get the [`Time`] in the stored offset.
     ///
     /// ```rust
     /// # use time_macros::{datetime, offset, time};

--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -37,14 +37,15 @@ use std::time::SystemTime;
 pub struct OffsetDateTime {
     /// The [`PrimitiveDateTime`], which is _always_ UTC.
     utc_datetime: PrimitiveDateTime,
-    /// The [`UtcOffset`], which will be added to the [`PrimitiveDateTime`] as necessary.
+    /// The [`UtcOffset`], which will be added to the [`PrimitiveDateTime`] as
+    /// necessary.
     offset: UtcOffset,
 }
 
 impl OffsetDateTime {
-    /// Create a new `OffsetDateTime` from the provided [`PrimitiveDateTime`] and
-    /// [`UtcOffset`]. The [`PrimitiveDateTime`] is assumed to be in the provided
-    /// offset.
+    /// Create a new `OffsetDateTime` from the provided [`PrimitiveDateTime`]
+    /// and [`UtcOffset`]. The [`PrimitiveDateTime`] is assumed to be in the
+    /// provided offset.
     // TODO Should this be made public?
     pub(crate) fn new_assuming_offset(utc_datetime: PrimitiveDateTime, offset: UtcOffset) -> Self {
         Self {
@@ -53,8 +54,8 @@ impl OffsetDateTime {
         }
     }
 
-    /// Create a new `OffsetDateTime` from the provided [`PrimitiveDateTime`] and
-    /// [`UtcOffset`]. The [`PrimitiveDateTime`] is assumed to be in UTC.
+    /// Create a new `OffsetDateTime` from the provided [`PrimitiveDateTime`]
+    /// and [`UtcOffset`]. The [`PrimitiveDateTime`] is assumed to be in UTC.
     // TODO Should this be made public?
     pub(crate) const fn new_assuming_utc(utc_datetime: PrimitiveDateTime) -> Self {
         Self {

--- a/src/primitive_date_time.rs
+++ b/src/primitive_date_time.rs
@@ -29,7 +29,7 @@ pub struct PrimitiveDateTime {
 }
 
 impl PrimitiveDateTime {
-    /// Create a new `PrimitiveDateTime` from the provided `Date` and `Time`.
+    /// Create a new `PrimitiveDateTime` from the provided [`Date`] and [`Time`].
     ///
     /// ```rust
     /// # use time::PrimitiveDateTime;
@@ -43,7 +43,7 @@ impl PrimitiveDateTime {
         Self { date, time }
     }
 
-    /// Get the `Date` component of the `PrimitiveDateTime`.
+    /// Get the [`Date`] component of the `PrimitiveDateTime`.
     ///
     /// ```rust
     /// # use time_macros::{date, datetime};
@@ -53,7 +53,7 @@ impl PrimitiveDateTime {
         self.date
     }
 
-    /// Get the `Time` component of the `PrimitiveDateTime`.
+    /// Get the [`Time`] component of the `PrimitiveDateTime`.
     ///
     /// ```rust
     /// # use time_macros::{datetime, time};
@@ -331,7 +331,7 @@ impl PrimitiveDateTime {
     }
 
     /// Assuming that the existing `PrimitiveDateTime` represents a moment in
-    /// the provided `UtcOffset`, return an `OffsetDateTime`.
+    /// the provided [`UtcOffset`], return an [`OffsetDateTime`].
     ///
     /// ```rust
     /// # use time_macros::{datetime, offset};
@@ -353,7 +353,7 @@ impl PrimitiveDateTime {
     }
 
     /// Assuming that the existing `PrimitiveDateTime` represents a moment in
-    /// the UTC, return an `OffsetDateTime`.
+    /// the UTC, return an [`OffsetDateTime`].
     ///
     /// ```rust
     /// # use time_macros::datetime;

--- a/src/primitive_date_time.rs
+++ b/src/primitive_date_time.rs
@@ -29,7 +29,8 @@ pub struct PrimitiveDateTime {
 }
 
 impl PrimitiveDateTime {
-    /// Create a new `PrimitiveDateTime` from the provided [`Date`] and [`Time`].
+    /// Create a new `PrimitiveDateTime` from the provided [`Date`] and
+    /// [`Time`].
     ///
     /// ```rust
     /// # use time::PrimitiveDateTime;

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -1,4 +1,4 @@
-//! Implementation of `Distribution` for various structs.
+//! Implementation of [`Distribution`] for various structs.
 
 use crate::{
     date::{MAX_YEAR, MIN_YEAR},

--- a/src/time_mod.rs
+++ b/src/time_mod.rs
@@ -299,7 +299,7 @@ impl Time {
             + self.nanosecond() as u64
     }
 
-    /// Add the sub-day time of the `Duration` to the `Time`. Wraps on overflow,
+    /// Add the sub-day time of the [`Duration`] to the `Time`. Wraps on overflow,
     /// returning the necessary adjustment to the date value as the first
     /// element of the tuple.
     pub(crate) fn adjusting_add(self, duration: Duration) -> (Duration, Time) {
@@ -467,7 +467,7 @@ impl Display for Time {
 impl Add<Duration> for Time {
     type Output = Self;
 
-    /// Add the sub-day time of the `Duration` to the `Time`. Wraps on overflow.
+    /// Add the sub-day time of the [`Duration`] to the `Time`. Wraps on overflow.
     ///
     /// ```rust
     /// # use time::prelude::*;
@@ -483,7 +483,7 @@ impl Add<Duration> for Time {
 impl Add<StdDuration> for Time {
     type Output = Self;
 
-    /// Add the sub-day time of the `std::time::Duration` to the `Time`. Wraps
+    /// Add the sub-day time of the [`std::time::Duration`] to the `Time`. Wraps
     /// on overflow.
     ///
     /// ```rust
@@ -499,7 +499,7 @@ impl Add<StdDuration> for Time {
 }
 
 impl AddAssign<Duration> for Time {
-    /// Add the sub-day time of the `Duration` to the existing `Time`. Wraps on
+    /// Add the sub-day time of the [`Duration`] to the existing `Time`. Wraps on
     /// overflow.
     ///
     /// ```rust
@@ -519,7 +519,7 @@ impl AddAssign<Duration> for Time {
 }
 
 impl AddAssign<StdDuration> for Time {
-    /// Add the sub-day time of the `std::time::Duration` to the existing
+    /// Add the sub-day time of the [`std::time::Duration`] to the existing
     /// `Time`. Wraps on overflow.
     ///
     /// ```rust
@@ -541,7 +541,7 @@ impl AddAssign<StdDuration> for Time {
 impl Sub<Duration> for Time {
     type Output = Self;
 
-    /// Subtract the sub-day time of the `Duration` from the `Time`. Wraps on
+    /// Subtract the sub-day time of the [`Duration`] from the `Time`. Wraps on
     /// overflow.
     ///
     /// ```rust
@@ -558,7 +558,7 @@ impl Sub<Duration> for Time {
 impl Sub<StdDuration> for Time {
     type Output = Self;
 
-    /// Subtract the sub-day time of the `std::time::Duration` from the `Time`.
+    /// Subtract the sub-day time of the [`std::time::Duration`] from the `Time`.
     /// Wraps on overflow.
     ///
     /// ```rust
@@ -574,7 +574,7 @@ impl Sub<StdDuration> for Time {
 }
 
 impl SubAssign<Duration> for Time {
-    /// Subtract the sub-day time of the `Duration` from the existing `Time`.
+    /// Subtract the sub-day time of the [`Duration`] from the existing `Time`.
     /// Wraps on overflow.
     ///
     /// ```rust
@@ -594,7 +594,7 @@ impl SubAssign<Duration> for Time {
 }
 
 impl SubAssign<StdDuration> for Time {
-    /// Subtract the sub-day time of the `std::time::Duration` from the existing
+    /// Subtract the sub-day time of the [`std::time::Duration`] from the existing
     /// `Time`. Wraps on overflow.
     ///
     /// ```rust
@@ -616,7 +616,7 @@ impl SubAssign<StdDuration> for Time {
 impl Sub<Time> for Time {
     type Output = Duration;
 
-    /// Subtract two `Time`s, returning the `Duration` between. This assumes
+    /// Subtract two `Time`s, returning the [`Duration`] between. This assumes
     /// both `Time`s are in the same calendar day.
     ///
     /// ```rust

--- a/src/time_mod.rs
+++ b/src/time_mod.rs
@@ -299,9 +299,9 @@ impl Time {
             + self.nanosecond() as u64
     }
 
-    /// Add the sub-day time of the [`Duration`] to the `Time`. Wraps on overflow,
-    /// returning the necessary adjustment to the date value as the first
-    /// element of the tuple.
+    /// Add the sub-day time of the [`Duration`] to the `Time`. Wraps on
+    /// overflow, returning the necessary adjustment to the date value as the
+    /// first element of the tuple.
     pub(crate) fn adjusting_add(self, duration: Duration) -> (Duration, Time) {
         let mut nanoseconds = self.nanosecond as i32 + duration.subsec_nanoseconds();
         let mut seconds = self.second as i8 + (duration.whole_seconds() % 60) as i8;
@@ -467,7 +467,8 @@ impl Display for Time {
 impl Add<Duration> for Time {
     type Output = Self;
 
-    /// Add the sub-day time of the [`Duration`] to the `Time`. Wraps on overflow.
+    /// Add the sub-day time of the [`Duration`] to the `Time`. Wraps on
+    /// overflow.
     ///
     /// ```rust
     /// # use time::prelude::*;
@@ -499,8 +500,8 @@ impl Add<StdDuration> for Time {
 }
 
 impl AddAssign<Duration> for Time {
-    /// Add the sub-day time of the [`Duration`] to the existing `Time`. Wraps on
-    /// overflow.
+    /// Add the sub-day time of the [`Duration`] to the existing `Time`. Wraps
+    /// on overflow.
     ///
     /// ```rust
     /// # use time::prelude::*;
@@ -558,7 +559,8 @@ impl Sub<Duration> for Time {
 impl Sub<StdDuration> for Time {
     type Output = Self;
 
-    /// Subtract the sub-day time of the [`std::time::Duration`] from the `Time`.
+    /// Subtract the sub-day time of the [`std::time::Duration`] from the
+    /// `Time`.
     /// Wraps on overflow.
     ///
     /// ```rust
@@ -594,8 +596,8 @@ impl SubAssign<Duration> for Time {
 }
 
 impl SubAssign<StdDuration> for Time {
-    /// Subtract the sub-day time of the [`std::time::Duration`] from the existing
-    /// `Time`. Wraps on overflow.
+    /// Subtract the sub-day time of the [`std::time::Duration`] from the
+    /// existing `Time`. Wraps on overflow.
     ///
     /// ```rust
     /// # use time::prelude::*;

--- a/src/utc_offset.rs
+++ b/src/utc_offset.rs
@@ -454,7 +454,7 @@ fn local_offset_at(datetime: OffsetDateTime) -> Option<UtcOffset> {
             ((filetime.dwHighDateTime as i64) << 32 | filetime.dwLowDateTime as i64) / FT_TO_SECS
         }
 
-        /// Convert an `OffsetDateTime` to a `SYSTEMTIME`.
+        /// Convert an [`OffsetDateTime`] to a `SYSTEMTIME`.
         fn offset_to_systemtime(datetime: OffsetDateTime) -> SYSTEMTIME {
             let (month, day_of_month) = datetime.to_offset(UtcOffset::UTC).month_day();
             SYSTEMTIME {


### PR DESCRIPTION
Hopefully the title says it all. :slightly_smiling_face: I saw that [intra-rustdoc links](https://github.com/rust-lang/rust/issues/43466) are used in [some cases](https://github.com/time-rs/time/blob/ee141a366a7cd9b293cbda42a79c0a1459e79178/src/lib.rs#L17) but [not all](https://github.com/time-rs/time/blob/ee141a366a7cd9b293cbda42a79c0a1459e79178/src/date.rs#L604), so I "upgraded" all the ones I could find where it seems appropriate. I did not add links to references to the containing type, for example in "Attempt to create a `Date` from the year, month, and day." on `Date::from_ymd`, since that seems a bit redundant. I also did not rewrap any lines as I'm not sure about the convention on that here, but I'd be happy to do so if desired.