### PR TITLE
Add direct doc example for `datetime!` macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,6 +30,24 @@ pub use time_macros::date;
 ///
 /// [`OffsetDateTime`]: crate::OffsetDateTime
 /// [`PrimitiveDateTime`]: crate::PrimitiveDateTime
+///
+/// ```rust
+/// # use time::{Date, Month, macros::datetime, UtcOffset};
+/// assert_eq!(
+///     datetime!(2020-01-01 0:00),
+///     Date::from_calendar_date(2020, Month::January, 1)?.midnight()
+/// );
+/// assert_eq!(
+///     datetime!(2020-01-01 0:00 UTC),
+///     Date::from_calendar_date(2020, Month::January, 1)?.midnight().assume_utc()
+/// );
+/// assert_eq!(
+///     datetime!(2020-01-01 0:00 -1),
+///     Date::from_calendar_date(2020, Month::January, 1)?.midnight()
+///         .assume_offset(UtcOffset::from_hms(-1, 0, 0)?)
+/// );
+/// # Ok::<_, time::Error>(())
+/// ```
 pub use time_macros::datetime;
 /// Equivalent of performing [`format_description::parse()`] at compile time.
 ///


### PR DESCRIPTION
# Motivation

When using this crate, I wanted to create a PrimitiveDateTime. But I struggled to find how to create one. Eventually I landed on the datetime!() macro, but it didn't have an example usage. 

Now I know that `datetime!()` usage exemples are all over the doc, but  it's difficult to figure out the format from that, and there's no example in the exported macro tiself. This PR fixes that.