### PR TITLE
feat: additional formatting options for human readable parsing

### DIFF
--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -229,10 +229,14 @@ const TIME_FORMAT: &[FormatItem<'_>] = &[
     FormatItem::Component(Component::Hour(<modifier::Hour>::default())),
     FormatItem::Literal(b":"),
     FormatItem::Component(Component::Minute(<modifier::Minute>::default())),
-    FormatItem::Literal(b":"),
-    FormatItem::Component(Component::Second(<modifier::Second>::default())),
-    FormatItem::Literal(b"."),
-    FormatItem::Component(Component::Subsecond(<modifier::Subsecond>::default())),
+    FormatItem::Optional(&FormatItem::Compound(&[
+        FormatItem::Literal(b":"),
+        FormatItem::Component(Component::Second(<modifier::Second>::default())),
+        FormatItem::Optional(&FormatItem::Compound(&[
+            FormatItem::Literal(b"."),
+            FormatItem::Component(Component::Subsecond(<modifier::Subsecond>::default())),
+        ])),
+    ])),
 ];
 
 impl Serialize for Time {

--- a/tests/integration/serde.rs
+++ b/tests/integration/serde.rs
@@ -1,4 +1,6 @@
-use serde_test::{assert_de_tokens_error, assert_tokens, Compact, Configure, Readable, Token};
+use serde_test::{
+    assert_de_tokens, assert_de_tokens_error, assert_tokens, Compact, Configure, Readable, Token,
+};
 use time::macros::{date, datetime, offset, time};
 use time::{Date, Duration, Month, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset, Weekday};
 
@@ -45,6 +47,15 @@ fn time() {
     assert_tokens(
         &time!(23:58:59.123_456_789).readable(),
         &[Token::BorrowedStr("23:58:59.123456789")],
+    );
+    assert_de_tokens::<Readable<Time>>(
+        &time!(23:58:59).readable(),
+        &[Token::BorrowedStr("23:58:59")],
+    );
+    assert_de_tokens::<Readable<Time>>(&time!(23:58).readable(), &[Token::BorrowedStr("23:58")]);
+    assert_de_tokens_error::<Readable<Time>>(
+        &[Token::BorrowedStr("24:00.0")],
+        "invalid value: literal, expected no extraneous characters",
     );
     assert_de_tokens_error::<Readable<Time>>(
         &[Token::BorrowedStr("24:00:00.0")],


### PR DESCRIPTION
Serialized times are often written in different human readable formats than strictly hh:mm:ss.ms

This also makes deserializer behavior closer to the time!() macro