### PR TITLE
Use `deserialize_str` for well-known formats

### DIFF
--- a/src/serde/rfc2822.rs
+++ b/src/serde/rfc2822.rs
@@ -27,7 +27,7 @@ pub fn serialize<S: Serializer>(
 
 /// Deserialize an [`OffsetDateTime`] from its RFC2822 representation.
 pub fn deserialize<'a, D: Deserializer<'a>>(deserializer: D) -> Result<OffsetDateTime, D::Error> {
-    deserializer.deserialize_any(Visitor::<Rfc2822>(PhantomData))
+    deserializer.deserialize_str(Visitor::<Rfc2822>(PhantomData))
 }
 
 /// Use the well-known [RFC2822 format] when serializing and deserializing an

--- a/src/serde/rfc3339.rs
+++ b/src/serde/rfc3339.rs
@@ -27,7 +27,7 @@ pub fn serialize<S: Serializer>(
 
 /// Deserialize an [`OffsetDateTime`] from its RFC3339 representation.
 pub fn deserialize<'a, D: Deserializer<'a>>(deserializer: D) -> Result<OffsetDateTime, D::Error> {
-    deserializer.deserialize_any(Visitor::<Rfc3339>(PhantomData))
+    deserializer.deserialize_str(Visitor::<Rfc3339>(PhantomData))
 }
 
 /// Use the well-known [RFC3339 format] when serializing and deserializing an


### PR DESCRIPTION
Follow-up to #466, these formats are all strings, so `deserialize_str` should be fine instead of `deserialize_any`.