### PR TITLE
Saturating arithmetic

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -629,6 +629,86 @@ impl Date {
         }
     }
     // endregion: checked arithmetic
+
+    // region: saturating arithmetic
+    /// Computes `self + duration`, saturating value on overflow.
+    ///
+    /// ```rust
+    /// # use time::{Date, ext::NumericalDuration, macros::date};
+    ///
+    /// assert_eq!(Date::MAX.saturating_add(1.days()), Date::MAX);
+    /// assert_eq!(Date::MIN.saturating_add((-2).days()), Date::MIN);
+    /// assert_eq!(
+    ///     date!(2020 - 12 - 31).saturating_add(2.days()),
+    ///     date!(2021 - 01 - 02)
+    /// );
+    /// ```
+    ///
+    /// # Note
+    ///
+    /// This function only takes whole days into account.
+    ///
+    /// ```rust
+    /// # use time::{ext::NumericalDuration, macros::date};
+    ///
+    /// assert_eq!(
+    ///     date!(2020 - 12 - 31).saturating_add(23.hours()),
+    ///     date!(2020 - 12 - 31)
+    /// );
+    /// assert_eq!(
+    ///     date!(2020 - 12 - 31).saturating_add(47.hours()),
+    ///     date!(2021 - 01 - 01)
+    /// );
+    /// ```
+    pub const fn saturating_add(self, duration: Duration) -> Self {
+        if let Some(datetime) = self.checked_add(duration) {
+            datetime
+        } else if duration.is_negative() {
+            Self::MIN
+        } else {
+            Self::MAX
+        }
+    }
+
+    /// Computes `self - duration`, saturating value on overflow.
+    ///
+    /// ```
+    /// # use time::{Date, ext::NumericalDuration, macros::date};
+    ///
+    /// assert_eq!(Date::MAX.saturating_sub((-2).days()), Date::MAX);
+    /// assert_eq!(Date::MIN.saturating_sub(1.days()), Date::MIN);
+    /// assert_eq!(
+    ///     date!(2020 - 12 - 31).saturating_sub(2.days()),
+    ///     date!(2020 - 12 - 29)
+    /// );
+    /// ```
+    ///
+    /// # Note
+    ///
+    /// This function only takes whole days into account.
+    ///
+    /// ```
+    /// # use time::{ext::NumericalDuration, macros::date};
+    ///
+    /// assert_eq!(
+    ///     date!(2020 - 12 - 31).saturating_sub(23.hours()),
+    ///     date!(2020 - 12 - 31)
+    /// );
+    /// assert_eq!(
+    ///     date!(2020 - 12 - 31).saturating_sub(47.hours()),
+    ///     date!(2020 - 12 - 30)
+    /// );
+    /// ```
+    pub const fn saturating_sub(self, duration: Duration) -> Self {
+        if let Some(datetime) = self.checked_sub(duration) {
+            datetime
+        } else if duration.is_negative() {
+            Self::MAX
+        } else {
+            Self::MIN
+        }
+    }
+    // region: saturating arithmetic
 }
 
 // region: attach time

--- a/src/date.rs
+++ b/src/date.rs
@@ -635,7 +635,6 @@ impl Date {
     ///
     /// ```rust
     /// # use time::{Date, ext::NumericalDuration, macros::date};
-    ///
     /// assert_eq!(Date::MAX.saturating_add(1.days()), Date::MAX);
     /// assert_eq!(Date::MIN.saturating_add((-2).days()), Date::MIN);
     /// assert_eq!(
@@ -650,7 +649,6 @@ impl Date {
     ///
     /// ```rust
     /// # use time::{ext::NumericalDuration, macros::date};
-    ///
     /// assert_eq!(
     ///     date!(2020 - 12 - 31).saturating_add(23.hours()),
     ///     date!(2020 - 12 - 31)
@@ -674,7 +672,6 @@ impl Date {
     ///
     /// ```
     /// # use time::{Date, ext::NumericalDuration, macros::date};
-    ///
     /// assert_eq!(Date::MAX.saturating_sub((-2).days()), Date::MAX);
     /// assert_eq!(Date::MIN.saturating_sub(1.days()), Date::MIN);
     /// assert_eq!(
@@ -689,7 +686,6 @@ impl Date {
     ///
     /// ```
     /// # use time::{ext::NumericalDuration, macros::date};
-    ///
     /// assert_eq!(
     ///     date!(2020 - 12 - 31).saturating_sub(23.hours()),
     ///     date!(2020 - 12 - 31)

--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -691,15 +691,15 @@ impl OffsetDateTime {
     /// ```
     /// # use time::{Date, ext::NumericalDuration};
     /// # use time::macros::{datetime, offset};
-    /// let datetime = Date::MIN.midnight().assume_offset(offset!(+10:00));
+    /// let datetime = Date::MIN.midnight().assume_offset(offset!(+10));
     /// assert_eq!(datetime.checked_add((-2).days()), None);
     ///
-    /// let datetime = Date::MAX.midnight().assume_offset(offset!(+10:00));
+    /// let datetime = Date::MAX.midnight().assume_offset(offset!(+10));
     /// assert_eq!(datetime.checked_add(2.days()), None);
     ///
     /// assert_eq!(
-    ///     datetime!(2019 - 11 - 25 15:30 +10:00).checked_add(27.hours()),
-    ///     Some(datetime!(2019 - 11 - 26 18:30 +10:00))
+    ///     datetime!(2019 - 11 - 25 15:30 +10).checked_add(27.hours()),
+    ///     Some(datetime!(2019 - 11 - 26 18:30 +10))
     /// );
     /// ```
     pub const fn checked_add(self, duration: Duration) -> Option<Self> {
@@ -712,15 +712,15 @@ impl OffsetDateTime {
     /// ```
     /// # use time::{Date, ext::NumericalDuration};
     /// # use time::macros::{datetime, offset};
-    /// let datetime = Date::MIN.midnight().assume_offset(offset!(+10:00));
+    /// let datetime = Date::MIN.midnight().assume_offset(offset!(+10));
     /// assert_eq!(datetime.checked_sub(2.days()), None);
     ///
-    /// let datetime = Date::MAX.midnight().assume_offset(offset!(+10:00));
+    /// let datetime = Date::MAX.midnight().assume_offset(offset!(+10));
     /// assert_eq!(datetime.checked_sub((-2).days()), None);
     ///
     /// assert_eq!(
-    ///     datetime!(2019 - 11 - 25 15:30 +10:00).checked_sub(27.hours()),
-    ///     Some(datetime!(2019 - 11 - 24 12:30 +10:00))
+    ///     datetime!(2019 - 11 - 25 15:30 +10).checked_sub(27.hours()),
+    ///     Some(datetime!(2019 - 11 - 24 12:30 +10))
     /// );
     /// ```
     pub const fn checked_sub(self, duration: Duration) -> Option<Self> {

--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -729,6 +729,77 @@ impl OffsetDateTime {
     }
 
     // endregion: checked arithmetic
+
+    // region: saturating arithmetic
+    /// Computes `self + duration`, saturating value on overflow.
+    ///
+    /// ```
+    /// # use time::ext::NumericalDuration;
+    /// # use time::macros::datetime;
+    ///
+    /// assert_eq!(
+    ///     datetime!(-999999 - 01 - 01 00:00 +10:00).saturating_add((-2).days()),
+    ///     datetime!(-999999 - 01 - 01 00:00 +10:00)
+    /// );
+    ///
+    /// assert_eq!(
+    ///     datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00).saturating_add(2.days()),
+    ///     datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00)
+    /// );
+    ///
+    /// assert_eq!(
+    ///     datetime!(2019 - 11 - 25 15:30 +10:00).saturating_add(27.hours()),
+    ///     datetime!(2019 - 11 - 26 18:30 +10:00)
+    /// );
+    /// ```
+    pub const fn saturating_add(self, duration: Duration) -> Self {
+        if let Some(datetime) = self.checked_add(duration) {
+            datetime
+        } else if duration.is_negative() {
+            PrimitiveDateTime::MIN
+                .assume_utc()
+                .replace_offset(self.offset)
+        } else {
+            PrimitiveDateTime::MAX
+                .assume_utc()
+                .replace_offset(self.offset)
+        }
+    }
+
+    /// Computes `self - duration`, saturating value on overflow.
+    ///
+    /// ```
+    /// # use time::ext::NumericalDuration;
+    /// # use time::macros::datetime;
+    ///
+    /// assert_eq!(
+    ///     datetime!(-999999 - 01 - 01 00:00 +10:00).saturating_sub(2.days()),
+    ///     datetime!(-999999 - 01 - 01 00:00 +10:00)
+    /// );
+    ///
+    /// assert_eq!(
+    ///     datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00).saturating_sub((-2).days()),
+    ///     datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00)
+    /// );
+    ///
+    /// assert_eq!(
+    ///     datetime!(2019 - 11 - 25 15:30 +10:00).saturating_sub(27.hours()),
+    ///     datetime!(2019 - 11 - 24 12:30 +10:00)
+    /// );
+    /// ```
+    pub const fn saturating_sub(self, duration: Duration) -> Self {
+        if let Some(datetime) = self.checked_sub(duration) {
+            datetime
+        } else if duration.is_negative() {
+            PrimitiveDateTime::MAX
+                .assume_utc()
+                .replace_offset(self.offset)
+        } else {
+            PrimitiveDateTime::MIN
+                .assume_utc()
+                .replace_offset(self.offset)
+        }
+    }
 }
 
 // region: replacement

--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -727,7 +727,6 @@ impl OffsetDateTime {
         let offset_datetime = self.utc_datetime.utc_to_offset(self.offset);
         Some(const_try_opt!(offset_datetime.checked_sub(duration)).assume_offset(self.offset))
     }
-
     // endregion: checked arithmetic
 
     // region: saturating arithmetic
@@ -736,20 +735,19 @@ impl OffsetDateTime {
     /// ```
     /// # use time::ext::NumericalDuration;
     /// # use time::macros::datetime;
-    ///
     /// assert_eq!(
-    ///     datetime!(-999999 - 01 - 01 00:00 +10:00).saturating_add((-2).days()),
-    ///     datetime!(-999999 - 01 - 01 00:00 +10:00)
+    ///     datetime!(-999999 - 01 - 01 0:00 +10).saturating_add((-2).days()),
+    ///     datetime!(-999999 - 01 - 01 0:00 +10)
     /// );
     ///
     /// assert_eq!(
-    ///     datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00).saturating_add(2.days()),
-    ///     datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00)
+    ///     datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10).saturating_add(2.days()),
+    ///     datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10)
     /// );
     ///
     /// assert_eq!(
-    ///     datetime!(2019 - 11 - 25 15:30 +10:00).saturating_add(27.hours()),
-    ///     datetime!(2019 - 11 - 26 18:30 +10:00)
+    ///     datetime!(2019 - 11 - 25 15:30 +10).saturating_add(27.hours()),
+    ///     datetime!(2019 - 11 - 26 18:30 +10)
     /// );
     /// ```
     pub const fn saturating_add(self, duration: Duration) -> Self {
@@ -771,20 +769,19 @@ impl OffsetDateTime {
     /// ```
     /// # use time::ext::NumericalDuration;
     /// # use time::macros::datetime;
-    ///
     /// assert_eq!(
-    ///     datetime!(-999999 - 01 - 01 00:00 +10:00).saturating_sub(2.days()),
-    ///     datetime!(-999999 - 01 - 01 00:00 +10:00)
+    ///     datetime!(-999999 - 01 - 01 0:00 +10).saturating_sub(2.days()),
+    ///     datetime!(-999999 - 01 - 01 0:00 +10)
     /// );
     ///
     /// assert_eq!(
-    ///     datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00).saturating_sub((-2).days()),
-    ///     datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00)
+    ///     datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10).saturating_sub((-2).days()),
+    ///     datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10)
     /// );
     ///
     /// assert_eq!(
-    ///     datetime!(2019 - 11 - 25 15:30 +10:00).saturating_sub(27.hours()),
-    ///     datetime!(2019 - 11 - 24 12:30 +10:00)
+    ///     datetime!(2019 - 11 - 25 15:30 +10).saturating_sub(27.hours()),
+    ///     datetime!(2019 - 11 - 24 12:30 +10)
     /// );
     /// ```
     pub const fn saturating_sub(self, duration: Duration) -> Self {
@@ -800,6 +797,7 @@ impl OffsetDateTime {
                 .replace_offset(self.offset)
         }
     }
+    // endregion: saturating arithmetic
 }
 
 // region: replacement

--- a/src/primitive_date_time.rs
+++ b/src/primitive_date_time.rs
@@ -33,7 +33,6 @@ impl PrimitiveDateTime {
     ///
     /// ```rust
     /// # use time::{PrimitiveDateTime, macros::datetime};
-    ///
     /// // Assuming `large-dates` feature is enabled.
     /// assert_eq!(PrimitiveDateTime::MIN, datetime!(-999999 - 01 - 01 0:00));
     /// ```
@@ -48,7 +47,6 @@ impl PrimitiveDateTime {
     ///
     /// ```rust
     /// # use time::{PrimitiveDateTime, macros::datetime};
-    ///
     /// // Assuming `large-dates` feature is enabled.
     /// assert_eq!(PrimitiveDateTime::MAX, datetime!(+999999 - 12 - 31 23:59:59.999_999_999));
     /// ```
@@ -525,7 +523,6 @@ impl PrimitiveDateTime {
     /// ```
     /// # use time::{PrimitiveDateTime, ext::NumericalDuration};
     /// # use time::macros::datetime;
-    ///
     /// assert_eq!(
     ///     PrimitiveDateTime::MIN.saturating_add((-2).days()),
     ///     PrimitiveDateTime::MIN
@@ -556,7 +553,6 @@ impl PrimitiveDateTime {
     /// ```
     /// # use time::{PrimitiveDateTime, ext::NumericalDuration};
     /// # use time::macros::datetime;
-    ///
     /// assert_eq!(
     ///     PrimitiveDateTime::MIN.saturating_sub(2.days()),
     ///     PrimitiveDateTime::MIN
@@ -581,7 +577,7 @@ impl PrimitiveDateTime {
             Self::MIN
         }
     }
-    // endregion: checked arithmetic
+    // endregion: saturating arithmetic
 }
 
 // region: replacement

--- a/src/primitive_date_time.rs
+++ b/src/primitive_date_time.rs
@@ -518,6 +518,70 @@ impl PrimitiveDateTime {
         })
     }
     // endregion: checked arithmetic
+
+    // region: saturating arithmetic
+    /// Computes `self + duration`, saturating value on overflow.
+    ///
+    /// ```
+    /// # use time::{PrimitiveDateTime, ext::NumericalDuration};
+    /// # use time::macros::datetime;
+    ///
+    /// assert_eq!(
+    ///     PrimitiveDateTime::MIN.saturating_add((-2).days()),
+    ///     PrimitiveDateTime::MIN
+    /// );
+    ///
+    /// assert_eq!(
+    ///     PrimitiveDateTime::MAX.saturating_add(2.days()),
+    ///     PrimitiveDateTime::MAX
+    /// );
+    ///
+    /// assert_eq!(
+    ///     datetime!(2019 - 11 - 25 15:30).saturating_add(27.hours()),
+    ///     datetime!(2019 - 11 - 26 18:30)
+    /// );
+    /// ```
+    pub const fn saturating_add(self, duration: Duration) -> Self {
+        if let Some(datetime) = self.checked_add(duration) {
+            datetime
+        } else if duration.is_negative() {
+            Self::MIN
+        } else {
+            Self::MAX
+        }
+    }
+
+    /// Computes `self - duration`, saturating value on overflow.
+    ///
+    /// ```
+    /// # use time::{PrimitiveDateTime, ext::NumericalDuration};
+    /// # use time::macros::datetime;
+    ///
+    /// assert_eq!(
+    ///     PrimitiveDateTime::MIN.saturating_sub(2.days()),
+    ///     PrimitiveDateTime::MIN
+    /// );
+    ///
+    /// assert_eq!(
+    ///     PrimitiveDateTime::MAX.saturating_sub((-2).days()),
+    ///     PrimitiveDateTime::MAX
+    /// );
+    ///
+    /// assert_eq!(
+    ///     datetime!(2019 - 11 - 25 15:30).saturating_sub(27.hours()),
+    ///     datetime!(2019 - 11 - 24 12:30)
+    /// );
+    /// ```
+    pub const fn saturating_sub(self, duration: Duration) -> Self {
+        if let Some(datetime) = self.checked_sub(duration) {
+            datetime
+        } else if duration.is_negative() {
+            Self::MAX
+        } else {
+            Self::MIN
+        }
+    }
+    // endregion: checked arithmetic
 }
 
 // region: replacement

--- a/src/primitive_date_time.rs
+++ b/src/primitive_date_time.rs
@@ -24,6 +24,36 @@ pub struct PrimitiveDateTime {
 }
 
 impl PrimitiveDateTime {
+    /// The smallest value that can be represented by `PrimitiveDateTime`.
+    ///
+    /// Depending on `large-dates` feature flag, value of this constant may vary.
+    ///
+    /// 1. With `large-dates` disabled it is equal to `-9999 - 01 - 01 00:00:00.0`
+    /// 2. With `large-dates` enabled it is equal to `-999999 - 01 - 01 00:00:00.0`
+    ///
+    /// ```rust
+    /// # use time::{PrimitiveDateTime, macros::datetime};
+    ///
+    /// // Assuming `large-dates` feature is enabled.
+    /// assert_eq!(PrimitiveDateTime::MIN, datetime!(-999999 - 01 - 01 0:00));
+    /// ```
+    pub const MIN: Self = Self::new(Date::MIN, Time::MIN);
+
+    /// The largest value that can be represented by `PrimitiveDateTime`.
+    ///
+    /// Depending on `large-dates` feature flag, value of this constant may vary.
+    ///
+    /// 1. With `large-dates` disabled it is equal to `9999 - 12 - 31 23:59:59.999_999_999`
+    /// 2. With `large-dates` enabled it is equal to `999999 - 12 - 31 23:59:59.999_999_999`
+    ///
+    /// ```rust
+    /// # use time::{PrimitiveDateTime, macros::datetime};
+    ///
+    /// // Assuming `large-dates` feature is enabled.
+    /// assert_eq!(PrimitiveDateTime::MAX, datetime!(+999999 - 12 - 31 23:59:59.999_999_999));
+    /// ```
+    pub const MAX: Self = Self::new(Date::MAX, Time::MAX);
+
     /// Create a new `PrimitiveDateTime` from the provided [`Date`] and [`Time`].
     ///
     /// ```rust

--- a/src/time.rs
+++ b/src/time.rs
@@ -62,6 +62,16 @@ impl Time {
     /// ```
     pub const MIDNIGHT: Self = Self::__from_hms_nanos_unchecked(0, 0, 0, 0);
 
+    /// The smallest value that can be represented by `Time`.
+    ///
+    /// `00:00:00.0`
+    pub(crate) const MIN: Self = Self::__from_hms_nanos_unchecked(0, 0, 0, 0);
+
+    /// The largest value that can be represented by `Time`.
+    ///
+    /// `23:59:59.999_999_999`
+    pub(crate) const MAX: Self = Self::__from_hms_nanos_unchecked(23, 59, 59, 999_999_999);
+
     // region: constructors
     /// Create a `Time` from its components.
     #[doc(hidden)]

--- a/tests/integration/date.rs
+++ b/tests/integration/date.rs
@@ -875,3 +875,47 @@ fn checked_sub_duration() {
     assert_eq!(Date::MIN.checked_sub(Duration::MAX), None);
     assert_eq!(Date::MAX.checked_sub(Duration::MIN), None);
 }
+
+#[test]
+fn saturating_add() {
+    assert_eq!(
+        date!(2021 - 11 - 05).saturating_add(2.days()),
+        date!(2021 - 11 - 07)
+    );
+    assert_eq!(
+        date!(2021 - 11 - 05).saturating_add((-2).days()),
+        date!(2021 - 11 - 03)
+    );
+
+    // Adding with underflow
+    assert_eq!(Date::MIN.saturating_add((-10).days()), Date::MIN);
+
+    // Adding with overflow
+    assert_eq!(Date::MAX.saturating_add(10.days()), Date::MAX);
+
+    // Adding zero duration at boundaries
+    assert_eq!(Date::MIN.saturating_add(Duration::ZERO), Date::MIN);
+    assert_eq!(Date::MAX.saturating_add(Duration::ZERO), Date::MAX);
+}
+
+#[test]
+fn saturating_sub() {
+    assert_eq!(
+        date!(2021 - 11 - 05).saturating_sub(2.days()),
+        date!(2021 - 11 - 03)
+    );
+    assert_eq!(
+        date!(2021 - 11 - 05).saturating_sub((-2).days()),
+        date!(2021 - 11 - 07)
+    );
+
+    // Subtracting with underflow
+    assert_eq!(Date::MIN.saturating_sub(10.days()), Date::MIN);
+
+    // Subtracting with overflow
+    assert_eq!(Date::MAX.saturating_sub((-10).days()), Date::MAX);
+
+    // Subtracting zero duration at boundaries
+    assert_eq!(Date::MIN.saturating_sub(Duration::ZERO), Date::MIN);
+    assert_eq!(Date::MAX.saturating_sub(Duration::ZERO), Date::MAX);
+}

--- a/tests/integration/date.rs
+++ b/tests/integration/date.rs
@@ -877,7 +877,7 @@ fn checked_sub_duration() {
 }
 
 #[test]
-fn saturating_add() {
+fn saturating_add_duration() {
     assert_eq!(
         date!(2021 - 11 - 05).saturating_add(2.days()),
         date!(2021 - 11 - 07)
@@ -899,7 +899,7 @@ fn saturating_add() {
 }
 
 #[test]
-fn saturating_sub() {
+fn saturating_sub_duration() {
     assert_eq!(
         date!(2021 - 11 - 05).saturating_sub(2.days()),
         date!(2021 - 11 - 03)

--- a/tests/integration/offset_date_time.rs
+++ b/tests/integration/offset_date_time.rs
@@ -1018,3 +1018,71 @@ fn checked_sub_duration() {
         Some(datetime!(-999_999 - 01 - 01 0:00 +10:00))
     );
 }
+
+#[test]
+fn saturating_add() {
+    assert_eq!(
+        datetime!(2021 - 11 - 12 17:47 +10:00).saturating_add(2.days()),
+        datetime!(2021 - 11 - 14 17:47 +10:00)
+    );
+    assert_eq!(
+        datetime!(2021 - 11 - 12 17:47 +10:00).saturating_add((-2).days()),
+        datetime!(2021 - 11 - 10 17:47 +10:00)
+    );
+
+    // Adding with underflow
+    assert_eq!(
+        datetime!(-999999 - 01 - 01 00:00 +10:00).saturating_add((-10).days()),
+        datetime!(-999999 - 01 - 01 00:00 +10:00)
+    );
+
+    // Adding with overflow
+    assert_eq!(
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00).saturating_add(10.days()),
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00)
+    );
+
+    // Adding zero duration at boundaries
+    assert_eq!(
+        datetime!(-999999 - 01 - 01 00:00 +10:00).saturating_add(Duration::ZERO),
+        datetime!(-999999 - 01 - 01 00:00 +10:00)
+    );
+    assert_eq!(
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00).saturating_add(Duration::ZERO),
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00)
+    );
+}
+
+#[test]
+fn saturating_sub() {
+    assert_eq!(
+        datetime!(2021 - 11 - 12 17:47 +10:00).saturating_sub(2.days()),
+        datetime!(2021 - 11 - 10 17:47 +10:00)
+    );
+    assert_eq!(
+        datetime!(2021 - 11 - 12 17:47 +10:00).saturating_sub((-2).days()),
+        datetime!(2021 - 11 - 14 17:47 +10:00)
+    );
+
+    // Subtracting with underflow
+    assert_eq!(
+        datetime!(-999999 - 01 - 01 00:00 +10:00).saturating_sub(10.days()),
+        datetime!(-999999 - 01 - 01 00:00 +10:00)
+    );
+
+    // Subtracting with overflow
+    assert_eq!(
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00).saturating_sub((-10).days()),
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00)
+    );
+
+    // Subtracting zero duration at boundaries
+    assert_eq!(
+        datetime!(-999999 - 01 - 01 00:00 +10:00).saturating_sub(Duration::ZERO),
+        datetime!(-999999 - 01 - 01 00:00 +10:00)
+    );
+    assert_eq!(
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00).saturating_sub(Duration::ZERO),
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00)
+    );
+}

--- a/tests/integration/offset_date_time.rs
+++ b/tests/integration/offset_date_time.rs
@@ -907,15 +907,15 @@ fn checked_add_duration() {
 
     // Addition with underflow
     assert_eq!(
-        datetime!(-999_999 - 01 - 01 00:00 UTC).checked_add((-1).nanoseconds()),
+        datetime!(-999_999 - 01 - 01 0:00 UTC).checked_add((-1).nanoseconds()),
         None
     );
     assert_eq!(
-        datetime!(-999_999 - 01 - 01 00:00 UTC).checked_add(Duration::MIN),
+        datetime!(-999_999 - 01 - 01 0:00 UTC).checked_add(Duration::MIN),
         None
     );
     assert_eq!(
-        datetime!(-999_990 - 01 - 01 00:00 UTC).checked_add((-530).weeks()),
+        datetime!(-999_990 - 01 - 01 0:00 UTC).checked_add((-530).weeks()),
         None
     );
 
@@ -982,15 +982,15 @@ fn checked_sub_duration() {
 
     // Subtraction with underflow
     assert_eq!(
-        datetime!(-999_999 - 01 - 01 00:00 UTC).checked_sub(1.nanoseconds()),
+        datetime!(-999_999 - 01 - 01 0:00 UTC).checked_sub(1.nanoseconds()),
         None
     );
     assert_eq!(
-        datetime!(-999_999 - 01 - 01 00:00 UTC).checked_sub(Duration::MAX),
+        datetime!(-999_999 - 01 - 01 0:00 UTC).checked_sub(Duration::MAX),
         None
     );
     assert_eq!(
-        datetime!(-999_990 - 01 - 01 00:00 UTC).checked_sub(530.weeks()),
+        datetime!(-999_990 - 01 - 01 0:00 UTC).checked_sub(530.weeks()),
         None
     );
 
@@ -1010,79 +1010,79 @@ fn checked_sub_duration() {
 
     // Subtracting 0 duration at MIN/MAX values with non-zero offset
     assert_eq!(
-        datetime!(+999_999 - 12 - 31 23:59:59.999_999_999 -10:00).checked_sub(Duration::ZERO),
-        Some(datetime!(+999_999 - 12 - 31 23:59:59.999_999_999 -10:00))
+        datetime!(+999_999 - 12 - 31 23:59:59.999_999_999 -10).checked_sub(Duration::ZERO),
+        Some(datetime!(+999_999 - 12 - 31 23:59:59.999_999_999 -10))
     );
     assert_eq!(
-        datetime!(-999_999 - 01 - 01 0:00 +10:00).checked_sub(Duration::ZERO),
-        Some(datetime!(-999_999 - 01 - 01 0:00 +10:00))
+        datetime!(-999_999 - 01 - 01 0:00 +10).checked_sub(Duration::ZERO),
+        Some(datetime!(-999_999 - 01 - 01 0:00 +10))
     );
 }
 
 #[test]
-fn saturating_add() {
+fn saturating_add_duration() {
     assert_eq!(
-        datetime!(2021 - 11 - 12 17:47 +10:00).saturating_add(2.days()),
-        datetime!(2021 - 11 - 14 17:47 +10:00)
+        datetime!(2021 - 11 - 12 17:47 +10).saturating_add(2.days()),
+        datetime!(2021 - 11 - 14 17:47 +10)
     );
     assert_eq!(
-        datetime!(2021 - 11 - 12 17:47 +10:00).saturating_add((-2).days()),
-        datetime!(2021 - 11 - 10 17:47 +10:00)
+        datetime!(2021 - 11 - 12 17:47 +10).saturating_add((-2).days()),
+        datetime!(2021 - 11 - 10 17:47 +10)
     );
 
     // Adding with underflow
     assert_eq!(
-        datetime!(-999999 - 01 - 01 00:00 +10:00).saturating_add((-10).days()),
-        datetime!(-999999 - 01 - 01 00:00 +10:00)
+        datetime!(-999999 - 01 - 01 0:00 +10).saturating_add((-10).days()),
+        datetime!(-999999 - 01 - 01 0:00 +10)
     );
 
     // Adding with overflow
     assert_eq!(
-        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00).saturating_add(10.days()),
-        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00)
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10).saturating_add(10.days()),
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10)
     );
 
     // Adding zero duration at boundaries
     assert_eq!(
-        datetime!(-999999 - 01 - 01 00:00 +10:00).saturating_add(Duration::ZERO),
-        datetime!(-999999 - 01 - 01 00:00 +10:00)
+        datetime!(-999999 - 01 - 01 0:00 +10).saturating_add(Duration::ZERO),
+        datetime!(-999999 - 01 - 01 0:00 +10)
     );
     assert_eq!(
-        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00).saturating_add(Duration::ZERO),
-        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00)
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10).saturating_add(Duration::ZERO),
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10)
     );
 }
 
 #[test]
-fn saturating_sub() {
+fn saturating_sub_duration() {
     assert_eq!(
-        datetime!(2021 - 11 - 12 17:47 +10:00).saturating_sub(2.days()),
-        datetime!(2021 - 11 - 10 17:47 +10:00)
+        datetime!(2021 - 11 - 12 17:47 +10).saturating_sub(2.days()),
+        datetime!(2021 - 11 - 10 17:47 +10)
     );
     assert_eq!(
-        datetime!(2021 - 11 - 12 17:47 +10:00).saturating_sub((-2).days()),
-        datetime!(2021 - 11 - 14 17:47 +10:00)
+        datetime!(2021 - 11 - 12 17:47 +10).saturating_sub((-2).days()),
+        datetime!(2021 - 11 - 14 17:47 +10)
     );
 
     // Subtracting with underflow
     assert_eq!(
-        datetime!(-999999 - 01 - 01 00:00 +10:00).saturating_sub(10.days()),
-        datetime!(-999999 - 01 - 01 00:00 +10:00)
+        datetime!(-999999 - 01 - 01 0:00 +10).saturating_sub(10.days()),
+        datetime!(-999999 - 01 - 01 0:00 +10)
     );
 
     // Subtracting with overflow
     assert_eq!(
-        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00).saturating_sub((-10).days()),
-        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00)
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10).saturating_sub((-10).days()),
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10)
     );
 
     // Subtracting zero duration at boundaries
     assert_eq!(
-        datetime!(-999999 - 01 - 01 00:00 +10:00).saturating_sub(Duration::ZERO),
-        datetime!(-999999 - 01 - 01 00:00 +10:00)
+        datetime!(-999999 - 01 - 01 0:00 +10).saturating_sub(Duration::ZERO),
+        datetime!(-999999 - 01 - 01 0:00 +10)
     );
     assert_eq!(
-        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00).saturating_sub(Duration::ZERO),
-        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10:00)
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10).saturating_sub(Duration::ZERO),
+        datetime!(+999999 - 12 - 31 23:59:59.999_999_999 +10)
     );
 }

--- a/tests/integration/primitive_date_time.rs
+++ b/tests/integration/primitive_date_time.rs
@@ -518,15 +518,15 @@ fn checked_add_duration() {
 
     // Addition with underflow
     assert_eq!(
-        datetime!(-999_999 - 01 - 01 00:00).checked_add((-1).nanoseconds()),
+        datetime!(-999_999 - 01 - 01 0:00).checked_add((-1).nanoseconds()),
         None
     );
     assert_eq!(
-        datetime!(-999_999 - 01 - 01 00:00).checked_add(Duration::MIN),
+        datetime!(-999_999 - 01 - 01 0:00).checked_add(Duration::MIN),
         None
     );
     assert_eq!(
-        datetime!(-999_990 - 01 - 01 00:00).checked_add((-530).weeks()),
+        datetime!(-999_990 - 01 - 01 0:00).checked_add((-530).weeks()),
         None
     );
 
@@ -583,15 +583,15 @@ fn checked_sub_duration() {
 
     // Subtraction with underflow
     assert_eq!(
-        datetime!(-999_999 - 01 - 01 00:00).checked_sub(1.nanoseconds()),
+        datetime!(-999_999 - 01 - 01 0:00).checked_sub(1.nanoseconds()),
         None
     );
     assert_eq!(
-        datetime!(-999_999 - 01 - 01 00:00).checked_sub(Duration::MAX),
+        datetime!(-999_999 - 01 - 01 0:00).checked_sub(Duration::MAX),
         None
     );
     assert_eq!(
-        datetime!(-999_990 - 01 - 01 00:00).checked_sub(530.weeks()),
+        datetime!(-999_990 - 01 - 01 0:00).checked_sub(530.weeks()),
         None
     );
 

--- a/tests/integration/primitive_date_time.rs
+++ b/tests/integration/primitive_date_time.rs
@@ -609,3 +609,71 @@ fn checked_sub_duration() {
         None
     );
 }
+
+#[test]
+fn saturating_add() {
+    assert_eq!(
+        datetime!(2021 - 11 - 12 17:47).saturating_add(2.days()),
+        datetime!(2021 - 11 - 14 17:47)
+    );
+    assert_eq!(
+        datetime!(2021 - 11 - 12 17:47).saturating_add((-2).days()),
+        datetime!(2021 - 11 - 10 17:47)
+    );
+
+    // Adding with underflow
+    assert_eq!(
+        PrimitiveDateTime::MIN.saturating_add((-10).days()),
+        PrimitiveDateTime::MIN
+    );
+
+    // Adding with overflow
+    assert_eq!(
+        PrimitiveDateTime::MAX.saturating_add(10.days()),
+        PrimitiveDateTime::MAX
+    );
+
+    // Adding zero duration at boundaries
+    assert_eq!(
+        PrimitiveDateTime::MIN.saturating_add(Duration::ZERO),
+        PrimitiveDateTime::MIN
+    );
+    assert_eq!(
+        PrimitiveDateTime::MAX.saturating_add(Duration::ZERO),
+        PrimitiveDateTime::MAX
+    );
+}
+
+#[test]
+fn saturating_sub() {
+    assert_eq!(
+        datetime!(2021 - 11 - 12 17:47).saturating_sub(2.days()),
+        datetime!(2021 - 11 - 10 17:47)
+    );
+    assert_eq!(
+        datetime!(2021 - 11 - 12 17:47).saturating_sub((-2).days()),
+        datetime!(2021 - 11 - 14 17:47)
+    );
+
+    // Subtracting with underflow
+    assert_eq!(
+        PrimitiveDateTime::MIN.saturating_sub(10.days()),
+        PrimitiveDateTime::MIN
+    );
+
+    // Subtracting with overflow
+    assert_eq!(
+        PrimitiveDateTime::MAX.saturating_sub((-10).days()),
+        PrimitiveDateTime::MAX
+    );
+
+    // Subtracting zero duration at boundaries
+    assert_eq!(
+        PrimitiveDateTime::MIN.saturating_sub(Duration::ZERO),
+        PrimitiveDateTime::MIN
+    );
+    assert_eq!(
+        PrimitiveDateTime::MAX.saturating_sub(Duration::ZERO),
+        PrimitiveDateTime::MAX
+    );
+}

--- a/tests/integration/primitive_date_time.rs
+++ b/tests/integration/primitive_date_time.rs
@@ -611,7 +611,7 @@ fn checked_sub_duration() {
 }
 
 #[test]
-fn saturating_add() {
+fn saturating_add_duration() {
     assert_eq!(
         datetime!(2021 - 11 - 12 17:47).saturating_add(2.days()),
         datetime!(2021 - 11 - 14 17:47)
@@ -645,7 +645,7 @@ fn saturating_add() {
 }
 
 #[test]
-fn saturating_sub() {
+fn saturating_sub_duration() {
     assert_eq!(
         datetime!(2021 - 11 - 12 17:47).saturating_sub(2.days()),
         datetime!(2021 - 11 - 10 17:47)


### PR DESCRIPTION
This PR adds the following:

- `Time::{MIN, MAX}` constants (private)
- `PrimitiveDateTime::{MIN, MAX}` constants
- `Date::saturating_{add,sub}` methods
- `PrimitiveDateTime::saturating_{add,sub}` methods
- `OffsetDateTime::saturating_{add,sub}` methods