### PR TITLE
Add RFC2822 well-known format

### DIFF
--- a/src/format_description/mod.rs
+++ b/src/format_description/mod.rs
@@ -61,6 +61,31 @@ pub mod well_known {
     /// ```
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct Rfc3339;
+
+    /// The format described in [RFC 2822](https://tools.ietf.org/html/rfc2822#section-3.3).
+    ///
+    /// Example: Fri, 21 Nov 1997 09:55:06 -0600
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use time::{format_description::well_known::Rfc2822, macros::datetime, OffsetDateTime};
+    /// assert_eq!(
+    ///     OffsetDateTime::parse("Sat, 12 Jun 1993 13:25:19 GMT", &Rfc2822)?,
+    ///     datetime!(1993-06-12 13:25:19 +00:00)
+    /// );
+    /// # Ok::<_, time::Error>(())
+    /// ```
+    ///
+    /// ```rust
+    /// # use time::{format_description::well_known::Rfc2822, macros::datetime};
+    /// assert_eq!(
+    ///     datetime!(1997-11-21 09:55:06 -06:00).format(&Rfc2822)?,
+    ///     "Fri, 21 Nov 1997 09:55:06 -0600"
+    /// );
+    /// # Ok::<_, time::Error>(())
+    /// ```
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct Rfc2822;
 }
 
 /// A complete description of how to format and parse a type.

--- a/src/formatting/formattable.rs
+++ b/src/formatting/formattable.rs
@@ -135,7 +135,7 @@ impl sealed::Sealed for Rfc2822 {
         bytes += write(output, b", ")?;
         bytes += format_number_pad_zero::<_, _, 2>(output, day)?;
         bytes += write(output, b" ")?;
-        bytes += write(output, &MONTH_NAMES[month as u8 as usize - 1][..3])?;
+        bytes += write(output, &MONTH_NAMES[month as usize - 1][..3])?;
         bytes += write(output, b" ")?;
         bytes += format_number_pad_zero::<_, _, 4>(output, year as u32)?;
         bytes += write(output, b" ")?;

--- a/src/parsing/combinator/rfc/mod.rs
+++ b/src/parsing/combinator/rfc/mod.rs
@@ -1,0 +1,8 @@
+//! Combinators for rules as defined in an RFC.
+//!
+//! These rules have been converted strictly following the ABNF syntax as specified in [RFC 2234].
+//!
+//! [RFC 2234]: https://datatracker.ietf.org/doc/html/rfc2234
+
+pub(crate) mod rfc2234;
+pub(crate) mod rfc2822;

--- a/src/parsing/combinator/rfc/rfc2234.rs
+++ b/src/parsing/combinator/rfc/rfc2234.rs
@@ -1,0 +1,13 @@
+//! Rules defined in [RFC 2234].
+//!
+//! [RFC 2234]: https://datatracker.ietf.org/doc/html/rfc2234
+
+use crate::parsing::ParsedItem;
+
+/// Consume exactly one space or tab.
+pub(crate) const fn wsp(input: &[u8]) -> Option<ParsedItem<'_, ()>> {
+    match input {
+        [b' ', rest @ ..] | [b'\t', rest @ ..] => Some(ParsedItem(rest, ())),
+        _ => None,
+    }
+}

--- a/src/parsing/combinator/rfc/rfc2822.rs
+++ b/src/parsing/combinator/rfc/rfc2822.rs
@@ -1,0 +1,120 @@
+//! Rules defined in [RFC 2822].
+//!
+//! [RFC 2822]: https://datatracker.ietf.org/doc/html/rfc2822
+
+use crate::parsing::combinator::rfc::rfc2234::wsp;
+use crate::parsing::combinator::{ascii_char, one_or_more, zero_or_more};
+use crate::parsing::ParsedItem;
+
+/// Consume the `fws` rule.
+// The full rule is equivalent to /\r\n[ \t]+|[ \t]+(?:\r\n[ \t]+)*/
+pub(crate) fn fws(mut input: &[u8]) -> Option<ParsedItem<'_, ()>> {
+    if let [b'\r', b'\n', rest @ ..] = input {
+        one_or_more(wsp)(rest)
+    } else {
+        input = one_or_more(wsp)(input)?.into_inner();
+        while let [b'\r', b'\n', rest @ ..] = input {
+            input = one_or_more(wsp)(rest)?.into_inner();
+        }
+        Some(ParsedItem(input, ()))
+    }
+}
+
+/// Consume the `cfws` rule.
+// The full rule is equivalent to any combination of `fws` and `comment` so long as it is not empty.
+pub(crate) fn cfws(input: &[u8]) -> Option<ParsedItem<'_, ()>> {
+    one_or_more(|input| fws(input).or_else(|| comment(input)))(input)
+}
+
+/// Consume the `comment` rule.
+fn comment(mut input: &[u8]) -> Option<ParsedItem<'_, ()>> {
+    input = ascii_char::<b'('>(input)?.into_inner();
+    input = zero_or_more(fws)(input).into_inner();
+    while let Some(rest) = ccontent(input) {
+        input = rest.into_inner();
+        input = zero_or_more(fws)(input).into_inner();
+    }
+    input = ascii_char::<b')'>(input)?.into_inner();
+
+    Some(ParsedItem(input, ()))
+}
+
+/// Consume the `ccontent` rule.
+fn ccontent(input: &[u8]) -> Option<ParsedItem<'_, ()>> {
+    ctext(input)
+        .or_else(|| quoted_pair(input))
+        .or_else(|| comment(input))
+}
+
+/// Consume the `ctext` rule.
+fn ctext(input: &[u8]) -> Option<ParsedItem<'_, ()>> {
+    no_ws_ctl(input).or_else(|| match input {
+        [33..=39, rest @ ..] | [42..=91, rest @ ..] | [93..=126, rest @ ..] => {
+            Some(ParsedItem(rest, ()))
+        }
+        _ => None,
+    })
+}
+
+/// Consume the `quoted_pair` rule.
+fn quoted_pair(mut input: &[u8]) -> Option<ParsedItem<'_, ()>> {
+    input = ascii_char::<b'\\'>(input)?.into_inner();
+
+    let old_input_len = input.len();
+
+    input = text(input).into_inner();
+
+    // If nothing is parsed, this means we hit the `obs-text` rule and nothing matched. This is
+    // technically a success, but we should still check the `obs-qp` rule to ensure we consume
+    // everything possible.
+    if input.len() == old_input_len {
+        match input {
+            [0..=127, rest @ ..] => Some(ParsedItem(rest, ())),
+            _ => Some(ParsedItem(input, ())),
+        }
+    } else {
+        Some(ParsedItem(input, ()))
+    }
+}
+
+/// Consume the `no_ws_ctl` rule.
+const fn no_ws_ctl(input: &[u8]) -> Option<ParsedItem<'_, ()>> {
+    match input {
+        [1..=8, rest @ ..] | [11..=12, rest @ ..] | [14..=31, rest @ ..] | [127, rest @ ..] => {
+            Some(ParsedItem(rest, ()))
+        }
+        _ => None,
+    }
+}
+
+/// Consume the `text` rule.
+fn text<'a>(input: &'a [u8]) -> ParsedItem<'a, ()> {
+    let new_text = |input: &'a [u8]| match input {
+        [1..=9, rest @ ..] | [11..=12, rest @ ..] | [14..=127, rest @ ..] => {
+            Some(ParsedItem(rest, ()))
+        }
+        _ => None,
+    };
+
+    let obs_char = |input: &'a [u8]| match input {
+        // This is technically allowed, but consuming this would mean the rest of the string is
+        // eagerly consumed without consideration for where the comment actually ends.
+        [b')', ..] => None,
+        [0..=9, rest @ ..] | [11..=12, rest @ ..] | [14..=127, rest @ ..] => Some(rest),
+        _ => None,
+    };
+
+    let obs_text = |mut input| {
+        input = zero_or_more(ascii_char::<b'\n'>)(input).into_inner();
+        input = zero_or_more(ascii_char::<b'\r'>)(input).into_inner();
+        while let Some(rest) = obs_char(input) {
+            input = rest;
+            input = zero_or_more(ascii_char::<b'\n'>)(input).into_inner();
+            input = zero_or_more(ascii_char::<b'\r'>)(input).into_inner();
+        }
+
+        ParsedItem(input, ())
+    };
+
+    new_text(input).unwrap_or_else(|| obs_text(input))
+}

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -33,6 +33,7 @@ impl<'a, T> ParsedItem<'a, T> {
     }
 
     /// Assign the stored value to the provided target. The remaining input is returned.
+    #[must_use = "this returns the remaining input"]
     pub(crate) fn assign_value_to(self, target: &mut Option<T>) -> &'a [u8] {
         *target = Some(self.1);
         self.0
@@ -41,6 +42,15 @@ impl<'a, T> ParsedItem<'a, T> {
 
 impl<'a> ParsedItem<'a, ()> {
     /// Discard the unit value, returning the remaining input.
+    #[must_use = "this returns the remaining input"]
+    pub(crate) const fn into_inner(self) -> &'a [u8] {
+        self.0
+    }
+}
+
+impl<'a> ParsedItem<'a, Option<()>> {
+    /// Discard the potential unit value, returning the remaining input.
+    #[must_use = "this returns the remaining input"]
     pub(crate) const fn into_inner(self) -> &'a [u8] {
         self.0
     }

--- a/tests/integration/derives.rs
+++ b/tests/integration/derives.rs
@@ -130,6 +130,7 @@ fn debug() {
         Instant::now();
         error::ParseFromDescription::InvalidComponent("foo");
         error::Format::InvalidComponent("foo");
+        well_known::Rfc2822;
         well_known::Rfc3339;
         component_range_error();
         Error::ConversionRange(ConversionRange);

--- a/tests/integration/derives.rs
+++ b/tests/integration/derives.rs
@@ -47,6 +47,7 @@ fn clone() {
     assert_cloned_eq!(error::DifferentVariant);
     assert_cloned_eq!(error::ParseFromDescription::InvalidComponent("foo"));
     assert_cloned_eq!(Component::OffsetSecond(modifier::OffsetSecond::default()));
+    assert_cloned_eq!(well_known::Rfc2822);
     assert_cloned_eq!(well_known::Rfc3339);
     assert_cloned_eq!(component_range_error());
     assert_cloned_eq!(FormatItem::Literal(b""));

--- a/tests/integration/formatting.rs
+++ b/tests/integration/formatting.rs
@@ -1,9 +1,36 @@
 use std::io::{self, ErrorKind};
 
-use time::format_description::well_known::Rfc3339;
+use time::format_description::well_known::{Rfc2822, Rfc3339};
 use time::format_description::{self, FormatItem};
 use time::macros::{date, datetime, format_description as fd, offset, time};
 use time::{OffsetDateTime, Time};
+
+#[test]
+fn rfc_2822() -> time::Result<()> {
+    assert_eq!(
+        datetime!(2021-01-02 03:04:05 UTC).format(&Rfc2822)?,
+        "Sat, 02 Jan 2021 03:04:05 +0000"
+    );
+    assert_eq!(
+        datetime!(2021-01-02 03:04:05 +06:07).format(&Rfc2822)?,
+        "Sat, 02 Jan 2021 03:04:05 +0607"
+    );
+    assert_eq!(
+        datetime!(2021-01-02 03:04:05 -06:07).format(&Rfc2822)?,
+        "Sat, 02 Jan 2021 03:04:05 -0607"
+    );
+
+    assert!(matches!(
+        datetime!(1885-01-01 01:01:01 UTC).format(&Rfc2822),
+        Err(time::error::Format::InvalidComponent("year"))
+    ));
+    assert!(matches!(
+        datetime!(2000-01-01 00:00:00 +00:00:01).format(&Rfc2822),
+        Err(time::error::Format::InvalidComponent("offset_second"))
+    ));
+
+    Ok(())
+}
 
 #[test]
 fn rfc_3339() -> time::Result<()> {

--- a/tests/integration/formatting.rs
+++ b/tests/integration/formatting.rs
@@ -377,6 +377,9 @@ fn insufficient_type_information() {
     assert_insufficient_type_information(Time::MIDNIGHT.format(&Rfc3339));
     assert_insufficient_type_information(date!(2021 - 001).format(&Rfc3339));
     assert_insufficient_type_information(datetime!(2021 - 001 0:00).format(&Rfc3339));
+    assert_insufficient_type_information(Time::MIDNIGHT.format(&Rfc2822));
+    assert_insufficient_type_information(date!(2021 - 001).format(&Rfc2822));
+    assert_insufficient_type_information(datetime!(2021 - 001 0:00).format(&Rfc2822));
     assert_insufficient_type_information(
         Time::MIDNIGHT.format(&FormatItem::First(&[FormatItem::Compound(fd!("[year]"))])),
     );
@@ -420,6 +423,26 @@ fn failed_write() -> time::Result<()> {
     assert_err(datetime!(2021-001 0:00 +0:01).format_into(bytes!(20), &Rfc3339));
     assert_err(datetime!(2021-001 0:00 +0:01).format_into(bytes!(22), &Rfc3339));
     assert_err(datetime!(2021-001 0:00 +0:01).format_into(bytes!(23), &Rfc3339));
+
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(0), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(4), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(6), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(7), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(8), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(11), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(12), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(16), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(17), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(19), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(20), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(22), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(23), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(25), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(26), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(27), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(29), &Rfc2822));
+    assert_err(OffsetDateTime::UNIX_EPOCH.format_into(bytes!(30), &Rfc2822));
+
     assert_err(Time::MIDNIGHT.format_into(bytes!(0), fd!("[hour padding:space]")));
     assert_err(Time::MIDNIGHT.format_into(bytes!(1), fd!("[hour padding:space]")));
     assert_err(offset!(+1).format_into(bytes!(0), fd!("[offset_hour sign:mandatory]")));

--- a/tests/integration/parsing.rs
+++ b/tests/integration/parsing.rs
@@ -49,6 +49,7 @@ fn rfc_2822() -> time::Result<()> {
         Time::parse("Sat, 02 Jan 2021 03:04:05 GMT", &Rfc2822)?,
         time!(03:04:05)
     );
+
     Ok(())
 }
 

--- a/tests/integration/parsing.rs
+++ b/tests/integration/parsing.rs
@@ -1,7 +1,7 @@
 use core::convert::{TryFrom, TryInto};
 use std::num::NonZeroU8;
 
-use time::format_description::well_known::Rfc3339;
+use time::format_description::well_known::{Rfc2822, Rfc3339};
 use time::format_description::{modifier, Component, FormatItem};
 use time::macros::{date, datetime, time};
 use time::parsing::Parsed;
@@ -9,6 +9,48 @@ use time::{
     error, format_description as fd, Date, Month, OffsetDateTime, PrimitiveDateTime, Time,
     UtcOffset, Weekday,
 };
+
+#[test]
+fn rfc_2822() -> time::Result<()> {
+    assert_eq!(
+        OffsetDateTime::parse("Sat, 02 Jan 2021 03:04:05 GMT", &Rfc2822)?,
+        datetime!(2021-01-02 03:04:05 UTC),
+    );
+    assert_eq!(
+        OffsetDateTime::parse("Sat, 02 Jan 2021 03:04:05 UT", &Rfc2822)?,
+        datetime!(2021-01-02 03:04:05 UTC),
+    );
+    assert_eq!(
+        OffsetDateTime::parse("Sat, 02 Jan 2021 03:04:05 +0000", &Rfc2822)?,
+        datetime!(2021-01-02 03:04:05 UTC),
+    );
+    assert_eq!(
+        OffsetDateTime::parse("Sat, 02 Jan 2021 03:04:05 +0607", &Rfc2822)?,
+        datetime!(2021-01-02 03:04:05 +06:07),
+    );
+    assert_eq!(
+        OffsetDateTime::parse("Sat, 02 Jan 2021 03:04:05 -0607", &Rfc2822)?,
+        datetime!(2021-01-02 03:04:05 -06:07),
+    );
+
+    assert_eq!(
+        Date::parse("Sat, 02 Jan 2021 03:04:05 GMT", &Rfc2822)?,
+        date!(2021 - 01 - 02)
+    );
+    assert_eq!(
+        Date::parse("Sat, 02 Jan 2021 03:04:05 +0607", &Rfc2822)?,
+        date!(2021 - 01 - 02)
+    );
+    assert_eq!(
+        Date::parse("Sat, 02 Jan 2021 03:04:05 -0607", &Rfc2822)?,
+        date!(2021 - 01 - 02)
+    );
+    assert_eq!(
+        Time::parse("Sat, 02 Jan 2021 03:04:05 GMT", &Rfc2822)?,
+        time!(03:04:05)
+    );
+    Ok(())
+}
 
 #[test]
 fn rfc_3339() -> time::Result<()> {


### PR DESCRIPTION
Closes #399.

I've tried to stick to the robustness principle to a reasonable degree in the implementation, and included handling for obsolete parts of the RFC which seemed likely to be encountered.

<del>One of the doc tests fails with an error about the `Rfc2822` struct not implementing `Deref` which I'm not able to make sense of.</del> fixed