### PR TITLE
Gate js-sys dependency behind 'wasm-bindgen' feature (#496)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ quickcheck = ["quickcheck-dep", "alloc"]
 serde-human-readable = ["serde", "formatting", "parsing"]
 serde-well-known = ["serde/alloc", "formatting", "parsing"] # use case for weak feature dependencies (`alloc` could just require `serde?.alloc`)
 std = ["alloc"]
+wasm-bindgen = ["js-sys"]
 
 [dependencies]
 itoa = { version = "1.0.1", optional = true }
@@ -50,7 +51,7 @@ libc = "0.2.98"
 num_threads = "0.1.2"
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
-js-sys = "0.3.58"
+js-sys = { version = "0.3.58", optional = true }
 
 [dev-dependencies]
 rand = { version = "0.8.4", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,12 @@
 //!
 //!   Enables [quickcheck](https://docs.rs/quickcheck) support for all types except [`Instant`].
 //!
+//! - `wasm-bindgen`
+//!
+//!   Enables [wasm-bindgen](https://github.com/rustwasm/wasm-bindgen) support for converting
+//!   [JavaScript dates](https://rustwasm.github.io/wasm-bindgen/api/js_sys/struct.Date.html), as
+//!   well as obtaining the UTC offset from JavaScript.
+//!
 //! One pseudo-feature flag that is only available to end users is the `unsound_local_offset` cfg.
 //! As the name indicates, using the feature is unsound, and [may cause unexpected segmentation
 //! faults](https://github.com/time-rs/time/issues/293). Unlike other flags, this is deliberately

--- a/src/offset_date_time.rs
+++ b/src/offset_date_time.rs
@@ -59,7 +59,8 @@ impl OffsetDateTime {
     pub fn now_utc() -> Self {
         #[cfg(all(
             target_arch = "wasm32",
-            not(any(target_os = "emscripten", target_os = "wasi"))
+            not(any(target_os = "emscripten", target_os = "wasi")),
+            feature = "wasm-bindgen"
         ))]
         {
             js_sys::Date::new_0().into()
@@ -67,7 +68,8 @@ impl OffsetDateTime {
 
         #[cfg(not(all(
             target_arch = "wasm32",
-            not(any(target_os = "emscripten", target_os = "wasi"))
+            not(any(target_os = "emscripten", target_os = "wasi")),
+            feature = "wasm-bindgen"
         )))]
         SystemTime::now().into()
     }
@@ -1301,7 +1303,8 @@ impl From<OffsetDateTime> for SystemTime {
 #[allow(clippy::fallible_impl_from)]
 #[cfg(all(
     target_arch = "wasm32",
-    not(any(target_os = "emscripten", target_os = "wasi"))
+    not(any(target_os = "emscripten", target_os = "wasi")),
+    feature = "wasm-bindgen"
 ))]
 impl From<js_sys::Date> for OffsetDateTime {
     fn from(js_date: js_sys::Date) -> Self {
@@ -1314,7 +1317,8 @@ impl From<js_sys::Date> for OffsetDateTime {
 
 #[cfg(all(
     target_arch = "wasm32",
-    not(any(target_os = "emscripten", target_os = "wasi"))
+    not(any(target_os = "emscripten", target_os = "wasi")),
+    feature = "wasm-bindgen"
 ))]
 impl From<OffsetDateTime> for js_sys::Date {
     fn from(datetime: OffsetDateTime) -> Self {

--- a/src/sys/local_offset_at/mod.rs
+++ b/src/sys/local_offset_at/mod.rs
@@ -5,7 +5,8 @@
 #[cfg_attr(
     all(
         target_arch = "wasm32",
-        not(any(target_os = "emscripten", target_os = "wasi"))
+        not(any(target_os = "emscripten", target_os = "wasi")),
+        feature = "wasm-bindgen"
     ),
     path = "wasm_js.rs"
 )]


### PR DESCRIPTION
This pr fixes the breaking change of time 0.3.12.