### PR TITLE
Fixed `OffsetDateTime::checked_{add,sub}` implementations

### DIFF
--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -704,8 +704,8 @@ impl OffsetDateTime {
     /// );
     /// ```
     pub const fn checked_add(self, duration: Duration) -> Option<Self> {
-        let utc_datetime = const_try_opt!(self.utc_datetime.checked_add(duration));
-        Some(utc_datetime.assume_utc().to_offset(self.offset))
+        let offset_datetime = self.utc_datetime.utc_to_offset(self.offset);
+        Some(const_try_opt!(offset_datetime.checked_add(duration)).assume_offset(self.offset))
     }
 
     /// Computes `self - duration`, returning `None` if an overflow occurred.
@@ -726,8 +726,8 @@ impl OffsetDateTime {
     /// );
     /// ```
     pub const fn checked_sub(self, duration: Duration) -> Option<Self> {
-        let utc_datetime = const_try_opt!(self.utc_datetime.checked_sub(duration));
-        Some(utc_datetime.assume_utc().to_offset(self.offset))
+        let offset_datetime = self.utc_datetime.utc_to_offset(self.offset);
+        Some(const_try_opt!(offset_datetime.checked_sub(duration)).assume_offset(self.offset))
     }
 
     // endregion: checked arithmetic

--- a/tests/integration/offset_date_time.rs
+++ b/tests/integration/offset_date_time.rs
@@ -932,6 +932,16 @@ fn checked_add_duration() {
         datetime!(+999_990 - 12 - 31 23:59:59.999_999_999 UTC).checked_add(530.weeks()),
         None
     );
+
+    // Adding 0 duration at MIN/MAX values with non-zero offset
+    assert_eq!(
+        datetime!(+999_999 - 12 - 31 23:59:59.999_999_999 -10:00).checked_add(Duration::ZERO),
+        Some(datetime!(+999_999 - 12 - 31 23:59:59.999_999_999 -10:00))
+    );
+    assert_eq!(
+        datetime!(-999_999 - 01 - 01 0:00 +10:00).checked_add(Duration::ZERO),
+        Some(datetime!(-999_999 - 01 - 01 0:00 +10:00))
+    );
 }
 
 #[test]
@@ -996,5 +1006,15 @@ fn checked_sub_duration() {
     assert_eq!(
         datetime!(+999_990 - 12 - 31 23:59:59.999_999_999 UTC).checked_sub((-530).weeks()),
         None
+    );
+
+    // Subtracting 0 duration at MIN/MAX values with non-zero offset
+    assert_eq!(
+        datetime!(+999_999 - 12 - 31 23:59:59.999_999_999 -10:00).checked_sub(Duration::ZERO),
+        Some(datetime!(+999_999 - 12 - 31 23:59:59.999_999_999 -10:00))
+    );
+    assert_eq!(
+        datetime!(-999_999 - 01 - 01 0:00 +10:00).checked_sub(Duration::ZERO),
+        Some(datetime!(-999_999 - 01 - 01 0:00 +10:00))
     );
 }


### PR DESCRIPTION
This fixes invalid behavior of aforementioned functions when internal `utc_datetime` has (intentional) out-or-range value.