### PR TITLE
Add impl of arbitrary::Arbitrary for types

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
             --feature-powerset
             --optional-deps
             --group-features serde,rand
-            --exclude-features default,std,formatting,serde-human-readable,serde-well-known,local-offset,quickcheck,quickcheck-dep,time-macros,itoa,js-sys,wasm-bindgen
+            --exclude-features default,std,formatting,serde-human-readable,serde-well-known,local-offset,quickcheck,quickcheck-dep,time-macros,itoa,js-sys,wasm-bindgen,arbitrary,arbitrary-dep
             --features macros
             --exclude-all-features
             --target ${{ matrix.target.triple }}
@@ -106,7 +106,7 @@ jobs:
             --group-features serde,rand
             --group-features formatting,parsing
             --group-features serde-human-readable,serde-well-known
-            --exclude-features default,quickcheck-dep,time-macros,itoa,js-sys,wasm-bindgen
+            --exclude-features default,quickcheck-dep,time-macros,itoa,js-sys,wasm-bindgen,arbitrary,arbitrary-dep
             --features macros,local-offset
             --target ${{ matrix.target.triple }}
         if: matrix.target.has_std == true && matrix.target.has_local_offset == false
@@ -123,7 +123,7 @@ jobs:
             --group-features serde,rand
             --group-features formatting,parsing
             --group-features serde-human-readable,serde-well-known
-            --exclude-features default,quickcheck-dep,time-macros,itoa,js-sys,wasm-bindgen
+            --exclude-features default,quickcheck-dep,time-macros,itoa,js-sys,wasm-bindgen,arbitrary,arbitrary-dep
             --features macros
             --target ${{ matrix.target.triple }}
         if: matrix.target.has_std == true && matrix.target.has_local_offset == true
@@ -207,7 +207,7 @@ jobs:
             --group-features serde,rand
             --group-features formatting,parsing
             --group-features serde-human-readable,serde-well-known
-            --exclude-features default,quickcheck-dep,time-macros,itoa,js-sys,wasm-bindgen
+            --exclude-features default,quickcheck-dep,time-macros,itoa,js-sys,wasm-bindgen,arbitrary,arbitrary-dep
             --features macros
         if: matrix.os.has_local_offset == true
 

--- a/.github/workflows/powerset.yaml
+++ b/.github/workflows/powerset.yaml
@@ -105,7 +105,7 @@ jobs:
             --clean-per-version
             --feature-powerset
             --optional-deps
-            --exclude-features default,std,local-offset,quickcheck,quickcheck-dep,time-macros,formatting,itoa,serde-human-readable,serde-well-known,js-sys,wasm-bindgen
+            --exclude-features default,std,local-offset,quickcheck,quickcheck-dep,time-macros,formatting,itoa,serde-human-readable,serde-well-known,js-sys,wasm-bindgen,arbitrary,arbitrary-dep
             --exclude-all-features
             --target ${{ matrix.target.triple }}
         if: matrix.target.has_std == false
@@ -121,7 +121,7 @@ jobs:
             --clean-per-version
             --feature-powerset
             --optional-deps
-            --exclude-features default,quickcheck-dep,time-macros,itoa,js-sys,wasm-bindgen
+            --exclude-features default,quickcheck-dep,time-macros,itoa,js-sys,wasm-bindgen,arbitrary,arbitrary-dep
             --target ${{ matrix.target.triple }}
         if: matrix.target.has_std == true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ local-offset = ["std"]
 macros = ["time-macros"]
 parsing = []
 quickcheck = ["quickcheck-dep", "alloc"]
+arbitrary = ["arbitrary-dep", "alloc"]
 serde-human-readable = ["serde", "formatting", "parsing"]
 serde-well-known = ["serde/alloc", "formatting", "parsing"] # use case for weak feature dependencies (`alloc` could just require `serde?.alloc`)
 std = ["alloc"]
@@ -42,6 +43,7 @@ wasm-bindgen = ["js-sys"]
 [dependencies]
 itoa = { version = "1.0.1", optional = true }
 quickcheck-dep = { package = "quickcheck", version = "1.0.3", default-features = false, optional = true }
+arbitrary-dep = { package = "arbitrary", version = "1.1.3", default-features = false, optional = true }
 rand = { version = "0.8.4", optional = true, default-features = false }
 serde = { version = "1.0.126", optional = true, default-features = false }
 time-macros = { version = "=0.2.4", path = "time-macros", optional = true }

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -25,7 +25,7 @@
 //! relation to a [`Duration`], and obtaining an `Instant` from a [`Duration`] is very simple
 //! anyway.
 
-use arbitrary_dep::{Arbitrary, Result, Unstructured, size_hint};
+use arbitrary_dep::{size_hint, Arbitrary, Result, Unstructured};
 
 use crate::{Date, Duration, Month, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset, Weekday};
 

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1,0 +1,160 @@
+//! Implementations of the [`arbitrary::Arbitrary`](arbitrary_dep::Arbitrary) trait.
+//!
+//! It is generally intended for use with fuzzing using AFL or libFuzzer, but can
+//! also be used to generate random values for a data type
+//!
+//! ```
+//! # use arbitrary_dep::{Arbitrary, Unstructured};
+//! // use arbitrary::{Arbitrary, Unstructured};
+//! use time::PrimitiveDateTime;
+//!
+//! # let get_input_from_fuzzer = || &[];
+//! let raw_data: &[u8] = get_input_from_fuzzer();
+//!
+//! //Wrap it in an `Unstructured`.
+//! let mut unstructured = Unstructured::new(raw_data);
+//!
+//! // Generate an `PrimitiveDateTime` and run our checks
+//! if let Ok(datetime) = PrimitiveDateTime::arbitrary(&mut unstructured) {
+//! #   let run_my_datetime_checks = |_| {};
+//!     run_my_datetime_checks(datetime);
+//! }
+//! ```
+//!
+//! An implementation for `Instant` is intentionally omitted since its values are only meaningful in
+//! relation to a [`Duration`], and obtaining an `Instant` from a [`Duration`] is very simple
+//! anyway.
+
+use arbitrary_dep::{Arbitrary, Result, Unstructured, size_hint};
+
+use crate::{Date, Duration, Month, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset, Weekday};
+
+impl<'a> Arbitrary<'a> for Date {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        u.int_in_range(Self::MIN.to_julian_day()..=Self::MAX.to_julian_day())
+            .map(Self::from_julian_day_unchecked)
+    }
+
+    fn size_hint(_: usize) -> (usize, Option<usize>) {
+        let n = core::mem::size_of::<i32>();
+        (n, Some(n))
+    }
+}
+
+impl<'a> Arbitrary<'a> for Duration {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        u.int_in_range(Self::MIN.whole_nanoseconds()..=Self::MAX.whole_nanoseconds())
+            .map(Self::nanoseconds_i128)
+    }
+
+    fn size_hint(_: usize) -> (usize, Option<usize>) {
+        let n = core::mem::size_of::<i128>();
+        (n, Some(n))
+    }
+}
+
+impl<'a> Arbitrary<'a> for Time {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        let hour = u.int_in_range(0..=23)?;
+        let minute = u.int_in_range(0..=60)?;
+        let second = u.int_in_range(0..=60)?;
+        let nanosecond = u.int_in_range(0..=999_999_999)?;
+        Ok(Self::__from_hms_nanos_unchecked(
+            hour, minute, second, nanosecond,
+        ))
+    }
+
+    fn size_hint(_: usize) -> (usize, Option<usize>) {
+        let _u8 = core::mem::size_of::<u8>();
+        let _u32 = core::mem::size_of::<u32>();
+        size_hint::and_all(&[
+            (_u8, Some(_u8)),
+            (_u8, Some(_u8)),
+            (_u8, Some(_u8)),
+            (_u32, Some(_u32)),
+        ])
+    }
+}
+
+impl<'a> Arbitrary<'a> for PrimitiveDateTime {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        Ok(Self::new(Date::arbitrary(u)?, Time::arbitrary(u)?))
+    }
+
+    fn size_hint(_: usize) -> (usize, Option<usize>) {
+        size_hint::and(Date::size_hint(0), Time::size_hint(0))
+    }
+}
+
+impl<'a> Arbitrary<'a> for UtcOffset {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        u.int_in_range(-86_399..=86_399).map(|seconds| {
+            Self::__from_hms_unchecked(
+                (seconds / 3600) as _,
+                ((seconds % 3600) / 60) as _,
+                (seconds % 60) as _,
+            )
+        })
+    }
+
+    fn size_hint(_: usize) -> (usize, Option<usize>) {
+        let _i8 = core::mem::size_of::<i8>();
+        size_hint::and_all(&[(_i8, Some(_i8)), (_i8, Some(_i8)), (_i8, Some(_i8))])
+    }
+}
+
+impl<'a> Arbitrary<'a> for OffsetDateTime {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        let datetime = PrimitiveDateTime::arbitrary(u)?;
+        Ok(datetime.assume_offset(UtcOffset::arbitrary(u)?))
+    }
+
+    fn size_hint(_: usize) -> (usize, Option<usize>) {
+        size_hint::and(PrimitiveDateTime::size_hint(0), UtcOffset::size_hint(0))
+    }
+}
+
+impl<'a> Arbitrary<'a> for Weekday {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        u.choose(&[
+            Weekday::Monday,
+            Weekday::Tuesday,
+            Weekday::Wednesday,
+            Weekday::Thursday,
+            Weekday::Friday,
+            Weekday::Saturday,
+            Weekday::Sunday,
+        ])
+        .map(|w| *w)
+    }
+
+    fn size_hint(_: usize) -> (usize, Option<usize>) {
+        let n = core::mem::size_of::<u8>();
+        (n, Some(n))
+    }
+}
+
+impl<'a> Arbitrary<'a> for Month {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        u.choose(&[
+            Month::January,
+            Month::February,
+            Month::March,
+            Month::April,
+            Month::May,
+            Month::June,
+            Month::July,
+            Month::August,
+            Month::September,
+            Month::October,
+            Month::November,
+            Month::December,
+        ])
+        .map(|m| *m)
+    }
+
+    fn size_hint(_: usize) -> (usize, Option<usize>) {
+        let n = core::mem::size_of::<u8>();
+        (n, Some(n))
+    }
+}

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -55,8 +55,8 @@ impl<'a> Arbitrary<'a> for Duration {
 impl<'a> Arbitrary<'a> for Time {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         let hour = u.int_in_range(0..=23)?;
-        let minute = u.int_in_range(0..=60)?;
-        let second = u.int_in_range(0..=60)?;
+        let minute = u.int_in_range(0..=59)?;
+        let second = u.int_in_range(0..=59)?;
         let nanosecond = u.int_in_range(0..=999_999_999)?;
         Ok(Self::__from_hms_nanos_unchecked(
             hour, minute, second, nanosecond,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,6 +285,9 @@ macro_rules! const_try_opt {
 }
 // endregion macros
 
+#[cfg(feature = "arbitrary")]
+#[cfg_attr(__time_03_docs, doc(cfg(feature = "arbitrary")))]
+mod arbitrary;
 mod date;
 mod duration;
 pub mod error;
@@ -305,9 +308,6 @@ mod primitive_date_time;
 #[cfg(feature = "quickcheck")]
 #[cfg_attr(__time_03_docs, doc(cfg(feature = "quickcheck")))]
 mod quickcheck;
-#[cfg(feature = "arbitrary")]
-#[cfg_attr(__time_03_docs, doc(cfg(feature = "arbitrary")))]
-mod arbitrary;
 #[cfg(feature = "rand")]
 #[cfg_attr(__time_03_docs, doc(cfg(feature = "rand")))]
 mod rand;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,10 @@
 //!
 //!   Enables [quickcheck](https://docs.rs/quickcheck) support for all types except [`Instant`].
 //!
+//! - `arbitrary` (_implicitly enables `alloc`_)
+//!
+//!   Enables [arbitrary](https://docs.rs/arbitrary) support for all types except [`Instant`].
+//!
 //! - `wasm-bindgen`
 //!
 //!   Enables [wasm-bindgen](https://github.com/rustwasm/wasm-bindgen) support for converting
@@ -301,6 +305,9 @@ mod primitive_date_time;
 #[cfg(feature = "quickcheck")]
 #[cfg_attr(__time_03_docs, doc(cfg(feature = "quickcheck")))]
 mod quickcheck;
+#[cfg(feature = "arbitrary")]
+#[cfg_attr(__time_03_docs, doc(cfg(feature = "arbitrary")))]
+mod arbitrary;
 #[cfg(feature = "rand")]
 #[cfg_attr(__time_03_docs, doc(cfg(feature = "rand")))]
 mod rand;


### PR DESCRIPTION
  Adds implimentations of arbitrary::Arbitrary for the following:
  - Time
  - Duration
  - UtcOffset
  - PrimitiveDateTime
  - OffsetDateTime

Follows from the `quickcheck::Arbitrary` addition.  Otherwise projects using `time` that want to use `arbitrary` for fuzzing need to wrap everything in newtype structs and provide their own impls