### PR TITLE
Avoid compilation error with version_check 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ winapi = { version = "0.3", features = ["minwinbase", "minwindef", "timezoneapi"
 stdweb = { version = "0.4", default-features = false, optional = true }
 
 [build-dependencies]
-version_check = "0.9"
+version_check = "0.9.2"
 
 [dev-dependencies]
 rand = { version = "0.7", default-features = false }


### PR DESCRIPTION
This crate isn't actually compatible with the dependency it declares. When version_check 0.9.0 is used, it fails to compile:

```text
error[E0624]: associated function `to_mmp` is private
  --> ~/.cargo/registry/src/github.com-1ecc6299db9ec823/time-0.2.25/build.rs:30:69
   |
30 |         Some((version, channel, _)) if channel.is_dev() => (version.to_mmp().1 - 2, channel),
   |                                                                     ^^^^^^ private associated function
```
