### PR TITLE
Fix compilation error with proc-macro-hack 0.5.0

### DIFF
--- a/time-macros/Cargo.toml
+++ b/time-macros/Cargo.toml
@@ -12,4 +12,4 @@ description = "Procedural macros for the time crate."
 
 [dependencies]
 time-macros-impl = { version = "0.1", path = "../time-macros-impl" }
-proc-macro-hack = "0.5"
+proc-macro-hack = "0.5.19"


### PR DESCRIPTION
This crate isn't actually compatible with the dependency it declares. proc-macro-hack 0.5.0 doesn't compile:

```text
   --> ~/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro-hack-0.5.0/src/lib.rs:251:65
    |
251 |     proc_macro::TokenStream::from(match parse_macro_input!(input) {
    |                                                                 ^ missing tokens in macro arguments
```
