### PR TITLE
[v0.2] Fix feature detection with third-party rustc

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -26,11 +26,12 @@ fn main() {
 
     // Treat nightly & dev compilers as the equivalent of the then-beta.
     // As features are never stabilized in patch versions, we can safely ignore it.
-    let (effective_compiler_version, channel) = match rustc::triple() {
-        Some((version, channel, _)) if channel.is_dev() => (version.to_mmp().1 - 2, channel),
-        Some((version, channel, _)) if channel.is_nightly() => (version.to_mmp().1 - 1, channel),
-        Some((version, channel, _)) => (version.to_mmp().1, channel),
-        None => {
+    let rustc_info = (rustc::Version::read(), rustc::Channel::read());
+    let (effective_compiler_version, channel) = match rustc_info {
+        (Some(version), Some(channel)) if channel.is_dev() => (version.to_mmp().1 - 2, channel),
+        (Some(version), Some(channel)) if channel.is_nightly() => (version.to_mmp().1 - 1, channel),
+        (Some(version), Some(channel)) => (version.to_mmp().1, channel),
+        (None, _) | (_, None) => {
             warning!(
                 "Unable to determine rustc version. Assuming rustc 1.{}.0.",
                 MSRV


### PR DESCRIPTION
Third-party `rustc` builds, like those in Linux distributions, are built
from the source tarball without git commit info in `rustc --version`.
This makes `version_check::triple()` fail, which makes `time` unhappy:

    warning: Unable to determine rustc version. Assuming rustc 1.32.0.

The build script doesn't actually care about the commit date though, and
it works fine if you only request the version and channel separately.