### PR TITLE
Fixed doctests for `OffsetDateTime::checked_{add,sub}`

### DIFF
--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -692,7 +692,7 @@ impl OffsetDateTime {
     /// # use time::{Date, ext::NumericalDuration};
     /// # use time::macros::{datetime, offset};
     ///
-    /// let datetime = Date::MIN.midnight().assume_offset(offset!(+10:00));
+    /// let datetime = Date::MIN.midnight().assume_offset(offset!(-10:00));
     /// assert_eq!(datetime.checked_add((-2).days()), None);
     ///
     /// let datetime = Date::MAX.midnight().assume_offset(offset!(+10:00));
@@ -714,7 +714,7 @@ impl OffsetDateTime {
     /// # use time::{Date, ext::NumericalDuration};
     /// # use time::macros::{datetime, offset};
     ///
-    /// let datetime = Date::MIN.midnight().assume_offset(offset!(+10:00));
+    /// let datetime = Date::MIN.midnight().assume_offset(offset!(-10:00));
     /// assert_eq!(datetime.checked_sub(2.days()), None);
     ///
     /// let datetime = Date::MAX.midnight().assume_offset(offset!(+10:00));


### PR DESCRIPTION
Due to a bug in `PrimitiveDateTime::assume_offset` some doctests were passing, though they should not.
These test were replaced with correct ones.