### PR TITLE
Fix incorrect version constraint in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ winapi = { version = "0.3", features = ["minwinbase", "minwindef", "timezoneapi"
 stdweb = { version = "0.4", default-features = false, optional = true }
 
 [build-dependencies]
-version_check = "0.9"
+version_check = "0.9.2"
 
 [dev-dependencies]
 rand = { version = "0.7", default-features = false }


### PR DESCRIPTION
`time` requires at least `version_check` 0.9.2 in order to use `to_mmp()`, but it says
in Cargo.toml that it can use 0.9.0. This broke docs.rs: https://github.com/rust-lang/docs.rs/pull/1295/checks?check_run_id=2007093638

This fixes the version constraint so Cargo will automatically update
version_check if necessary.