### PR TITLE
Remove WINAPI dependency, replace with FFI calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default = ["std"]
 alloc = []
 formatting = ["itoa", "std"]
 large-dates = ["time-macros/large-dates"] # use case for weak feature dependencies (rust-lang/cargo#8832)
-local-offset = ["std", "winapi"]
+local-offset = ["std"]
 macros = ["time-macros"]
 parsing = []
 quickcheck = ["quickcheck-dep", "alloc"]
@@ -43,9 +43,6 @@ rand = { version = "0.8.3", optional = true, default-features = false }
 serde = { version = "1.0.125", optional = true, default-features = false }
 standback = { version = "0.3.2", default-features = false, features = ["msrv-1-46"] }
 time-macros = { version = "=0.2.0-alpha.0", path = "time-macros", optional = true }
-
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["minwinbase", "minwindef", "timezoneapi"], optional = true }
 
 [target.'cfg(unsound_local_offset)'.dependencies]
 libc = "0.2.93"

--- a/src/utc_offset.rs
+++ b/src/utc_offset.rs
@@ -448,12 +448,43 @@ fn local_offset_at(datetime: OffsetDateTime) -> Option<UtcOffset> {
     {
         use core::mem::MaybeUninit;
 
-        use winapi::shared::minwindef::FILETIME;
-        use winapi::um::minwinbase::SYSTEMTIME;
-        use winapi::um::timezoneapi::{SystemTimeToFileTime, SystemTimeToTzSpecificLocalTime};
+        // ffi: WINAPI FILETIME struct
+        #[repr(C)]
+        #[allow(non_snake_case)]
+        struct FileTime {
+            dwLowDateTime: u32,
+            dwHighDateTime: u32,
+        }
+
+        // ffi: WINAPI SYSTEMTIME struct
+        #[repr(C)]
+        #[allow(non_snake_case)]
+        struct SystemTime {
+            wYear: u16,
+            wMonth: u16,
+            wDayOfWeek: u16,
+            wDay: u16,
+            wHour: u16,
+            wMinute: u16,
+            wSecond: u16,
+            wMilliseconds: u16,
+        }
+
+        #[link(name = "Kernel32")]
+        extern "system" {
+            // https://docs.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-systemtimetofiletime
+            fn SystemTimeToFileTime(lpSystemTime: *const SystemTime, lpFileTime: *mut FileTime) -> i32;
+
+            // https://docs.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-systemtimetotzspecificlocaltime
+            fn SystemTimeToTzSpecificLocalTime(
+                lpTimeZoneInformation: *const std::ffi::c_void, // We only pass `nullptr` here
+                lpUniversalTime: *const SystemTime,
+                lpLocalTime: *mut SystemTime,
+            ) -> i32;
+        }
 
         /// Convert a `SYSTEMTIME` to a `FILETIME`. Returns `None` if any error occurred.
-        fn systemtime_to_filetime(systime: &SYSTEMTIME) -> Option<FILETIME> {
+        fn systemtime_to_filetime(systime: &SystemTime) -> Option<FileTime> {
             let mut ft = MaybeUninit::uninit();
 
             // Safety: `SystemTimeToFileTime` is thread-safe. We are only assuming initialization if
@@ -470,17 +501,17 @@ fn local_offset_at(datetime: OffsetDateTime) -> Option<UtcOffset> {
         }
 
         /// Convert a `FILETIME` to an `i64`, representing a number of seconds.
-        fn filetime_to_secs(filetime: &FILETIME) -> i64 {
+        fn filetime_to_secs(filetime: &FileTime) -> i64 {
             /// FILETIME represents 100-nanosecond intervals
             const FT_TO_SECS: i64 = 10_000_000;
             ((filetime.dwHighDateTime as i64) << 32 | filetime.dwLowDateTime as i64) / FT_TO_SECS
         }
 
         /// Convert an [`OffsetDateTime`] to a `SYSTEMTIME`.
-        fn offset_to_systemtime(datetime: OffsetDateTime) -> SYSTEMTIME {
+        fn offset_to_systemtime(datetime: OffsetDateTime) -> SystemTime {
             let (_, month, day_of_month) =
                 datetime.to_offset(UtcOffset::UTC).date().to_calendar_date();
-            SYSTEMTIME {
+            SystemTime {
                 wYear: datetime.year() as _,
                 wMonth: month as _,
                 wDay: day_of_month as _,


### PR DESCRIPTION
The dependency on the `winapi` crate here, which is over 10MB and has some considerable impact on build and link times, is quite unnecessary - it's only used for one function in one file, namely `UtcOffset::local_offset_at()` when the `local-offset` feature is enabled. This PR removes the crate as a dependency and replaces its usage in that function with a few lines of FFI.

The function still returns the same results, but with a significantly better build time. All tests pass.