### PR TITLE
Document #293 in local-offset feature description

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@
 //! - `local-offset` (_implicitly enables `std`_)
 //!
 //!   This feature enables a number of methods that allow obtaining the system's
-//!   UTC offset.
+//!   UTC offset.  The methods enabled by this feature currently always return
+//!   Err results on unix platforms.  See #293 for details.
 //!
 //! - `large-dates`
 //!


### PR DESCRIPTION
This PR adds documentation to the feature flag for local-offset indicating that the feature is useless on unix platforms, with a reference to #293.

I just spent longer than I wanted trying to figure out why `OffsetDateTime::try_local_now` was returning IndeterminateDateTime.  The path I had to take to figure it out:  

1. Go to the documentation for `OffsetDateTime::try_now_local`.  No mention of the issue.
2. Check the source for that method. No mention of the issue.
3. Go to the documentation for `UtcOffset::local_offset_at`.  No mention.
4. Find the undocumented private function `try_local_offset_at`.  Reference to #293.
5. Check github for #293.  Issue is marked resolved.  
6. Switch dependency to main.  Discover feature flag and new method names.  Error persists.
7. Repeat 1-4 with new nomenclature.  Same reference.

Hopefully a mention on the documentation for the feature flag will prevent others from having to follow that same path.



