### PR TITLE
Mention in documentation, that Instant has no serde support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //! - `serde`
 //!
-//!   Enables [serde](https://docs.rs/serde) support for all types.
+//!   Enables [serde](https://docs.rs/serde) support for all types except [`Instant`].
 //!
 //! - `serde-human-readable` (_implicitly enables `serde`, `formatting`, and `parsing`_)
 //!


### PR DESCRIPTION
Hey, 

This solves https://github.com/time-rs/time/issues/431, by making clear in the documentation, that `Instant` has no `serde` support.  Thanks for getting back to me so quickly :)