### PR TITLE
Depend on version_check 0.9.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ winapi = { version = "0.3", features = ["minwinbase", "minwindef", "timezoneapi"
 stdweb = { version = "0.4", default-features = false, optional = true }
 
 [build-dependencies]
-version_check = "0.9"
+version_check = "0.9.2"
 
 [dev-dependencies]
 rand = { version = "0.7", default-features = false }


### PR DESCRIPTION
`build.rs` makes calls to the `to_mmp` function: https://github.com/time-rs/time/blob/v0.2.25/build.rs#L30-L31

However, `to_mmp` is not public until this commit: https://github.com/SergioBenitez/version_check/commit/d9bd8e4495f54b4c9763cdbf4841500f353e85da

… which wasn't released until `version_check` v0.9.2.

Since `Cargo.toml` only lists `0.9` as a dependency, any project that is pulling in a version <0.9.2 will fail to build with something like,

```
error[E0624]: associated function `to_mmp` is private
  --> …/time-0.2.25/build.rs:30:69
   |
30 |         Some((version, channel, _)) if channel.is_dev() => (version.to_mmp().1 - 2, channel),
   |                                                                     ^^^^^^ private associated function

error[E0624]: associated function `to_mmp` is private
  --> …/time-0.2.25/build.rs:31:73
   |
31 |         Some((version, channel, _)) if channel.is_nightly() => (version.to_mmp().1 - 1, channel),
   |                                                                         ^^^^^^ private associated function

error[E0624]: associated function `to_mmp` is private
  --> …/time-0.2.25/build.rs:32:49
   |
32 |         Some((version, channel, _)) => (version.to_mmp().1, channel),
   |                                                 ^^^^^^ private associated function
```

Fixes #295, #300, #303