### PR TITLE
 Parse nulls as None on nested serde structs 

### DIFF
--- a/src/serde/visitor.rs
+++ b/src/serde/visitor.rs
@@ -299,6 +299,10 @@ macro_rules! well_known {
             fn visit_none<E: de::Error>(self) -> Result<Option<OffsetDateTime>, E> {
                 Ok(None)
             }
+
+            fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+                Ok(None)
+            }
         }
     };
 }

--- a/tests/integration/serde/mod.rs
+++ b/tests/integration/serde/mod.rs
@@ -5,6 +5,7 @@ use time::{Date, Duration, Month, OffsetDateTime, PrimitiveDateTime, Time, UtcOf
 mod error_conditions;
 mod iso8601;
 mod macros;
+mod rfc2822;
 mod rfc3339;
 mod timestamps;
 

--- a/tests/integration/serde/rfc2822.rs
+++ b/tests/integration/serde/rfc2822.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Serialize};
+use serde_test::{assert_tokens, Configure, Token};
+use time::serde::rfc2822;
+use time::OffsetDateTime;
+use time_macros::datetime;
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+struct Test {
+    #[serde(with = "rfc2822")]
+    dt: OffsetDateTime,
+    #[serde(with = "rfc2822::option")]
+    option_dt: Option<OffsetDateTime>,
+}
+
+#[test]
+fn serialize_deserialize() {
+    let value = Test {
+        dt: datetime!(2000-01-01 00:00:00 UTC),
+        option_dt: Some(datetime!(2000-01-01 00:00:00 UTC)),
+    };
+    assert_tokens(
+        &value.compact(),
+        &[
+            Token::Struct {
+                name: "Test",
+                len: 2,
+            },
+            Token::Str("dt"),
+            Token::BorrowedStr("Sat, 01 Jan 2000 00:00:00 +0000"),
+            Token::Str("option_dt"),
+            Token::Some,
+            Token::BorrowedStr("Sat, 01 Jan 2000 00:00:00 +0000"),
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
+fn parse_json() {
+    #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+    #[serde(untagged)]
+    enum Wrapper {
+        A(Test),
+    }
+    assert_eq!(
+        serde_json::from_str::<Wrapper>(
+            r#"{"dt": "Sat, 01 Jan 2000 00:00:00 +0000", "option_dt": null}"#
+        )
+        .unwrap(),
+        Wrapper::A(Test {
+            dt: datetime!(2000-01-01 00:00:00 UTC),
+            option_dt: None,
+        })
+    );
+}

--- a/tests/integration/serde/rfc3339.rs
+++ b/tests/integration/serde/rfc3339.rs
@@ -15,7 +15,7 @@ struct Test {
 }
 
 #[test]
-fn serialize() {
+fn serialize_deserialize() {
     let value = Test {
         dt: datetime!(2000-01-01 00:00:00 UTC),
         option_dt: Some(datetime!(2000-01-01 00:00:00 UTC)),
@@ -79,5 +79,22 @@ fn serialize() {
             Token::Str("dt"),
         ],
         "The offset_second component cannot be formatted into the requested format.",
+    );
+}
+
+#[test]
+fn parse_json() {
+    #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+    #[serde(untagged)]
+    enum Wrapper {
+        A(Test),
+    }
+    assert_eq!(
+        serde_json::from_str::<Wrapper>("{\"dt\": \"2000-01-01T00:00:00Z\", \"option_dt\": null}")
+            .unwrap(),
+        Wrapper::A(Test {
+            dt: datetime!(2000-01-01 00:00:00 UTC),
+            option_dt: None,
+        })
     );
 }


### PR DESCRIPTION
When parsing a structure nested inside an untagged enum serde treats
keys with a null value as Unit instead of calling visit_none.  This
causes an error of "invalid type: null, expected an
RFC3339-formatted `Option<OffsetDateTime>`".  This change just adds an
implementation for visit_unit so the value will be parsed as None as
expected.