### PR TITLE
Remove unused `syn/derive` feature

### DIFF
--- a/time-macros-impl/Cargo.toml
+++ b/time-macros-impl/Cargo.toml
@@ -12,8 +12,7 @@ description = "Procedural macros for the time crate."
 
 [dependencies]
 proc-macro2 = "1"
-# I'm not entirely sure why `derive` is necessary here, but it fails without it.
-syn = { version = "1.0.15", default-features = false, features = ["proc-macro", "parsing", "printing", "derive"] }
+syn = { version = "1.0.15", default-features = false, features = ["proc-macro", "parsing", "printing"] }
 quote = "1"
 proc-macro-hack = "0.5"
 standback = { version = "0.2", default-features = false }


### PR DESCRIPTION
It was unused. This cuts down build times from 7.9 to 7.2 seconds.
Before: https://jyn514.github.io/assets/cargo-timing-with-derive.html
After: https://jyn514.github.io/assets/cargo-timing-no-derive.html (currently having trouble with my website, but hopefully will be up soon).