### PR TITLE
refactor: parse_* methods accept more argument types

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -685,11 +685,11 @@ impl Date {
     /// assert_eq!(Date::parse("2020-01-02", &format)?, date!(2020 - 01 - 02));
     /// # Ok::<_, time::Error>(())
     /// ```
-    pub fn parse(
-        input: &str,
+    pub fn parse<S: AsRef<str>>(
+        input: S,
         description: &(impl Parsable + ?Sized),
     ) -> Result<Self, error::Parse> {
-        description.parse_date(input.as_bytes())
+        description.parse_date(input.as_ref().as_bytes())
     }
 }
 

--- a/src/format_description/parse.rs
+++ b/src/format_description/parse.rs
@@ -81,11 +81,11 @@ fn parse_item<'a>(
 /// The syntax for the format description can be found in [the
 /// book](https://time-rs.github.io/book/api/format-description.html).
 #[cfg_attr(__time_03_docs, doc(cfg(feature = "alloc")))]
-pub fn parse(s: &str) -> Result<Vec<FormatItem<'_>>, InvalidFormatDescription> {
+pub fn parse<S: AsRef<str>>(s: S) -> Result<Vec<FormatItem<'_>>, InvalidFormatDescription> {
     let mut compound = Vec::new();
     let mut loc = 0;
 
-    let mut s = s.as_bytes();
+    let mut s = s.as_ref().as_bytes();
 
     while !s.is_empty() {
         let ParsedItem { item, remaining } = parse_item(s, &mut loc)?;

--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -827,11 +827,11 @@ impl OffsetDateTime {
     /// );
     /// # Ok::<_, time::Error>(())
     /// ```
-    pub fn parse(
-        input: &str,
+    pub fn parse<S: AsRef<str>>(
+        input: S,
         description: &(impl Parsable + ?Sized),
     ) -> Result<Self, error::Parse> {
-        description.parse_offset_date_time(input.as_bytes())
+        description.parse_offset_date_time(input.as_ref().as_bytes())
     }
 }
 

--- a/src/primitive_date_time.rs
+++ b/src/primitive_date_time.rs
@@ -542,11 +542,11 @@ impl PrimitiveDateTime {
     /// );
     /// # Ok::<_, time::Error>(())
     /// ```
-    pub fn parse(
-        input: &str,
+    pub fn parse<S: AsRef<str>>(
+        input: S,
         description: &(impl Parsable + ?Sized),
     ) -> Result<Self, error::Parse> {
-        description.parse_date_time(input.as_bytes())
+        description.parse_date_time(input.as_ref().as_bytes())
     }
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -446,11 +446,11 @@ impl Time {
     /// assert_eq!(Time::parse("12:00:00", &format)?, time!(12:00));
     /// # Ok::<_, time::Error>(())
     /// ```
-    pub fn parse(
-        input: &str,
+    pub fn parse<S: AsRef<str>>(
+        input: S,
         description: &(impl Parsable + ?Sized),
     ) -> Result<Self, error::Parse> {
-        description.parse_time(input.as_bytes())
+        description.parse_time(input.as_ref().as_bytes())
     }
 }
 

--- a/src/utc_offset.rs
+++ b/src/utc_offset.rs
@@ -286,11 +286,11 @@ impl UtcOffset {
     /// assert_eq!(UtcOffset::parse("-03:42", &format)?, offset!(-3:42));
     /// # Ok::<_, time::Error>(())
     /// ```
-    pub fn parse(
-        input: &str,
+    pub fn parse<S: AsRef<str>>(
+        input: S,
         description: &(impl Parsable + ?Sized),
     ) -> Result<Self, error::Parse> {
-        description.parse_offset(input.as_bytes())
+        description.parse_offset(input.as_ref().as_bytes())
     }
 }
 


### PR DESCRIPTION
By using AsRef<str>, the `parse_*` methods can accept arguments of different types as long as they can be converted to a `&str`.

Closes #365 