### PR TITLE
fix documentation for %C

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
 //! | `%b`      | Abbreviated month name                                                 | `Aug`                      |
 //! | `%B`      | Full month name                                                        | `August`                   |
 //! | `%c`      | Date and time representation, equivalent to `%a %b %-d %-H:%M:%S %-Y`  | `Thu Aug 23 14:55:02 2001` |
-//! | `%C`      | Year divided by 100 and truncated to integer (`00`-`99`)               | `20`                       |
+//! | `%C`      | Year divided by 100 and truncated to integer (`00`-`999`)              | `20`                       |
 //! | `%d`      | Day of the month, zero-padded (`01`-`31`)                              | `23`                       |
 //! | `%D`      | Short MM/DD/YY date, equivalent to `%-m/%d/%y`                         | `8/23/01`                  |
 //! | `%F`      | Short YYYY-MM-DD date, equivalent to `%-Y-%m-%d`                       | `2001-08-23`               |


### PR DESCRIPTION
As stated [here](https://github.com/time-rs/time/blob/v0.2/src/format/date.rs#L138), the `%C` format specifier accepts both 2 and 3 digits.