### PR TITLE
Make `T::default` for format_description types public API, and mention the default values of the types in their docs.

### DIFF
--- a/src/format_description/modifier.rs
+++ b/src/format_description/modifier.rs
@@ -242,22 +242,40 @@ pub enum Padding {
     None,
 }
 
+macro_rules! doc_hack {
+    (pub $(#[$attr:meta])*; $($x:tt)*) => {
+        $(#[$attr])*
+        ///
+        /// This function exists since [`Default::default()`] cannot be used in a `const` context.
+        /// It may be removed once that becomes possible. As the [`Default`] trait is in the
+        /// prelude, removing this function in the future will not cause any resolution failures for
+        /// the overwhelming majority of users; only users who use `#![no_implicit_prelude]` will be
+        /// affected. As such it will not be considered a breaking change.
+        $($x)*
+    };
+
+    ($(#[$attr:meta])*; $($x:tt)*) => {
+        $(#[$attr])*
+        ///
+        /// A hack to work around the lack of const trait impls. This method is explicitly **not**
+        /// part of the stable API of the time crate and may be removed at any point.
+        #[doc(hidden)]
+        $($x)*
+    };
+}
+
 /// Implement `Default` for the given type. This also generates an inherent implementation of a
 /// `default` method that is `const fn`, permitting the default value to be used in const contexts.
 // Every modifier should use this macro rather than a derived `Default`.
 macro_rules! impl_const_default {
-    ($($(#[$doc:meta])* $type:ty => $default:expr;)*) => {$(
+    ($($(#[$doc:meta])* $(@$pub:ident)? $type:ty => $default:expr;)*) => {$(
         impl $type {
-            $(#[$doc])*
-            ///
-            /// This function exists since [`Default::default()`] cannot be used in a `const`
-            /// context. It may be removed once that becomes possible. As the [`Default`] trait is
-            /// in the prelude, removing this function in the future will not cause any resolution
-            /// failures for the overwhelming majority of users; only users who use
-            /// `#![no_implicit_prelude]` will be affected. As such it will not be considered a
-            /// breaking change.
-            pub const fn default() -> Self {
-                $default
+            doc_hack! {
+                $($pub)?
+                $(#[$doc])*;
+                pub const fn default() -> Self {
+                    $default
+                }
             }
         }
 
@@ -272,35 +290,35 @@ macro_rules! impl_const_default {
 
 impl_const_default! {
     /// Creates a modifier that indicates the value is [padded with zeroes](Padding::Zero).
-    Day => Self { padding: Padding::default() };
+    @pub Day => Self { padding: Padding::default() };
     /// Creates a modifier that indicates the value uses the
     /// [`Numerical`](Self::Numerical) representation.
     MonthRepr => Self::Numerical;
     /// Creates an instance of this type that indicates the value uses the
     /// [`Numerical`](MonthRepr::Numerical) representation, is [padded with zeroes](Padding::Zero),
     /// and is case-sensitive when parsing.
-    Month => Self {
+    @pub Month => Self {
         padding: Padding::default(),
         repr: MonthRepr::default(),
         case_sensitive: true,
     };
     /// Creates a modifier that indicates the value is [padded with zeroes](Padding::Zero).
-    Ordinal => Self { padding: Padding::default() };
+    @pub Ordinal => Self { padding: Padding::default() };
     /// Creates a modifier that indicates the value uses the [`Long`](Self::Long) representation.
     WeekdayRepr => Self::Long;
     /// Creates a modifier that indicates the value uses the [`Long`](WeekdayRepr::Long)
     /// representation and is case-sensitive when parsing. If the representation is changed to a
     /// numerical one, the instance defaults to one-based indexing.
-    Weekday => Self {
+    @pub Weekday => Self {
         repr: WeekdayRepr::default(),
         one_indexed: true,
         case_sensitive: true,
     };
     /// Creates a modifier that indicates that the value uses the [`Iso`](Self::Iso) representation.
-    WeekNumberRepr => Self::Iso;
+    @pub WeekNumberRepr => Self::Iso;
     /// Creates a modifier that indicates that the value is [padded with zeroes](Padding::Zero)
             /// and uses the [`Iso`](WeekNumberRepr::Iso) representation.
-    WeekNumber => Self {
+    @pub WeekNumber => Self {
         padding: Padding::default(),
         repr: WeekNumberRepr::default(),
     };
@@ -309,7 +327,7 @@ impl_const_default! {
     /// Creates a modifier that indicates the value uses the [`Full`](YearRepr::Full)
     /// representation, is [padded with zeroes](Padding::Zero), uses the Gregorian calendar as its
     /// base, and only includes the year's sign if necessary.
-    Year => Self {
+    @pub Year => Self {
         padding: Padding::default(),
         repr: YearRepr::default(),
         iso_week_based: false,
@@ -317,36 +335,36 @@ impl_const_default! {
     };
     /// Creates a modifier that indicates the value is [padded with zeroes](Padding::Zero) and
     /// has the 24-hour representation.
-    Hour => Self {
+    @pub Hour => Self {
         padding: Padding::default(),
         is_12_hour_clock: false,
     };
     /// Creates a modifier that indicates the value is [padded with zeroes](Padding::Zero).
-    Minute => Self { padding: Padding::default() };
+    @pub Minute => Self { padding: Padding::default() };
     /// Creates a modifier that indicates the value uses the upper-case representation and is
     /// case-sensitive when parsing.
-    Period => Self {
+    @pub Period => Self {
         is_uppercase: true,
         case_sensitive: true,
     };
     /// Creates a modifier that indicates the value is [padded with zeroes](Padding::Zero).
-    Second => Self { padding: Padding::default() };
-    /// Creates a modifier that indicates the stringified value contains [`one or more
-    /// digits`](Self::OneOrMore).
+    @pub Second => Self { padding: Padding::default() };
+    /// Creates a modifier that indicates the stringified value contains [one or more
+    /// digits](Self::OneOrMore).
     SubsecondDigits => Self::OneOrMore;
-    /// Creates a modifier that indicates the stringified value contains [`one or more
-    /// digits`](SubsecondDigits::OneOrMore).
-    Subsecond => Self { digits: SubsecondDigits::default() };
+    /// Creates a modifier that indicates the stringified value contains [one or more
+    /// digits](SubsecondDigits::OneOrMore).
+    @pub Subsecond => Self { digits: SubsecondDigits::default() };
     /// Creates a modifier that indicates the value uses the `+` sign for all positive values
     /// and is [padded with zeroes](Padding::Zero).
-    OffsetHour => Self {
+    @pub OffsetHour => Self {
         sign_is_mandatory: true,
         padding: Padding::default(),
     };
     /// Creates a modifier that indicates the value is [padded with zeroes](Padding::Zero).
-    OffsetMinute => Self { padding: Padding::default() };
+    @pub OffsetMinute => Self { padding: Padding::default() };
     /// Creates a modifier that indicates the value is [padded with zeroes](Padding::Zero).
-    OffsetSecond => Self { padding: Padding::default() };
+    @pub OffsetSecond => Self { padding: Padding::default() };
     /// Creates a modifier that indicates the value is [padded with zeroes](Self::Zero).
     Padding => Self::Zero;
 }


### PR DESCRIPTION
Fixes #362