### PR TITLE
WASM support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ time-macros = { version = "=0.2.4", path = "time-macros", optional = true }
 libc = "0.2.98"
 num_threads = "0.1.2"
 
+[target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
+js-sys = "0.3.58"
+
 [dev-dependencies]
 rand = { version = "0.8.4", default-features = false }
 serde = { version = "1.0.126", default-features = false, features = ["derive"] }

--- a/src/sys/local_offset_at/mod.rs
+++ b/src/sys/local_offset_at/mod.rs
@@ -2,6 +2,13 @@
 
 #[cfg_attr(target_family = "windows", path = "windows.rs")]
 #[cfg_attr(target_family = "unix", path = "unix.rs")]
+#[cfg_attr(
+    all(
+        target_arch = "wasm32",
+        not(any(target_os = "emscripten", target_os = "wasi"))
+    ),
+    path = "wasm_js.rs"
+)]
 mod imp;
 
 use crate::{OffsetDateTime, UtcOffset};

--- a/src/sys/local_offset_at/wasm_js.rs
+++ b/src/sys/local_offset_at/wasm_js.rs
@@ -1,0 +1,12 @@
+use crate::{OffsetDateTime, UtcOffset};
+
+/// Obtain the system's UTC offset.
+pub(super) fn local_offset_at(datetime: OffsetDateTime) -> Option<UtcOffset> {
+    let js_date: js_sys::Date = datetime.into();
+    // The number of minutes returned by getTimezoneOffset() is positive if the local time zone
+    // is behind UTC, and negative if the local time zone is ahead of UTC. For example,
+    // for UTC+10, -600 will be returned.
+    let timezone_offset = (js_date.get_timezone_offset() as i32) * -60;
+
+    UtcOffset::from_whole_seconds(timezone_offset).ok()
+}


### PR DESCRIPTION
This PR allows using `time` with WebAssembly, resolving #490.

# Concerns

## Transitive dependecies

When on a wasm target, `js-sys` depends on `wasm-bindgen`, which pulls `syn` and `quote` among others:

```
time v0.3.11 (/home/xy/work/time)
├── js-sys v0.3.58
│   └── wasm-bindgen v0.2.81
│       ├── cfg-if v1.0.0
│       └── wasm-bindgen-macro v0.2.81 (proc-macro)
│           ├── quote v1.0.20
│           │   └── proc-macro2 v1.0.40
│           │       └── unicode-ident v1.0.2
│           └── wasm-bindgen-macro-support v0.2.81
│               ├── proc-macro2 v1.0.40 (*)
│               ├── quote v1.0.20 (*)
│               ├── syn v1.0.98
│               │   ├── proc-macro2 v1.0.40 (*)
│               │   ├── quote v1.0.20 (*)
│               │   └── unicode-ident v1.0.2
│               ├── wasm-bindgen-backend v0.2.81
│               │   ├── bumpalo v3.10.0
│               │   ├── lazy_static v1.4.0
│               │   ├── log v0.4.17
│               │   │   └── cfg-if v1.0.0
│               │   ├── proc-macro2 v1.0.40 (*)
│               │   ├── quote v1.0.20 (*)
│               │   ├── syn v1.0.98 (*)
│               │   └── wasm-bindgen-shared v0.2.81
│               └── wasm-bindgen-shared v0.2.81
├── libc v0.2.126
└── num_threads v0.1.6
[dev-dependencies]
...
```

## Invalid JS dates

```
let dt = new Date(NaN);
passToRust(dt);
```
These dates are interpreted by `js-sys` as having timestamp 0, and will return a valid date (January 1, 1970).