### PR TITLE
OffsetDateTime: Add conversions to PrimitiveDateTime

### DIFF
--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -107,6 +107,41 @@ impl OffsetDateTime {
         }
     }
 
+    /// Obtain the corresponding UTC timestamp without offset as [`PrimitiveDateTime`].
+    ///
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2018-12-31 23:00:00),
+    ///     datetime!(2019-01-01 01:00:00 +02:00).to_primitive_utc(),
+    /// );
+    /// ```
+    pub fn to_primitive_utc(self) -> PrimitiveDateTime {
+        let Self {
+            utc_datetime,
+            offset: _,
+        } = self;
+        utc_datetime
+    }
+
+    /// Obtain the corresponding timestamp including the UTC offset as [`PrimitiveDateTime`].
+    ///
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2019-01-01 01:00:00),
+    ///     datetime!(2019-01-01 01:00:00 +02:00).to_primitive_offset(),
+    /// );
+    /// ```
+    pub fn to_primitive_offset(self) -> PrimitiveDateTime {
+        let Self {
+            utc_datetime,
+            offset,
+        } = self;
+        let utc_offset = Duration::seconds(offset.whole_seconds().into());
+        utc_datetime + utc_offset
+    }
+
     // region: constructors
     /// Create an `OffsetDateTime` from the provided Unix timestamp. Calling `.offset()` on the
     /// resulting value is guaranteed to return UTC.


### PR DESCRIPTION
A `PrimitiveDateTime` can be converted conveniently into `OffsetDateTime` with `assume_utc()` and `assume_offset()`. What is currently missing are conversion functions in the opposite direction.

This PR adds the missing functions to `OffsetDateTime` to accomplish these conversions efficiently. It is doable with the public 0.3.7 API but would require intermediate conversions which might not be optimized away.

The naming is descriptive yet verbose and could be improved.