### PR TITLE
Correct Unix timestamp implementation

### DIFF
--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -298,7 +298,13 @@ impl OffsetDateTime {
     /// );
     /// ```
     pub fn unix_timestamp(self) -> i64 {
-        (self - Self::unix_epoch()).whole_seconds()
+        let days = (self.utc_datetime.date.julian_day()
+            - internals::Date::from_yo_unchecked(1970, 1).julian_day())
+            * 86_400;
+        let hours = self.utc_datetime.hour() as i64 * 3_600;
+        let minutes = self.utc_datetime.minute() as i64 * 60;
+        let seconds = self.utc_datetime.second() as i64;
+        days + hours + minutes + seconds
     }
 
     /// Get the [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time).

--- a/src/primitive_date_time.rs
+++ b/src/primitive_date_time.rs
@@ -132,7 +132,13 @@ impl PrimitiveDateTime {
     #[allow(deprecated)]
     #[deprecated(since = "0.2.7", note = "This method assumes an offset of UTC.")]
     pub fn timestamp(self) -> i64 {
-        (self - Self::unix_epoch()).whole_seconds()
+        let days = (self.date.julian_day()
+            - internals::Date::from_yo_unchecked(1970, 1).julian_day())
+            * 86_400;
+        let hours = self.hour() as i64 * 3_600;
+        let minutes = self.minute() as i64 * 60;
+        let seconds = self.second() as i64;
+        days + hours + minutes + seconds
     }
 
     /// Get the `Date` component of the `PrimitiveDateTime`.

--- a/tests/offset_date_time.rs
+++ b/tests/offset_date_time.rs
@@ -123,6 +123,7 @@ fn timestamp() {
             .timestamp(),
         3_600,
     );
+    assert_eq!((OffsetDateTime::unix_epoch() -1.nanoseconds()).timestamp(), -1);
 }
 
 #[test]

--- a/tests/offset_date_time.rs
+++ b/tests/offset_date_time.rs
@@ -123,7 +123,10 @@ fn timestamp() {
             .timestamp(),
         3_600,
     );
-    assert_eq!((OffsetDateTime::unix_epoch() -1.nanoseconds()).timestamp(), -1);
+    assert_eq!(
+        (OffsetDateTime::unix_epoch() - 1.nanoseconds()).timestamp(),
+        -1
+    );
 }
 
 #[test]

--- a/tests/primitive_date_time.rs
+++ b/tests/primitive_date_time.rs
@@ -45,6 +45,10 @@ fn from_unix_timestamp() {
 fn timestamp() {
     assert_eq!(PrimitiveDateTime::unix_epoch().timestamp(), 0);
     assert_eq!(date!(2019 - 01 - 01).midnight().timestamp(), 1_546_300_800);
+    assert_eq!(
+        (PrimitiveDateTime::unix_epoch() - 1.nanoseconds()).timestamp(),
+        -1
+    );
 }
 
 #[test]


### PR DESCRIPTION
OffsetDateTime::unix_timestamp() in v0.2 is returning different results from v0.3 and chrono's DateTime::timestamp(), so I backported it from v0.3.

See below.

## chrono
```rust
Utc.timestamp(0, 0).timestamp(); // 0
(Utc.timestamp(0, 0) - Duration::nanoseconds(1)).timestamp(); // -1
```

## time v0.3
```rust
OffsetDateTime::unix_epoch().unix_timestamp(); // 0
(OffsetDateTime::unix_epoch() - 1.nanoseconds()).unix_timestamp(); // -1
```

## time v0.2
```rust
OffsetDateTime::unix_epoch().unix_timestamp(); // 0
(OffsetDateTime::unix_epoch() - 1.nanoseconds()).unix_timestamp(); // 0
```