### PR TITLE
New Ranges Feature

### DIFF
--- a/tests/main.rs
+++ b/tests/main.rs
@@ -137,6 +137,7 @@ require_all_features! {
     mod macros;
     mod meta;
     mod month;
+    mod offset_date_time_range;
     mod offset_date_time;
     mod parse_format_description;
     mod parsed;

--- a/tests/offset_date_time.rs
+++ b/tests/offset_date_time.rs
@@ -529,6 +529,319 @@ fn replace_nanosecond() -> Result<()> {
 }
 
 #[test]
+fn floor_seconds() {
+    assert_eq!(
+        datetime!(2022-04-18 03:17:12.123_456_789 UTC).floor_seconds(),
+        datetime!(2022-04-18 03:17:12 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-18 03:17:12 UTC).floor_seconds(),
+        datetime!(2022-04-18 03:17:12 UTC)
+    );
+}
+
+#[test]
+fn floor_minutes() {
+    assert_eq!(
+        datetime!(2022-04-18 03:17:12.123_456_789 UTC).floor_minutes(),
+        datetime!(2022-04-18 03:17:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-18 03:17:00 UTC).floor_minutes(),
+        datetime!(2022-04-18 03:17:00 UTC)
+    );
+}
+
+#[test]
+fn floor_hours() {
+    assert_eq!(
+        datetime!(2022-04-18 03:17:12.123_456_789 UTC).floor_hours(),
+        datetime!(2022-04-18 03:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-18 03:00:00 UTC).floor_hours(),
+        datetime!(2022-04-18 03:00:00 UTC)
+    );
+}
+
+#[test]
+fn floor_days() {
+    assert_eq!(
+        datetime!(2022-04-18 03:17:12.123_456_789 UTC).floor_days(),
+        datetime!(2022-04-18 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-18 00:00:00 UTC).floor_days(),
+        datetime!(2022-04-18 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn floor_monday_based_weeks() {
+    assert_eq!(
+        datetime!(2022-04-21 03:17:12.123_456_789 UTC).floor_monday_based_weeks(),
+        datetime!(2022-04-18 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-18 00:00:00 UTC).floor_monday_based_weeks(),
+        datetime!(2022-04-18 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn floor_sunday_based_weeks() {
+    assert_eq!(
+        datetime!(2022-04-21 03:17:12.123_456_789 UTC).floor_sunday_based_weeks(),
+        datetime!(2022-04-17 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-17 00:00:00 UTC).floor_sunday_based_weeks(),
+        datetime!(2022-04-17 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn floor_months() {
+    assert_eq!(
+        datetime!(2022-04-21 03:17:12.123_456_789 UTC).floor_months(),
+        datetime!(2022-04-01 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-01 00:00:00 UTC).floor_months(),
+        datetime!(2022-04-01 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn floor_years() {
+    assert_eq!(
+        datetime!(2022-04-21 03:17:12.123_456_789 UTC).floor_years(),
+        datetime!(2022-01-01 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-01-01 00:00:00 UTC).floor_years(),
+        datetime!(2022-01-01 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn ceil_seconds() {
+    assert_eq!(
+        datetime!(2022-04-18 03:17:12.123_456_789 UTC).ceil_seconds(),
+        datetime!(2022-04-18 03:17:13 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-18 03:17:12 UTC).ceil_seconds(),
+        datetime!(2022-04-18 03:17:12 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-30 23:59:59.5 UTC).next_hour(),
+        datetime!(2022-05-01 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn ceil_minutes() {
+    assert_eq!(
+        datetime!(2022-04-18 03:17:12.123_456_789 UTC).ceil_minutes(),
+        datetime!(2022-04-18 03:18:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-18 03:17:00 UTC).ceil_minutes(),
+        datetime!(2022-04-18 03:17:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-30 23:59:30 UTC).next_hour(),
+        datetime!(2022-05-01 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn ceil_hours() {
+    assert_eq!(
+        datetime!(2022-04-18 03:17:12.123_456_789 UTC).ceil_hours(),
+        datetime!(2022-04-18 04:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-18 03:00:00 UTC).ceil_hours(),
+        datetime!(2022-04-18 03:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-30 23:30:00 UTC).next_hour(),
+        datetime!(2022-05-01 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn ceil_monday_based_weeks() {
+    assert_eq!(
+        datetime!(2022-04-21 03:17:12.123_456_789 UTC).ceil_monday_based_weeks(),
+        datetime!(2022-04-25 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-25 00:00:00 UTC).ceil_monday_based_weeks(),
+        datetime!(2022-04-25 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-25 12:00:00 UTC).next_monday_based_week(),
+        datetime!(2022-05-02 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn ceil_sunday_based_weeks() {
+    assert_eq!(
+        datetime!(2022-04-21 03:17:12.123_456_789 UTC).ceil_sunday_based_weeks(),
+        datetime!(2022-04-24 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-24 00:00:00 UTC).ceil_sunday_based_weeks(),
+        datetime!(2022-04-24 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-24 12:00:00 UTC).next_sunday_based_week(),
+        datetime!(2022-05-01 00:00:00 UTC)
+    );
+}
+
+
+#[test]
+fn ceil_months() {
+    assert_eq!(
+        datetime!(2022-04-21 03:17:12.123_456_789 UTC).ceil_months(),
+        datetime!(2022-05-01 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-01 00:00:00 UTC).ceil_months(),
+        datetime!(2022-04-01 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-12-15 00:00:00 UTC).next_month(),
+        datetime!(2023-01-01 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn ceil_years() {
+    assert_eq!(
+        datetime!(2022-04-21 03:17:12.123_456_789 UTC).ceil_years(),
+        datetime!(2023-01-01 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-01-01 00:00:00 UTC).ceil_years(),
+        datetime!(2022-01-01 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn next_second() {
+    assert_eq!(
+        datetime!(2022-04-18 03:17:12.123_456_789 UTC).next_second(),
+        datetime!(2022-04-18 03:17:13 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-18 03:17:12 UTC).next_second(),
+        datetime!(2022-04-18 03:17:13 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-30 23:59:59 UTC).next_hour(),
+        datetime!(2022-05-01 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn next_minute() {
+    assert_eq!(
+        datetime!(2022-04-18 03:17:12.123_456_789 UTC).next_minute(),
+        datetime!(2022-04-18 03:18:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-18 03:17:00 UTC).next_minute(),
+        datetime!(2022-04-18 03:18:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-30 23:59:00 UTC).next_hour(),
+        datetime!(2022-05-01 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn next_hour() {
+    assert_eq!(
+        datetime!(2022-04-18 03:17:12.123_456_789 UTC).next_hour(),
+        datetime!(2022-04-18 04:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-18 03:00:00 UTC).next_hour(),
+        datetime!(2022-04-18 04:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-30 23:00:00 UTC).next_hour(),
+        datetime!(2022-05-01 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn next_monday_based_week() {
+    assert_eq!(
+        datetime!(2022-04-21 03:17:12.123_456_789 UTC).next_monday_based_week(),
+        datetime!(2022-04-25 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-21 00:00:00 UTC).next_monday_based_week(),
+        datetime!(2022-04-25 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-25 00:00:00 UTC).next_monday_based_week(),
+        datetime!(2022-05-02 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn next_sunday_based_week() {
+    assert_eq!(
+        datetime!(2022-04-15 03:17:12.123_456_789 UTC).next_sunday_based_week(),
+        datetime!(2022-04-17 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-17 00:00:00 UTC).next_sunday_based_week(),
+        datetime!(2022-04-24 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-24 00:00:00 UTC).next_sunday_based_week(),
+        datetime!(2022-05-01 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn next_month() {
+    assert_eq!(
+        datetime!(2022-04-21 03:17:12.123_456_789 UTC).next_month(),
+        datetime!(2022-05-01 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-04-01 00:00:00 UTC).next_month(),
+        datetime!(2022-05-01 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-12-01 00:00:00 UTC).next_month(),
+        datetime!(2023-01-01 00:00:00 UTC)
+    );
+}
+
+#[test]
+fn next_year() {
+    assert_eq!(
+        datetime!(2022-04-21 03:17:12.123_456_789 UTC).next_year(),
+        datetime!(2023-01-01 00:00:00 UTC)
+    );
+    assert_eq!(
+        datetime!(2022-01-01 00:00:00 UTC).next_year(),
+        datetime!(2023-01-01 00:00:00 UTC)
+    );
+}
+
+#[test]
 fn partial_eq() {
     assert_eq!(
         datetime!(2000-01-01 0:00 UTC).to_offset(offset!(-1)),

--- a/tests/offset_date_time_range.rs
+++ b/tests/offset_date_time_range.rs
@@ -1,0 +1,705 @@
+use time::macros::datetime;
+use time::OffsetDateTimeRangeExt;
+use time::OffsetDateTimeRangeSliceExt;
+use time::Duration;
+
+
+mod offset_date_time_range_ext {
+    use super::*;
+
+    #[test]
+    fn len() {
+        let start = datetime!(2022-04-18 03:17:12.200 UTC);
+        let end = datetime!(2022-04-18 03:17:17.600 UTC);
+
+        assert_eq!((start..end).len(Duration::SECOND), 5);
+        assert_eq!((start..end).len(Duration::ZERO), 0);
+        assert_eq!((start..end).len(-Duration::SECOND), 0);
+        assert_eq!((end..start).len(Duration::SECOND), 0);
+    }
+
+    #[test]
+    fn seconds() {
+        let start = datetime!(2022-04-18 03:17:12.200 UTC);
+        let end = datetime!(2022-04-18 03:17:17.600 UTC);
+        let mut seconds = (start..end).seconds();
+
+        assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:13 UTC)));
+        assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:14 UTC)));
+        assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:15 UTC)));
+        assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:16 UTC)));
+        assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:17 UTC)));
+        assert_eq!(seconds.next(), None);
+
+        assert_eq!((end..start).seconds().next(), None);
+    }
+
+    #[test]
+    fn minutes() {
+        let start = datetime!(2022-04-18 03:17:17 UTC);
+        let end = datetime!(2022-04-18 03:19:42 UTC);
+        let mut minutes = (start..end).minutes();
+        assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:18:00 UTC)));
+        assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:19:00 UTC)));
+        assert_eq!(minutes.next(), None);
+
+        assert_eq!((end..start).minutes().next(), None);
+    }
+
+    #[test]
+    fn hours() {
+        let start = datetime!(2022-04-18 03:17:00 UTC);
+        let end = datetime!(2022-04-18 07:42:00 UTC);
+        let mut hours = (start..end).hours();
+        assert_eq!(hours.next(), Some(datetime!(2022-04-18 04:00:00 UTC)));
+        assert_eq!(hours.next(), Some(datetime!(2022-04-18 05:00:00 UTC)));
+        assert_eq!(hours.next(), Some(datetime!(2022-04-18 06:00:00 UTC)));
+        assert_eq!(hours.next(), Some(datetime!(2022-04-18 07:00:00 UTC)));
+        assert_eq!(hours.next(), None);
+        
+        assert_eq!((end..start).hours().next(), None);
+    }
+
+    #[test]
+    fn days() {
+        let start = datetime!(2022-04-18 04:00:00 UTC);
+        let end = datetime!(2022-04-20 08:00:00 UTC);
+        let mut days = (start..end).days();
+
+        assert_eq!(days.next(), Some(datetime!(2022-04-19 00:00:00 UTC)));
+        assert_eq!(days.next(), Some(datetime!(2022-04-20 00:00:00 UTC)));
+        assert_eq!(days.next(), None);
+        
+        assert_eq!((end..start).days().next(), None);
+    }
+
+    #[test]
+    fn monday_based_weeks() {
+        let start = datetime!(2022-04-07 00:00:00 UTC);
+        let end = datetime!(2022-04-21 00:00:00 UTC);
+        let mut weeks = (start..end).monday_based_weeks();
+
+        assert_eq!(weeks.next(), Some(datetime!(2022-04-11 00:00:00 UTC)));
+        assert_eq!(weeks.next(), Some(datetime!(2022-04-18 00:00:00 UTC)));
+        assert_eq!(weeks.next(), None);
+        
+        assert_eq!((end..start).monday_based_weeks().next(), None);
+    }
+
+    #[test]
+    fn sunday_based_weeks() {
+        let start = datetime!(2022-04-07 00:00:00 UTC);
+        let end = datetime!(2022-04-21 00:00:00 UTC);
+        let mut weeks = (start..end).sunday_based_weeks();
+        
+        assert_eq!(weeks.next(), Some(datetime!(2022-04-10 00:00:00 UTC)));
+        assert_eq!(weeks.next(), Some(datetime!(2022-04-17 00:00:00 UTC)));
+        assert_eq!(weeks.next(), None);
+        
+        assert_eq!((end..start).sunday_based_weeks().next(), None);
+    }
+
+    #[test]
+    fn months() {
+        let start = datetime!(2022-04-13 00:00:00 UTC);
+        let end = datetime!(2022-06-26 00:00:00 UTC);
+        let mut months = (start..end).months();
+
+        assert_eq!(months.next(), Some(datetime!(2022-05-01 00:00:00 UTC)));
+        assert_eq!(months.next(), Some(datetime!(2022-06-01 00:00:00 UTC)));
+        assert_eq!(months.next(), None);
+        
+        assert_eq!((end..start).months().next(), None);
+    }
+
+    #[test]
+    fn years() {
+        let start = datetime!(2020-06-01 00:00:00 UTC);
+        let end = datetime!(2022-09-01 00:00:00 UTC);
+        let mut years = (start..end).years();
+
+        assert_eq!(years.next(), Some(datetime!(2021-01-01 00:00:00 UTC)));
+        assert_eq!(years.next(), Some(datetime!(2022-01-01 00:00:00 UTC)));
+        assert_eq!(years.next(), None);
+        
+        assert_eq!((end..start).years().next(), None);
+    }
+
+    #[test]
+    fn full_seconds() {
+        let start = datetime!(2022-04-18 03:17:12.200 UTC);
+        let end = datetime!(2022-04-18 03:17:17.600 UTC);
+        let mut seconds = (start..end).full_seconds();
+
+        assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:13 UTC)));
+        assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:14 UTC)));
+        assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:15 UTC)));
+        assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:16 UTC)));
+        assert_eq!(seconds.next(), None);
+
+        assert_eq!((end..start).full_seconds().next(), None);
+    }
+
+    #[test]
+    fn full_minutes() {
+        let start = datetime!(2022-04-18 03:17:17 UTC);
+        let end = datetime!(2022-04-18 03:19:42 UTC);
+        let mut minutes = (start..end).full_minutes();
+
+        assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:18:00 UTC)));
+        assert_eq!(minutes.next(), None);
+
+        assert_eq!((end..start).full_minutes().next(), None);
+    }
+
+    #[test]
+    fn full_hours() {
+        let start = datetime!(2022-04-18 03:17:00 UTC);
+        let end = datetime!(2022-04-18 07:42:00 UTC);
+        let mut hours = (start..end).full_hours();
+
+        assert_eq!(hours.next(), Some(datetime!(2022-04-18 04:00:00 UTC)));
+        assert_eq!(hours.next(), Some(datetime!(2022-04-18 05:00:00 UTC)));
+        assert_eq!(hours.next(), Some(datetime!(2022-04-18 06:00:00 UTC)));
+        assert_eq!(hours.next(), None);
+
+        assert_eq!((end..start).full_hours().next(), None);
+    }
+
+    #[test]
+    fn full_days() {
+        let start = datetime!(2022-04-18 04:00:00 UTC);
+        let end = datetime!(2022-04-20 08:00:00 UTC);
+        let mut days = (start..end).full_days();
+
+        assert_eq!(days.next(), Some(datetime!(2022-04-19 00:00:00 UTC)));
+        assert_eq!(days.next(), None);
+
+        assert_eq!((end..start).full_days().next(), None);
+    }
+
+    #[test]
+    fn full_monday_based_weeks() {
+        let start = datetime!(2022-04-7 00:00:00 UTC);
+        let end = datetime!(2022-04-21 00:00:00 UTC);
+        let mut weeks = (start..end).full_monday_based_weeks();
+
+        assert_eq!(weeks.next(), Some(datetime!(2022-04-11 00:00:00 UTC)));
+        assert_eq!(weeks.next(), None);
+
+        assert_eq!((end..start).full_monday_based_weeks().next(), None);
+    }
+
+    #[test]
+    fn full_sunday_based_weeks() {
+        let start = datetime!(2022-04-7 00:00:00 UTC);
+        let end = datetime!(2022-04-21 00:00:00 UTC);
+        let mut weeks = (start..end).full_sunday_based_weeks();
+
+        assert_eq!(weeks.next(), Some(datetime!(2022-04-10 00:00:00 UTC)));
+        assert_eq!(weeks.next(), None);
+
+        assert_eq!((end..start).full_sunday_based_weeks().next(), None);
+    }
+
+    #[test]
+    fn full_months() {
+        let start = datetime!(2022-04-13 00:00:00 UTC);
+        let end = datetime!(2022-06-26 00:00:00 UTC);
+        let mut months = (start..end).full_months();
+
+        assert_eq!(months.next(), Some(datetime!(2022-05-01 00:00:00 UTC)));
+        assert_eq!(months.next(), None);
+
+        assert_eq!((end..start).full_months().next(), None);
+    }
+
+    #[test]
+    fn full_years() {
+        let start = datetime!(2020-06-01 00:00:00 UTC);
+        let end = datetime!(2022-09-01 00:00:00 UTC);
+        let mut years = (start..end).full_years();
+
+        assert_eq!(years.next(), Some(datetime!(2021-01-01 00:00:00 UTC)));
+        assert_eq!(years.next(), None);
+
+        assert_eq!((end..start).full_years().next(), None);
+    }
+
+    #[test]
+    fn overlapping_seconds() {
+        let start = datetime!(2022-04-18 03:17:12.200 UTC);
+        let end = datetime!(2022-04-18 03:17:17.600 UTC);
+        let mut seconds = (start..end).overlapping_seconds();
+
+        assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:12 UTC)));
+        assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:13 UTC)));
+        assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:14 UTC)));
+        assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:15 UTC)));
+        assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:16 UTC)));
+        assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:17 UTC)));
+        assert_eq!(seconds.next(), None);
+
+        assert_eq!((end..start).overlapping_seconds().next(), None);
+    }
+
+    #[test]
+    fn overlapping_minutes() {
+        let start = datetime!(2022-04-18 03:17:17 UTC);
+        let end = datetime!(2022-04-18 03:19:42 UTC);
+        let mut minutes = (start..end).overlapping_minutes();
+
+        assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:17:00 UTC)));
+        assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:18:00 UTC)));
+        assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:19:00 UTC)));
+        assert_eq!(minutes.next(), None);
+
+        assert_eq!((end..start).overlapping_minutes().next(), None);
+    }
+
+    #[test]
+    fn overlapping_hours() {
+        let start = datetime!(2022-04-18 03:17:00 UTC);
+        let end = datetime!(2022-04-18 07:42:00 UTC);
+        let mut hours = (start..end).overlapping_hours();
+
+        assert_eq!(hours.next(), Some(datetime!(2022-04-18 03:00:00 UTC)));
+        assert_eq!(hours.next(), Some(datetime!(2022-04-18 04:00:00 UTC)));
+        assert_eq!(hours.next(), Some(datetime!(2022-04-18 05:00:00 UTC)));
+        assert_eq!(hours.next(), Some(datetime!(2022-04-18 06:00:00 UTC)));
+        assert_eq!(hours.next(), Some(datetime!(2022-04-18 07:00:00 UTC)));
+        assert_eq!(hours.next(), None);
+
+        assert_eq!((end..start).overlapping_hours().next(), None);
+    }
+
+    #[test]
+    fn overlapping_days() {
+        let start = datetime!(2022-04-18 04:00:00 UTC);
+        let end = datetime!(2022-04-20 08:00:00 UTC);
+        let mut days = (start..end).overlapping_days();
+
+        assert_eq!(days.next(), Some(datetime!(2022-04-18 00:00:00 UTC)));
+        assert_eq!(days.next(), Some(datetime!(2022-04-19 00:00:00 UTC)));
+        assert_eq!(days.next(), Some(datetime!(2022-04-20 00:00:00 UTC)));
+        assert_eq!(days.next(), None);
+
+        assert_eq!((end..start).overlapping_days().next(), None);
+    }
+
+    #[test]
+    fn overlapping_monday_based_weeks() {
+        let start = datetime!(2022-04-07 00:00:00 UTC);
+        let end = datetime!(2022-04-21 00:00:00 UTC);
+        let mut weeks = (start..end).overlapping_monday_based_weeks();
+
+        assert_eq!(weeks.next(), Some(datetime!(2022-04-04 00:00:00 UTC)));
+        assert_eq!(weeks.next(), Some(datetime!(2022-04-11 00:00:00 UTC)));
+        assert_eq!(weeks.next(), Some(datetime!(2022-04-18 00:00:00 UTC)));
+        assert_eq!(weeks.next(), None);
+
+        assert_eq!((end..start).overlapping_monday_based_weeks().next(), None);
+    }
+
+    #[test]
+    fn overlapping_sunday_based_weeks() {
+        let start = datetime!(2022-04-07 00:00:00 UTC);
+        let end = datetime!(2022-04-21 00:00:00 UTC);
+        let mut weeks = (start..end).overlapping_sunday_based_weeks();
+
+        assert_eq!(weeks.next(), Some(datetime!(2022-04-03 00:00:00 UTC)));
+        assert_eq!(weeks.next(), Some(datetime!(2022-04-10 00:00:00 UTC)));
+        assert_eq!(weeks.next(), Some(datetime!(2022-04-17 00:00:00 UTC)));
+        assert_eq!(weeks.next(), None);
+
+        assert_eq!((end..start).overlapping_sunday_based_weeks().next(), None);
+    }
+
+    #[test]
+    fn overlapping_months() {
+        let start = datetime!(2022-04-13 00:00:00 UTC);
+        let end = datetime!(2022-06-26 00:00:00 UTC);
+        let mut months = (start..end).overlapping_months();
+
+        assert_eq!(months.next(), Some(datetime!(2022-04-01 00:00:00 UTC)));
+        assert_eq!(months.next(), Some(datetime!(2022-05-01 00:00:00 UTC)));
+        assert_eq!(months.next(), Some(datetime!(2022-06-01 00:00:00 UTC)));
+        assert_eq!(months.next(), None);
+
+        assert_eq!((end..start).overlapping_months().next(), None);
+    }
+
+    #[test]
+    fn overlapping_years() {
+        let start = datetime!(2020-06-01 00:00:00 UTC);
+        let end = datetime!(2022-09-01 00:00:00 UTC);
+        let mut years = (start..end).overlapping_years();
+
+        assert_eq!(years.next(), Some(datetime!(2020-01-01 00:00:00 UTC)));
+        assert_eq!(years.next(), Some(datetime!(2021-01-01 00:00:00 UTC)));
+        assert_eq!(years.next(), Some(datetime!(2022-01-01 00:00:00 UTC)));
+        assert_eq!(years.next(), None);
+
+        assert_eq!((end..start).overlapping_years().next(), None);
+    }
+
+    #[test]
+    fn overlaps() {
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(range1.clone().overlaps(range2.clone()));
+        assert!(range2.clone().overlaps(range1.clone()));
+        
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-03 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(range1.clone().overlaps(range2.clone()));
+        assert!(range2.clone().overlaps(range1.clone()));
+        
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-12 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(!range1.clone().overlaps(range2.clone()));
+        assert!(!range2.clone().overlaps(range1.clone()));
+        
+        let range1 = datetime!(2022-04-10 00:00:00 UTC)..datetime!(2022-04-06 00:00:00 UTC);
+        let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(!range1.clone().overlaps(range2.clone()));
+        assert!(!range2.clone().overlaps(range1.clone()));
+    }
+
+    #[test]
+    fn left_adjacent_to() {
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-10 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(range1.clone().left_adjacent_to(range2.clone()));
+        assert!(!range2.clone().left_adjacent_to(range1.clone()));
+
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-12 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(!range1.clone().left_adjacent_to(range2.clone()));
+        assert!(!range2.clone().left_adjacent_to(range1.clone()));
+    }
+
+    #[test]
+    fn right_adjacent_to() {
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-10 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(!range1.clone().right_adjacent_to(range2.clone()));
+        assert!(range2.clone().right_adjacent_to(range1.clone()));
+
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-12 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(!range1.clone().right_adjacent_to(range2.clone()));
+        assert!(!range2.clone().right_adjacent_to(range1.clone()));
+    }
+
+    #[test]
+    fn engulfs() {
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+        let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(range1.clone().engulfs(range2.clone()));
+        assert!(!range2.clone().engulfs(range1.clone()));
+
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+        let range2 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(range1.clone().engulfs(range2.clone()));
+        assert!(range2.clone().engulfs(range1.clone()));
+
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-06 00:00:00 UTC);
+        let range2 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(!range1.clone().engulfs(range2.clone()));
+        assert!(!range2.clone().engulfs(range1.clone()));
+
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-12 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(!range1.clone().engulfs(range2.clone()));
+        assert!(!range2.clone().engulfs(range1.clone()));
+    }
+
+    #[test]
+    fn engulfed_by() {
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+        let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(!range1.clone().engulfed_by(range2.clone()));
+        assert!(range2.clone().engulfed_by(range1.clone()));
+
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+        let range2 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(range1.clone().engulfed_by(range2.clone()));
+        assert!(range2.clone().engulfed_by(range1.clone()));
+
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-06 00:00:00 UTC);
+        let range2 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(!range1.clone().engulfed_by(range2.clone()));
+        assert!(!range2.clone().engulfed_by(range1.clone()));
+
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-12 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert!(!range1.clone().engulfed_by(range2.clone()));
+        assert!(!range2.clone().engulfed_by(range1.clone()));
+    }
+
+    #[test]
+    fn split_at() {
+        let range = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+        let split = datetime!(2022-04-08 00:00:00 UTC);
+
+        let (left, right) = range.split_at(split).unwrap();
+
+        assert_eq!(left, datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-08 00:00:00 UTC));
+        assert_eq!(right, datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC));
+        
+        let range = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+        let split = datetime!(2022-04-18 00:00:00 UTC);
+
+        assert_eq!(range.split_at(split), None);
+        
+        let range = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+        let split = datetime!(2022-04-06 00:00:00 UTC);
+
+        assert_eq!(range.split_at(split), None);
+        
+        let range = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-06 00:00:00 UTC);
+        let split = datetime!(2022-04-06 00:00:00 UTC);
+
+        assert_eq!(range.split_at(split), None);
+    }
+
+    #[test]
+    fn split_at_multiple() {
+        let range = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+        let splits = vec![
+            datetime!(2022-04-07 00:00:00 UTC),
+            datetime!(2022-04-08 00:00:00 UTC),
+            datetime!(2022-04-09 00:00:00 UTC),
+            datetime!(2022-04-15 00:00:00 UTC),
+        ];
+        let ranges = range.split_at_multiple(&splits);
+
+        assert_eq!(ranges.len(), 4);
+        assert_eq!(ranges[0], datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-07 00:00:00 UTC));
+        assert_eq!(ranges[1], datetime!(2022-04-07 00:00:00 UTC)..datetime!(2022-04-08 00:00:00 UTC));
+        assert_eq!(ranges[2], datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-09 00:00:00 UTC));
+        assert_eq!(ranges[3], datetime!(2022-04-09 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC));
+
+        let range = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-06 00:00:00 UTC);
+        let splits = vec![
+            datetime!(2022-04-07 00:00:00 UTC),
+        ];
+        let ranges = range.split_at_multiple(&splits);
+
+        assert_eq!(ranges.len(), 0);
+    }
+
+    #[test]
+    fn split_by() {
+        let range = datetime!(2022-04-06 14:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let mut split = range.split_by(Duration::days(1));
+
+        assert_eq!(split.next(), Some(datetime!(2022-04-06 14:00:00 UTC)..datetime!(2022-04-07 14:00:00 UTC)));
+        assert_eq!(split.next(), Some(datetime!(2022-04-07 14:00:00 UTC)..datetime!(2022-04-08 14:00:00 UTC)));
+        assert_eq!(split.next(), Some(datetime!(2022-04-08 14:00:00 UTC)..datetime!(2022-04-09 14:00:00 UTC)));
+        assert_eq!(split.next(), Some(datetime!(2022-04-09 14:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC)));
+        assert_eq!(split.next(), None);
+    }
+
+    #[test]
+    fn divide_equally() {
+        let range = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00.000_000_002 UTC);
+        let mut split = range.divide_equally(4);
+
+        assert_eq!(split.next(), Some(datetime!(2022-04-06 00:00:00.000_000_000 UTC)..datetime!(2022-04-07 00:00:00.000_000_001 UTC)));
+        assert_eq!(split.next(), Some(datetime!(2022-04-07 00:00:00.000_000_001 UTC)..datetime!(2022-04-08 00:00:00.000_000_002 UTC)));
+        assert_eq!(split.next(), Some(datetime!(2022-04-08 00:00:00.000_000_002 UTC)..datetime!(2022-04-09 00:00:00.000_000_002 UTC)));
+        assert_eq!(split.next(), Some(datetime!(2022-04-09 00:00:00.000_000_002 UTC)..datetime!(2022-04-10 00:00:00.000_000_002 UTC)));
+        assert_eq!(split.next(), None);
+    }
+
+    #[test]
+    fn intersection() {
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert_eq!(range1.clone().intersection(range2.clone()), Some(datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC)));
+        assert_eq!(range2.clone().intersection(range1.clone()), Some(datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC)));
+
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-12 00:00:00 UTC)..datetime!(2022-04-15 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert_eq!(range1.clone().intersection(range2.clone()), None);
+        assert_eq!(range2.clone().intersection(range1.clone()), None);
+    }
+
+    #[test]
+    fn union() {
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert_eq!(range1.clone().union(range2.clone()), Some(datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC)));
+        assert_eq!(range2.clone().union(range1.clone()), Some(datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC)));
+
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-12 00:00:00 UTC)..datetime!(2022-04-15 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert_eq!(range1.clone().union(range2.clone()), None);
+        assert_eq!(range2.clone().union(range1.clone()), None);
+    }
+
+    #[test]
+    fn difference() {
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert_eq!(range1.clone().difference(range2.clone()), vec![datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-08 00:00:00 UTC)]);
+        assert_eq!(range2.clone().difference(range1.clone()), vec![datetime!(2022-04-10 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC)]);
+
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-12 00:00:00 UTC)..datetime!(2022-04-15 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert_eq!(range1.clone().difference(range2.clone()), vec![datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC)]);
+        assert_eq!(range2.clone().difference(range1.clone()), vec![datetime!(2022-04-12 00:00:00 UTC)..datetime!(2022-04-15 00:00:00 UTC)]);
+
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-15 00:00:00 UTC);
+        let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert_eq!(range1.clone().difference(range2.clone()), vec![
+            datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-08 00:00:00 UTC),
+            datetime!(2022-04-12 00:00:00 UTC)..datetime!(2022-04-15 00:00:00 UTC),
+        ]);
+        assert_eq!(range2.clone().difference(range1.clone()), vec![]);
+    }
+
+    #[test]
+    fn difference_multiple() {
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-15 00:00:00 UTC);
+        let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+        let range3 = datetime!(2022-04-10 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+
+        // ranges can't be copied, so we are using `clone()` here
+        assert_eq!(
+            range1.clone().difference_multiple(&vec![range2.clone(), range3.clone()]),
+            vec![
+                datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-08 00:00:00 UTC),
+                datetime!(2022-04-13 00:00:00 UTC)..datetime!(2022-04-15 00:00:00 UTC),
+            ]
+        );
+    }
+}
+
+mod offset_date_time_range_slice_ext {
+    use super::*;
+
+    #[test]
+    fn intersection() {
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+        let range3 = datetime!(2022-04-09 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+
+        assert_eq!(
+            [range1, range2, range3].intersection(),
+            Some(datetime!(2022-04-09 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC))
+        );
+
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-13 00:00:00 UTC)..datetime!(2022-04-15 00:00:00 UTC);
+
+        assert_eq!(
+            [range1, range2].intersection(),
+            None
+        );
+    }
+
+    #[test]
+    fn union() {
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+        let range3 = datetime!(2022-04-09 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+
+        assert_eq!(
+            [range1, range2, range3].union(),
+            Some(datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC))
+        );
+
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-13 00:00:00 UTC)..datetime!(2022-04-15 00:00:00 UTC);
+
+        assert_eq!(
+            [range1, range2].union(),
+            None
+        );
+    }
+
+    #[test]
+    fn merge() {
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+        let range3 = datetime!(2022-04-09 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+        let range4 = datetime!(2022-04-15 00:00:00 UTC)..datetime!(2022-04-19 00:00:00 UTC);
+        let range5 = datetime!(2022-04-15 00:00:00 UTC)..datetime!(2022-04-17 00:00:00 UTC);
+        let range6 = datetime!(2022-04-19 00:00:00 UTC)..datetime!(2022-04-20 00:00:00 UTC);
+        
+        assert_eq!(
+            [range1, range2, range3, range4, range5, range6].merge(),
+            vec![
+                datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC),
+                datetime!(2022-04-15 00:00:00 UTC)..datetime!(2022-04-20 00:00:00 UTC),
+            ]
+        );
+    }
+
+    #[test]
+    fn xor() {
+        let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+        let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-12 00:00:00 UTC);
+        let range3 = datetime!(2022-04-09 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+        let range4 = datetime!(2022-04-15 00:00:00 UTC)..datetime!(2022-04-19 00:00:00 UTC);
+        let range5 = datetime!(2022-04-15 00:00:00 UTC)..datetime!(2022-04-17 00:00:00 UTC);
+        
+        assert_eq!(
+            [range1, range2, range3, range4, range5].xor(),
+            vec![
+                datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-08 00:00:00 UTC),
+                datetime!(2022-04-12 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC),
+                datetime!(2022-04-17 00:00:00 UTC)..datetime!(2022-04-19 00:00:00 UTC),
+            ]
+        );
+    }
+}

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -319,9 +319,9 @@ mod instant;
 #[cfg(feature = "macros")]
 pub mod macros;
 mod month;
+mod offset_date_time;
 #[cfg(feature = "std")]
 mod offset_date_time_range;
-mod offset_date_time;
 #[cfg(feature = "parsing")]
 pub mod parsing;
 mod primitive_date_time;
@@ -347,9 +347,11 @@ pub use crate::error::Error;
 #[cfg(feature = "std")]
 pub use crate::instant::Instant;
 pub use crate::month::Month;
-#[cfg(feature = "std")]
-pub use crate::offset_date_time_range::{ OffsetDateTimeRangeExt, OffsetDateTimeRangeSliceExt, iter };
 pub use crate::offset_date_time::OffsetDateTime;
+#[cfg(feature = "std")]
+pub use crate::offset_date_time_range::{
+    iter, OffsetDateTimeRangeExt, OffsetDateTimeRangeSliceExt,
+};
 pub use crate::primitive_date_time::PrimitiveDateTime;
 pub use crate::time::Time;
 pub use crate::utc_offset::UtcOffset;

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -319,6 +319,7 @@ mod instant;
 #[cfg(feature = "macros")]
 pub mod macros;
 mod month;
+mod offset_date_time_range;
 mod offset_date_time;
 #[cfg(feature = "parsing")]
 pub mod parsing;
@@ -346,6 +347,8 @@ pub use crate::error::Error;
 pub use crate::instant::Instant;
 pub use crate::month::Month;
 pub use crate::offset_date_time::OffsetDateTime;
+#[cfg(feature = "std")]
+pub use crate::offset_date_time_range::{ OffsetDateTimeRange, iter };
 pub use crate::primitive_date_time::PrimitiveDateTime;
 pub use crate::time::Time;
 pub use crate::utc_offset::UtcOffset;

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -347,7 +347,7 @@ pub use crate::error::Error;
 pub use crate::instant::Instant;
 pub use crate::month::Month;
 #[cfg(feature = "std")]
-pub use crate::offset_date_time_range::{ OffsetDateTimeRange, OffsetDateTimeRangeSlice, iter };
+pub use crate::offset_date_time_range::{ OffsetDateTimeRangeExt, OffsetDateTimeRangeSliceExt, iter };
 pub use crate::offset_date_time::OffsetDateTime;
 pub use crate::primitive_date_time::PrimitiveDateTime;
 pub use crate::time::Time;

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -319,6 +319,7 @@ mod instant;
 #[cfg(feature = "macros")]
 pub mod macros;
 mod month;
+#[cfg(feature = "std")]
 mod offset_date_time_range;
 mod offset_date_time;
 #[cfg(feature = "parsing")]

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -346,9 +346,9 @@ pub use crate::error::Error;
 #[cfg(feature = "std")]
 pub use crate::instant::Instant;
 pub use crate::month::Month;
-pub use crate::offset_date_time::OffsetDateTime;
 #[cfg(feature = "std")]
-pub use crate::offset_date_time_range::{ OffsetDateTimeRange, iter };
+pub use crate::offset_date_time_range::{ OffsetDateTimeRange, OffsetDateTimeRangeSlice, iter };
+pub use crate::offset_date_time::OffsetDateTime;
 pub use crate::primitive_date_time::PrimitiveDateTime;
 pub use crate::time::Time;
 pub use crate::utc_offset::UtcOffset;

--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -961,14 +961,6 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-18 03:17:12 UTC)
     /// );
     /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-18 03:17:12 UTC).floor_seconds(),
-    ///     datetime!(2022-04-18 03:17:12 UTC)
-    /// );
-    /// ```
     pub fn floor_seconds(self) -> Self {
         self
             .replace_nanosecond(0).unwrap()
@@ -980,14 +972,6 @@ impl OffsetDateTime {
     /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).floor_minutes(),
-    ///     datetime!(2022-04-18 03:17:00 UTC)
-    /// );
-    /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-18 03:17:00 UTC).floor_minutes(),
     ///     datetime!(2022-04-18 03:17:00 UTC)
     /// );
     /// ```
@@ -1003,14 +987,6 @@ impl OffsetDateTime {
     /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).floor_hours(),
-    ///     datetime!(2022-04-18 03:00:00 UTC)
-    /// );
-    /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-18 03:00:00 UTC).floor_hours(),
     ///     datetime!(2022-04-18 03:00:00 UTC)
     /// );
     /// ```
@@ -1030,14 +1006,6 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-18 00:00:00 UTC)
     /// );
     /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-18 00:00:00 UTC).floor_days(),
-    ///     datetime!(2022-04-18 00:00:00 UTC)
-    /// );
-    /// ```
     pub fn floor_days(self) -> Self {
         self
             .replace_nanosecond(0).unwrap()
@@ -1052,14 +1020,6 @@ impl OffsetDateTime {
     /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-04-21 03:17:12.123_456_789 UTC).floor_monday_based_weeks(),
-    ///     datetime!(2022-04-18 00:00:00 UTC)
-    /// );
-    /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-18 00:00:00 UTC).floor_monday_based_weeks(),
     ///     datetime!(2022-04-18 00:00:00 UTC)
     /// );
     /// ```
@@ -1081,14 +1041,6 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-17 00:00:00 UTC)
     /// );
     /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-17 00:00:00 UTC).floor_sunday_based_weeks(),
-    ///     datetime!(2022-04-17 00:00:00 UTC)
-    /// );
-    /// ```
     pub fn floor_sunday_based_weeks(self) -> Self {
         self
             .replace_nanosecond(0).unwrap()
@@ -1107,14 +1059,6 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-01 00:00:00 UTC)
     /// );
     /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-01 00:00:00 UTC).floor_months(),
-    ///     datetime!(2022-04-01 00:00:00 UTC)
-    /// );
-    /// ```
     pub fn floor_months(self) -> Self {
         self
             .replace_nanosecond(0).unwrap()
@@ -1130,14 +1074,6 @@ impl OffsetDateTime {
     /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).floor_years(),
-    ///     datetime!(2022-01-01 00:00:00 UTC)
-    /// );
-    /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-01-01 00:00:00 UTC).floor_years(),
     ///     datetime!(2022-01-01 00:00:00 UTC)
     /// );
     /// ```
@@ -1160,14 +1096,6 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-18 03:17:13 UTC)
     /// );
     /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-18 03:17:12 UTC).ceil_seconds(),
-    ///     datetime!(2022-04-18 03:17:12 UTC)
-    /// );
-    /// ```
     pub fn ceil_seconds(self) -> Self {
         let floored = self.floor_seconds();
         if floored == self {
@@ -1184,14 +1112,6 @@ impl OffsetDateTime {
     /// assert_eq!(
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).ceil_minutes(),
     ///     datetime!(2022-04-18 03:18:00 UTC)
-    /// );
-    /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-18 03:17:00 UTC).ceil_minutes(),
-    ///     datetime!(2022-04-18 03:17:00 UTC)
     /// );
     /// ```
     pub fn ceil_minutes(self) -> Self {
@@ -1212,14 +1132,6 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-18 04:00:00 UTC)
     /// );
     /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-18 03:00:00 UTC).ceil_hours(),
-    ///     datetime!(2022-04-18 03:00:00 UTC)
-    /// );
-    /// ```
     pub fn ceil_hours(self) -> Self {
         let floored = self.floor_hours();
         if floored == self {
@@ -1238,14 +1150,6 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-19 00:00:00 UTC)
     /// );
     /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-18 00:00:00 UTC).ceil_days(),
-    ///     datetime!(2022-04-18 00:00:00 UTC)
-    /// );
-    /// ```
     pub fn ceil_days(self) -> Self {
         let floored = self.floor_days();
         if floored == self {
@@ -1261,14 +1165,6 @@ impl OffsetDateTime {
     /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-04-20 03:17:12.123_456_789 UTC).ceil_monday_based_weeks(),
-    ///     datetime!(2022-04-25 00:00:00 UTC)
-    /// );
-    /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-25 00:00:00 UTC).ceil_monday_based_weeks(),
     ///     datetime!(2022-04-25 00:00:00 UTC)
     /// );
     /// ```
@@ -1290,14 +1186,6 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-24 00:00:00 UTC)
     /// );
     /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-24 00:00:00 UTC).ceil_sunday_based_weeks(),
-    ///     datetime!(2022-04-24 00:00:00 UTC)
-    /// );
-    /// ```
     pub fn ceil_sunday_based_weeks(self) -> Self {
         let floored = self.floor_sunday_based_weeks();
         if floored == self {
@@ -1314,14 +1202,6 @@ impl OffsetDateTime {
     /// assert_eq!(
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).ceil_months(),
     ///     datetime!(2022-05-01 00:00:00 UTC)
-    /// );
-    /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-01 00:00:00 UTC).ceil_months(),
-    ///     datetime!(2022-04-01 00:00:00 UTC)
     /// );
     /// ```
     pub fn ceil_months(self) -> Self {
@@ -1342,14 +1222,6 @@ impl OffsetDateTime {
     ///     datetime!(2023-01-01 00:00:00 UTC)
     /// );
     /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-01-01 00:00:00 UTC).ceil_years(),
-    ///     datetime!(2022-01-01 00:00:00 UTC)
-    /// );
-    /// ```
     pub fn ceil_years(self) -> Self {
         let floored = self.floor_years();
         if floored == self {
@@ -1368,14 +1240,6 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-18 03:17:13 UTC)
     /// );
     /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-18 03:17:14 UTC).next_second(),
-    ///     datetime!(2022-04-18 03:17:15 UTC)
-    /// );
-    /// ```
     pub fn next_second(self) -> Self {
         self
             .replace_nanosecond(0).unwrap()
@@ -1388,14 +1252,6 @@ impl OffsetDateTime {
     /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).next_minute(),
-    ///     datetime!(2022-04-18 03:18:00 UTC)
-    /// );
-    /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-18 03:17:00 UTC).next_minute(),
     ///     datetime!(2022-04-18 03:18:00 UTC)
     /// );
     /// ```
@@ -1412,14 +1268,6 @@ impl OffsetDateTime {
     /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).next_hour(),
-    ///     datetime!(2022-04-18 04:00:00 UTC)
-    /// );
-    /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-18 03:00:00 UTC).next_hour(),
     ///     datetime!(2022-04-18 04:00:00 UTC)
     /// );
     /// ```
@@ -1440,22 +1288,6 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-19 00:00:00 UTC)
     /// );
     /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-18 00:00:00 UTC).next_day(),
-    ///     datetime!(2022-04-19 00:00:00 UTC)
-    /// );
-    /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-12-31 00:00:00 UTC).next_day(),
-    ///     datetime!(2023-01-01 00:00:00 UTC)
-    /// );
-    /// ```
     pub fn next_day(self) -> Self {
         self
             .replace_nanosecond(0).unwrap()
@@ -1474,13 +1306,6 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-25 00:00:00 UTC)
     /// );
     /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-25 00:00:00 UTC).next_monday_based_week(),
-    ///     datetime!(2022-05-02 00:00:00 UTC)
-    /// );
     pub fn next_monday_based_week(self) -> Self {
         self
             .replace_nanosecond(0).unwrap()
@@ -1498,14 +1323,6 @@ impl OffsetDateTime {
     /// assert_eq!(
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).next_sunday_based_week(),
     ///     datetime!(2022-04-24 00:00:00 UTC)
-    /// );
-    /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-24 00:00:00 UTC).next_sunday_based_week(),
-    ///     datetime!(2022-05-01 00:00:00 UTC)
     /// );
     /// ```
     pub fn next_sunday_based_week(self) -> Self {
@@ -1527,14 +1344,6 @@ impl OffsetDateTime {
     ///     datetime!(2022-05-01 00:00:00 UTC)
     /// );
     /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-04-01 00:00:00 UTC).next_month(),
-    ///     datetime!(2022-05-01 00:00:00 UTC)
-    /// );
-    /// ```
     pub fn next_month(self) -> Self {
         self
             .replace_nanosecond(0).unwrap()
@@ -1551,14 +1360,6 @@ impl OffsetDateTime {
     /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).next_year(),
-    ///     datetime!(2023-01-01 00:00:00 UTC)
-    /// );
-    /// ```
-    /// 
-    /// ```rust
-    /// # use time_macros::datetime;
-    /// assert_eq!(
-    ///     datetime!(2022-01-01 00:00:00 UTC).next_year(),
     ///     datetime!(2023-01-01 00:00:00 UTC)
     /// );
     /// ```

--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -961,6 +961,14 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-18 03:17:12 UTC)
     /// );
     /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-18 03:17:12 UTC).floor_seconds(),
+    ///     datetime!(2022-04-18 03:17:12 UTC)
+    /// );
+    /// ```
     pub fn floor_seconds(self) -> Self {
         self
             .replace_nanosecond(0).unwrap()
@@ -972,6 +980,14 @@ impl OffsetDateTime {
     /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).floor_minutes(),
+    ///     datetime!(2022-04-18 03:17:00 UTC)
+    /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-18 03:17:00 UTC).floor_minutes(),
     ///     datetime!(2022-04-18 03:17:00 UTC)
     /// );
     /// ```
@@ -987,6 +1003,14 @@ impl OffsetDateTime {
     /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).floor_hours(),
+    ///     datetime!(2022-04-18 03:00:00 UTC)
+    /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-18 03:00:00 UTC).floor_hours(),
     ///     datetime!(2022-04-18 03:00:00 UTC)
     /// );
     /// ```
@@ -1006,6 +1030,14 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-18 00:00:00 UTC)
     /// );
     /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-18 00:00:00 UTC).floor_days(),
+    ///     datetime!(2022-04-18 00:00:00 UTC)
+    /// );
+    /// ```
     pub fn floor_days(self) -> Self {
         self
             .replace_nanosecond(0).unwrap()
@@ -1019,12 +1051,16 @@ impl OffsetDateTime {
     /// ```rust
     /// # use time_macros::datetime;
     /// assert_eq!(
-    ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).floor_monday_based_weeks(),
+    ///     datetime!(2022-04-21 03:17:12.123_456_789 UTC).floor_monday_based_weeks(),
     ///     datetime!(2022-04-18 00:00:00 UTC)
     /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
     /// assert_eq!(
-    ///    datetime!(2022-04-21 03:17:12.123_456_789 UTC).floor_monday_based_weeks(),
-    ///    datetime!(2022-04-18 00:00:00 UTC)
+    ///     datetime!(2022-04-18 00:00:00 UTC).floor_monday_based_weeks(),
+    ///     datetime!(2022-04-18 00:00:00 UTC)
     /// );
     /// ```
     pub fn floor_monday_based_weeks(self) -> Self {
@@ -1041,11 +1077,15 @@ impl OffsetDateTime {
     /// ```rust
     /// # use time_macros::datetime;
     /// assert_eq!(
-    ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).floor_sunday_based_weeks(),
+    ///     datetime!(2022-04-21 03:17:12.123_456_789 UTC).floor_sunday_based_weeks(),
     ///     datetime!(2022-04-17 00:00:00 UTC)
     /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
     /// assert_eq!(
-    ///     datetime!(2022-04-21 03:17:12.123_456_789 UTC).floor_sunday_based_weeks(),
+    ///     datetime!(2022-04-17 00:00:00 UTC).floor_sunday_based_weeks(),
     ///     datetime!(2022-04-17 00:00:00 UTC)
     /// );
     /// ```
@@ -1067,6 +1107,14 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-01 00:00:00 UTC)
     /// );
     /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-01 00:00:00 UTC).floor_months(),
+    ///     datetime!(2022-04-01 00:00:00 UTC)
+    /// );
+    /// ```
     pub fn floor_months(self) -> Self {
         self
             .replace_nanosecond(0).unwrap()
@@ -1085,6 +1133,14 @@ impl OffsetDateTime {
     ///     datetime!(2022-01-01 00:00:00 UTC)
     /// );
     /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-01-01 00:00:00 UTC).floor_years(),
+    ///     datetime!(2022-01-01 00:00:00 UTC)
+    /// );
+    /// ```
     pub fn floor_years(self) -> Self {
         self
             .replace_nanosecond(0).unwrap()
@@ -1095,6 +1151,214 @@ impl OffsetDateTime {
             .replace_month(Month::January).unwrap()
     }
 
+    /// Round up to the closest whole second.
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).ceil_seconds(),
+    ///     datetime!(2022-04-18 03:17:13 UTC)
+    /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-18 03:17:12 UTC).ceil_seconds(),
+    ///     datetime!(2022-04-18 03:17:12 UTC)
+    /// );
+    /// ```
+    pub fn ceil_seconds(self) -> Self {
+        let floored = self.floor_seconds();
+        if floored == self {
+            self
+        } else {
+            floored.checked_add(Duration::seconds(1)).unwrap()
+        }
+    }
+
+    /// Round up to the closest whole minute.
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).ceil_minutes(),
+    ///     datetime!(2022-04-18 03:18:00 UTC)
+    /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-18 03:17:00 UTC).ceil_minutes(),
+    ///     datetime!(2022-04-18 03:17:00 UTC)
+    /// );
+    /// ```
+    pub fn ceil_minutes(self) -> Self {
+        let floored = self.floor_minutes();
+        if floored == self {
+            self
+        } else {
+            floored.checked_add(Duration::minutes(1)).unwrap()
+        }
+    }
+
+    /// Round up to the closest whole hour.
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).ceil_hours(),
+    ///     datetime!(2022-04-18 04:00:00 UTC)
+    /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-18 03:00:00 UTC).ceil_hours(),
+    ///     datetime!(2022-04-18 03:00:00 UTC)
+    /// );
+    /// ```
+    pub fn ceil_hours(self) -> Self {
+        let floored = self.floor_hours();
+        if floored == self {
+            self
+        } else {
+            floored.checked_add(Duration::hours(1)).unwrap()
+        }
+    }
+
+    /// Round up to the closest whole day.
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).ceil_days(),
+    ///     datetime!(2022-04-19 00:00:00 UTC)
+    /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-18 00:00:00 UTC).ceil_days(),
+    ///     datetime!(2022-04-18 00:00:00 UTC)
+    /// );
+    /// ```
+    pub fn ceil_days(self) -> Self {
+        let floored = self.floor_days();
+        if floored == self {
+            self
+        } else {
+            floored.checked_add(Duration::days(1)).unwrap()
+        }
+    }
+
+    /// Round up to the closest whole monday-based week.
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-20 03:17:12.123_456_789 UTC).ceil_monday_based_weeks(),
+    ///     datetime!(2022-04-25 00:00:00 UTC)
+    /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-25 00:00:00 UTC).ceil_monday_based_weeks(),
+    ///     datetime!(2022-04-25 00:00:00 UTC)
+    /// );
+    /// ```
+    pub fn ceil_monday_based_weeks(self) -> Self {
+        let floored = self.floor_monday_based_weeks();
+        if floored == self {
+            self
+        } else {
+            floored.checked_add(Duration::weeks(1)).unwrap()
+        }
+    }
+
+    /// Round up to the closest whole sunday-based week.
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-20 03:17:12.123_456_789 UTC).ceil_sunday_based_weeks(),
+    ///     datetime!(2022-04-24 00:00:00 UTC)
+    /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-24 00:00:00 UTC).ceil_sunday_based_weeks(),
+    ///     datetime!(2022-04-24 00:00:00 UTC)
+    /// );
+    /// ```
+    pub fn ceil_sunday_based_weeks(self) -> Self {
+        let floored = self.floor_sunday_based_weeks();
+        if floored == self {
+            self
+        } else {
+            floored.checked_add(Duration::weeks(1)).unwrap()
+        }
+    }
+
+    /// Round up to the closest whole month.
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).ceil_months(),
+    ///     datetime!(2022-05-01 00:00:00 UTC)
+    /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-01 00:00:00 UTC).ceil_months(),
+    ///     datetime!(2022-04-01 00:00:00 UTC)
+    /// );
+    /// ```
+    pub fn ceil_months(self) -> Self {
+        let floored = self.floor_months();
+        if floored == self {
+            self
+        } else {
+            floored.checked_add(Duration::days(util::days_in_year_month(floored.year(), floored.month()) as i64)).unwrap()
+        }
+    }
+
+    /// Round up to the closest whole year.
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).ceil_years(),
+    ///     datetime!(2023-01-01 00:00:00 UTC)
+    /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2022-01-01 00:00:00 UTC).ceil_years(),
+    ///     datetime!(2022-01-01 00:00:00 UTC)
+    /// );
+    /// ```
+    pub fn ceil_years(self) -> Self {
+        let floored = self.floor_years();
+        if floored == self {
+            self
+        } else {
+            floored.checked_add(Duration::days(util::days_in_year(floored.year()) as i64)).unwrap()
+        }
+    }
+
     /// Get the next closest whole second.
     /// 
     /// ```rust
@@ -1103,6 +1367,10 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).next_second(),
     ///     datetime!(2022-04-18 03:17:13 UTC)
     /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-04-18 03:17:14 UTC).next_second(),
     ///     datetime!(2022-04-18 03:17:15 UTC)
@@ -1122,6 +1390,10 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).next_minute(),
     ///     datetime!(2022-04-18 03:18:00 UTC)
     /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-04-18 03:17:00 UTC).next_minute(),
     ///     datetime!(2022-04-18 03:18:00 UTC)
@@ -1142,6 +1414,10 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).next_hour(),
     ///     datetime!(2022-04-18 04:00:00 UTC)
     /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-04-18 03:00:00 UTC).next_hour(),
     ///     datetime!(2022-04-18 04:00:00 UTC)
@@ -1163,10 +1439,18 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).next_day(),
     ///     datetime!(2022-04-19 00:00:00 UTC)
     /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-04-18 00:00:00 UTC).next_day(),
     ///     datetime!(2022-04-19 00:00:00 UTC)
     /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-12-31 00:00:00 UTC).next_day(),
     ///     datetime!(2023-01-01 00:00:00 UTC)
@@ -1189,9 +1473,13 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).next_monday_based_week(),
     ///     datetime!(2022-04-25 00:00:00 UTC)
     /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
     /// assert_eq!(
-    ///     datetime!(2022-04-21 00:00:00 UTC).next_monday_based_week(),
-    ///     datetime!(2022-04-25 00:00:00 UTC)
+    ///     datetime!(2022-04-25 00:00:00 UTC).next_monday_based_week(),
+    ///     datetime!(2022-05-02 00:00:00 UTC)
     /// );
     pub fn next_monday_based_week(self) -> Self {
         self
@@ -1211,9 +1499,13 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).next_sunday_based_week(),
     ///     datetime!(2022-04-24 00:00:00 UTC)
     /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
     /// assert_eq!(
-    ///     datetime!(2022-04-21 00:00:00 UTC).next_sunday_based_week(),
-    ///     datetime!(2022-04-24 00:00:00 UTC)
+    ///     datetime!(2022-04-24 00:00:00 UTC).next_sunday_based_week(),
+    ///     datetime!(2022-05-01 00:00:00 UTC)
     /// );
     /// ```
     pub fn next_sunday_based_week(self) -> Self {
@@ -1234,6 +1526,10 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).next_month(),
     ///     datetime!(2022-05-01 00:00:00 UTC)
     /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
     /// assert_eq!(
     ///     datetime!(2022-04-01 00:00:00 UTC).next_month(),
     ///     datetime!(2022-05-01 00:00:00 UTC)
@@ -1257,9 +1553,13 @@ impl OffsetDateTime {
     ///     datetime!(2022-04-18 03:17:12.123_456_789 UTC).next_year(),
     ///     datetime!(2023-01-01 00:00:00 UTC)
     /// );
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time_macros::datetime;
     /// assert_eq!(
-    ///    datetime!(2022-01-01 00:00:00 UTC).next_year(),
-    ///    datetime!(2023-01-01 00:00:00 UTC)
+    ///     datetime!(2022-01-01 00:00:00 UTC).next_year(),
+    ///     datetime!(2023-01-01 00:00:00 UTC)
     /// );
     /// ```
     pub fn next_year(self) -> Self {

--- a/time/src/offset_date_time_range.rs
+++ b/time/src/offset_date_time_range.rs
@@ -1,135 +1,136 @@
 //! Implementations of useful methods for the [`Range<OffsetDateTime>`] and [`&[Range<OffsetDateTime>]`](https://doc.rust-lang.org/std/primitive.slice.html) structs.
 
-use std::ops::Range;
-use crate::{OffsetDateTime, Duration, util, Month, Weekday};
+use crate::{Duration, Month, OffsetDateTime, Weekday};
 use iter::*;
+use std::ops::Range;
 
 /// Extension of [`Range<OffsetDateTime>`] containing useful methods.
-/// 
+///
 /// If you want to access these methods, you must import the [`OffsetDateTimeRangeExt`] trait.
 pub trait OffsetDateTimeRangeExt {
     /// Returns the length of the range using the specified duration as the unit.
-    /// 
-    /// Attention, using `Duration::DAY` as unit wouldn't count how many days are in the range, but rather how many day-long ranges would fits inside.
+    ///
+    /// Attention, using `Duration::DAY` as unit wouldn't count how many days are in the range, but rather how many day-long ranges would fit inside.
+    /// If you want to know the number of days starting in the range, use [`OffsetDateTimeRangeExt::days`] and [`iter::Days::len`] instead.
     fn len(self, unit: Duration) -> usize;
 
     /// Returns an iterator of all the seconds that start within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn seconds(self) -> Seconds;
 
     /// Returns an iterator of all the minutes that start within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn minutes(self) -> Minutes;
 
     /// Returns an iterator of all the hours that start within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn hours(self) -> Hours;
 
     /// Returns an iterator of all the days that start within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn days(self) -> Days;
 
     /// Returns an iterator of all the monday-based weeks that start within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn monday_based_weeks(self) -> MondayBasedWeeks;
 
     /// Returns an iterator of all the sunday-based weeks that start within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn sunday_based_weeks(self) -> SundayBasedWeeks;
 
     /// Returns an iterator of all the months that start within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn months(self) -> Months;
 
     /// Returns an iterator of all the years that start within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn years(self) -> Years;
 
     /// Returns an iterator of all the seconds that start and end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn full_seconds(self) -> Seconds;
 
     /// Returns an iterator of all the minutes that start and end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn full_minutes(self) -> Minutes;
 
     /// Returns an iterator of all the hours that start and end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn full_hours(self) -> Hours;
 
     /// Returns an iterator of all the days that start and end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn full_days(self) -> Days;
 
     /// Returns an iterator of all the monday-based weeks that start and end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn full_monday_based_weeks(self) -> MondayBasedWeeks;
 
     /// Returns an iterator of all the sunday-based weeks that start and end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn full_sunday_based_weeks(self) -> SundayBasedWeeks;
 
     /// Returns an iterator of all the months that start and end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn full_months(self) -> Months;
 
     /// Returns an iterator of all the years that start and end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn full_years(self) -> Years;
 
     /// Returns an iterator of all the seconds that start or end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn overlapping_seconds(self) -> Seconds;
 
     /// Returns an iterator of all the minutes that start or end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn overlapping_minutes(self) -> Minutes;
 
     /// Returns an iterator of all the hours that start or end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn overlapping_hours(self) -> Hours;
 
     /// Returns an iterator of all the days that start or end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn overlapping_days(self) -> Days;
 
     /// Returns an iterator of all the monday-based weeks that start or end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn overlapping_monday_based_weeks(self) -> MondayBasedWeeks;
 
     /// Returns an iterator of all the sunday-based weeks that start or end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn overlapping_sunday_based_weeks(self) -> SundayBasedWeeks;
 
     /// Returns an iterator of all the months that start or end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn overlapping_months(self) -> Months;
 
     /// Returns an iterator of all the years that start or end within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn overlapping_years(self) -> Years;
 
@@ -149,86 +150,92 @@ pub trait OffsetDateTimeRangeExt {
     fn engulfed_by(self, other: Range<OffsetDateTime>) -> bool;
 
     /// Split the range into two ranges at the specified `OffsetDateTime`.
-    /// 
+    ///
     /// If the `OffsetDateTime` is not within the range, the method will return `None`.
-    /// 
+    ///
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the range start.
-    fn split_at(self, date: OffsetDateTime) -> Option<(Range<OffsetDateTime>, Range<OffsetDateTime>)>;
+    fn split_at(
+        self,
+        date: OffsetDateTime,
+    ) -> Option<(Range<OffsetDateTime>, Range<OffsetDateTime>)>;
 
     /// Split the range into multiple ranges at the specified `OffsetDateTime`.
-    /// 
+    ///
     /// The range will only be split at the specified `OffsetDateTime` if it is within the range.
-    /// 
+    ///
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
     fn split_at_multiple(self, dates: &[OffsetDateTime]) -> Vec<Range<OffsetDateTime>>;
 
     /// Split the range into ranges of specified duration.
-    /// 
+    ///
     /// If the unit is not a multiple of the range's duration, the last range will be shorter.
-    /// 
+    /// If the unit is zero or negative, the method will panic.
+    ///
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned by the iterator will have the same offset as this range start.
     fn split_by(self, unit: Duration) -> SplitDuration;
 
     /// Split the range into a list of ranges of equal duration.
-    /// 
-    /// If the number_of_parts is not a multiple of the range's duration, the first ranges returned will be longer than the last ones.
-    /// 
+    ///
+    /// If the `number_of_parts` is not a multiple of the range's duration, the first ranges returned will be longer than the last ones.
+    /// If the `number_of_parts` is larger than the range's duration, the last ranges will be empty.
+    /// If the `number_of_parts` is 0, the method will panic.
+    ///
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned by the iterator will have the same offset as this range start.
     fn divide_equally(self, number_of_parts: usize) -> SplitCount;
 
     /// Returns a range that is the intersection of this range and the specified one.
-    /// 
+    ///
     /// If the ranges do not intersect, the method will return `None`.
-    /// 
+    ///
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
     fn intersection(self, other: Range<OffsetDateTime>) -> Option<Range<OffsetDateTime>>;
 
     /// Returns a range that is the union of this range and the specified one.
-    /// 
+    ///
     /// If the ranges do not overlap, the method will return `None`.
-    /// 
+    ///
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
     fn union(self, other: Range<OffsetDateTime>) -> Option<Range<OffsetDateTime>>;
 
     /// Returns a list of ranges that don't overlap with the specified one.
-    /// 
+    ///
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
     fn difference(self, other: Range<OffsetDateTime>) -> Vec<Range<OffsetDateTime>>;
 
     /// Returns a list of ranges that don't overlap with any of the specified one
-    /// 
+    ///
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
     fn difference_multiple(self, others: &[Range<OffsetDateTime>]) -> Vec<Range<OffsetDateTime>>;
 }
 
 /// Extension of [`&[Range<OffsetDateTime>]`](https://doc.rust-lang.org/std/primitive.slice.html) containing useful methods.
-/// 
+///
 /// If you want to access these methods, you must import the [`OffsetDateTimeRangeSliceExt`] trait.
 pub trait OffsetDateTimeRangeSliceExt {
     /// Returns an intersection of all the ranges in the slice.
-    /// 
+    ///
     /// If there is no point where all the ranges intersect, the method will return `None`.
-    /// 
+    ///
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the first range start.
     fn intersection(&self) -> Option<Range<OffsetDateTime>>;
 
     /// Returns a range that is the union of all the ranges in the slice. If the intervals are adjacent, they will be merged.
     /// It essentially returns a range with start equal to the smallest start in the slice and end equal to the largest end in the slice.
-    /// 
-    /// If the ranges don't fully overlap, ie there are spots that are not covered by any range, the method will return `None`.
-    /// 
+    ///
+    /// If the ranges don't fully overlap, ie there are gaps that are not covered by any range, the method will return `None`.
+    ///
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the first range start.
     fn union(&self) -> Option<Range<OffsetDateTime>>;
 
     /// Returns a list of ranges that are reduced to the minimum set of ranges that don't overlap.
-    /// 
+    ///
     /// This function combines oferlapping and adjacent ranges.
-    /// 
+    ///
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the first range start.
     fn merge(&self) -> Vec<Range<OffsetDateTime>>;
 
     /// Returns a list of ranges that only appear in one of the specified ranges.
-    /// 
+    ///
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the first range start.
     fn xor(&self) -> Vec<Range<OffsetDateTime>>;
 }
@@ -264,7 +271,7 @@ pub mod iter {
         fn len(&self) -> usize {
             // if the range start is after the range end, the range is empty
             // in that case, we return 0
-            if self.end < self.current {
+            if self.end <= self.current {
                 return 0;
             }
 
@@ -273,13 +280,12 @@ pub mod iter {
 
             // basically a ceil function, but without f64 conversion
             // this way we don't have to worry about rounding errors
-            let has_exceeded_second =
-                self.end.nanosecond() != 0;
-            
+            let has_exceeded_second = self.end.nanosecond() != 0;
+
             duration.whole_seconds() as usize + has_exceeded_second as usize
         }
     }
-    
+
     /// An iterator of the minutes within a range.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Minutes {
@@ -307,7 +313,7 @@ pub mod iter {
         fn len(&self) -> usize {
             // if the range start is after the range end, the range is empty
             // in that case, we return 0
-            if self.end < self.current {
+            if self.end <= self.current {
                 return 0;
             }
 
@@ -316,10 +322,8 @@ pub mod iter {
 
             // basically a ceil function, but without f64 conversion
             // this way we don't have to worry about rounding errors
-            let has_exceeded_minute =
-                self.end.second() != 0 ||
-                self.end.nanosecond() != 0;
-                
+            let has_exceeded_minute = self.end.second() != 0 || self.end.nanosecond() != 0;
+
             duration.whole_minutes() as usize + has_exceeded_minute as usize
         }
     }
@@ -351,7 +355,7 @@ pub mod iter {
         fn len(&self) -> usize {
             // if the range start is after the range end, the range is empty
             // in that case, we return 0
-            if self.end < self.current {
+            if self.end <= self.current {
                 return 0;
             }
 
@@ -361,10 +365,8 @@ pub mod iter {
             // basically a ceil function, but without f64 conversion
             // this way we don't have to worry about rounding errors
             let has_exceeded_hour =
-                self.end.minute() != 0 ||
-                self.end.second() != 0 ||
-                self.end.nanosecond() != 0;
-                
+                self.end.minute() != 0 || self.end.second() != 0 || self.end.nanosecond() != 0;
+
             duration.whole_hours() as usize + has_exceeded_hour as usize
         }
     }
@@ -396,7 +398,7 @@ pub mod iter {
         fn len(&self) -> usize {
             // if the range start is after the range end, the range is empty
             // in that case, we return 0
-            if self.end < self.current {
+            if self.end <= self.current {
                 return 0;
             }
 
@@ -405,12 +407,11 @@ pub mod iter {
 
             // basically a ceil function, but without f64 conversion
             // this way we don't have to worry about rounding errors
-            let has_exceeded_day =
-                self.end.hour() != 0 ||
-                self.end.minute() != 0 ||
-                self.end.second() != 0 ||
-                self.end.nanosecond() != 0;
-            
+            let has_exceeded_day = self.end.hour() != 0
+                || self.end.minute() != 0
+                || self.end.second() != 0
+                || self.end.nanosecond() != 0;
+
             duration.whole_days() as usize + has_exceeded_day as usize
         }
     }
@@ -442,7 +443,7 @@ pub mod iter {
         fn len(&self) -> usize {
             // if the range start is after the range end, the range is empty
             // in that case, we return 0
-            if self.end < self.current {
+            if self.end <= self.current {
                 return 0;
             }
 
@@ -451,13 +452,12 @@ pub mod iter {
 
             // basically a ceil function, but without f64 conversion
             // this way we don't have to worry about rounding errors
-            let has_exceeded_week =
-                self.end.weekday() != Weekday::Monday ||
-                self.end.hour() != 0 ||
-                self.end.minute() != 0 ||
-                self.end.second() != 0 ||
-                self.end.nanosecond() != 0;
-                
+            let has_exceeded_week = self.end.weekday() != Weekday::Monday
+                || self.end.hour() != 0
+                || self.end.minute() != 0
+                || self.end.second() != 0
+                || self.end.nanosecond() != 0;
+
             duration.whole_weeks() as usize + has_exceeded_week as usize
         }
     }
@@ -489,7 +489,7 @@ pub mod iter {
         fn len(&self) -> usize {
             // if the range start is after the range end, the range is empty
             // in that case, we return 0
-            if self.end < self.current {
+            if self.end <= self.current {
                 return 0;
             }
 
@@ -498,13 +498,12 @@ pub mod iter {
 
             // basically a ceil function, but without f64 conversion
             // this way we don't have to worry about rounding errors
-            let has_exceeded_week =
-                self.end.weekday() != Weekday::Sunday ||
-                self.end.hour() != 0 ||
-                self.end.minute() != 0 ||
-                self.end.second() != 0 ||
-                self.end.nanosecond() != 0;
-                
+            let has_exceeded_week = self.end.weekday() != Weekday::Sunday
+                || self.end.hour() != 0
+                || self.end.minute() != 0
+                || self.end.second() != 0
+                || self.end.nanosecond() != 0;
+
             duration.whole_weeks() as usize + has_exceeded_week as usize
         }
     }
@@ -536,7 +535,7 @@ pub mod iter {
         fn len(&self) -> usize {
             // if the range start is after the range end, the range is empty
             // in that case, we return 0
-            if self.end < self.current {
+            if self.end <= self.current {
                 return 0;
             }
 
@@ -552,13 +551,12 @@ pub mod iter {
 
             // basically a ceil function, but without f64 conversion
             // this way we don't have to worry about rounding errors
-            let has_exceeded_month =
-                self.end.day() != 1 ||
-                self.end.hour() != 0 ||
-                self.end.minute() != 0 ||
-                self.end.second() != 0 ||
-                self.end.nanosecond() != 0;
-            
+            let has_exceeded_month = self.end.day() != 1
+                || self.end.hour() != 0
+                || self.end.minute() != 0
+                || self.end.second() != 0
+                || self.end.nanosecond() != 0;
+
             whole_months + has_exceeded_month as usize
         }
     }
@@ -590,7 +588,7 @@ pub mod iter {
         fn len(&self) -> usize {
             // if the range start is after the range end, the range is empty
             // in that case, we return 0
-            if self.end < self.current {
+            if self.end <= self.current {
                 return 0;
             }
 
@@ -599,14 +597,13 @@ pub mod iter {
 
             // basically a ceil function, but without f64 conversion
             // this way we don't have to worry about rounding errors
-            let has_exceeded_year =
-                self.end.month() != Month::January ||
-                self.end.day() != 1 ||
-                self.end.hour() != 0 ||
-                self.end.minute() != 0 ||
-                self.end.second() != 0 ||
-                self.end.nanosecond() != 0;
-                
+            let has_exceeded_year = self.end.month() != Month::January
+                || self.end.day() != 1
+                || self.end.hour() != 0
+                || self.end.minute() != 0
+                || self.end.second() != 0
+                || self.end.nanosecond() != 0;
+
             whole_years + has_exceeded_year as usize
         }
     }
@@ -614,9 +611,35 @@ pub mod iter {
     /// An iterator of the unit-wide ranges within a range.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct SplitDuration {
-        pub(super) current: OffsetDateTime,
-        pub(super) end: OffsetDateTime,
-        pub(super) unit: Duration,
+        current: OffsetDateTime,
+        end: OffsetDateTime,
+        unit: Duration,
+    }
+
+    impl SplitDuration {
+        pub(super) fn new(start: OffsetDateTime, end: OffsetDateTime, unit: Duration) -> Self {
+            // it is impossible to add enough 0 to get to the end of the range, so we panic
+            if unit == Duration::ZERO {
+                panic!("Cannot split a range into units of 0");
+            }
+
+            // if the unit is negative, we panic
+            if unit.is_negative() {
+                Self {
+                    current: start,
+                    end,
+                    unit,
+                }
+            }
+            // we build the iterator
+            else {
+                Self {
+                    current: start,
+                    end,
+                    unit,
+                }
+            }
+        }
     }
 
     impl Iterator for SplitDuration {
@@ -640,38 +663,108 @@ pub mod iter {
     /// An iterator of the  ranges within a range.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct SplitCount {
-        pub(super) current: OffsetDateTime,
-        pub(super) end: OffsetDateTime,
-        pub(super) number_of_parts: usize,
+        current: OffsetDateTime,
+        end: OffsetDateTime,
+        remaining_extended_ranges: usize,
+        extended_ranges_duration: Duration,
+        remaining_normal_ranges: usize,
+        normal_ranges_duration: Duration,
+    }
+
+    impl SplitCount {
+        pub(super) fn new(current: OffsetDateTime, end: OffsetDateTime, number_of_parts: usize) -> Self {
+            // it is impossible to divide something by 0, so we panic
+            if number_of_parts == 0 {
+                panic!("Cannot split a range into 0 parts");
+            }
+
+            // if the range start is after the range end, the range is empty
+            if end <= current {
+                Self {
+                    current,
+                    end,
+                    remaining_extended_ranges: 0,
+                    extended_ranges_duration: Duration::ZERO,
+                    remaining_normal_ranges: 0,
+                    normal_ranges_duration: Duration::ZERO,
+                }
+            }
+            // in case everything is normal
+            else {
+                // compute the duration of normal ranges
+                let range_duration = (end - current).whole_nanoseconds() as u128;
+                let normal_ranges_length = (range_duration / number_of_parts as u128) as i64;
+                let extended_ranges_count = (range_duration % number_of_parts as u128) as usize;
+
+                let normal_ranges_duration = Duration::nanoseconds(normal_ranges_length);
+                let extended_ranges_duration = Duration::nanoseconds(normal_ranges_length + 1);
+
+                Self {
+                    current,
+                    end,
+                    remaining_extended_ranges: extended_ranges_count,
+                    extended_ranges_duration,
+                    remaining_normal_ranges: number_of_parts - extended_ranges_count,
+                    normal_ranges_duration,
+                }
+            }
+        }
     }
 
     impl Iterator for SplitCount {
         type Item = Range<OffsetDateTime>;
 
         fn next(&mut self) -> Option<Self::Item> {
-            todo!()
+            // if there are still extended ranges to be returned, then return them first
+            if self.remaining_extended_ranges != 0 {
+                self.remaining_extended_ranges -= 1;
+                let current = self.current;
+                self.current += self.extended_ranges_duration;
+                Some(current..self.current)
+            }
+            // if there we don't have exhausted all the ranges yet, then continue returning them
+            else if self.remaining_normal_ranges != 0 {
+                self.remaining_normal_ranges -= 1;
+                let current = self.current;
+                self.current += self.normal_ranges_duration;
+                if self.current > self.end {
+                    Some(current..self.end)
+                } else {
+                    Some(current..self.current)
+                }
+            }
+            // once we are out of ranges, return None
+            else {
+                None
+            }
+        }
+    }
+
+    impl ExactSizeIterator for SplitCount {
+        fn len(&self) -> usize {
+            self.remaining_extended_ranges + self.remaining_normal_ranges
         }
     }
 }
 
-/// Implementation of the `OffsetDateTimeRange` trait for `Range<OffsetDateTime>`.
+/// Implementation of the `OffsetDateTimeRangeExt` trait for `Range<OffsetDateTime>`.
 impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
-
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// # use time::Duration;
-    /// let start = datetime!(2022-04-18 03:17:12.200 UTC);
-    /// let end = datetime!(2022-04-18 03:17:17.600 UTC);
-    /// assert_eq!((start..end).len(Duration::SECOND), 5);
-    /// ```
     fn len(self, unit: Duration) -> usize {
         // if the range start is after the range end, the range is empty
         // and we return 0
         if self.end <= self.start {
-            0
+            return 0;
         }
-        
+
+        // if the unit is zero, we return 0
+        if unit == Duration::ZERO {
+            return 0;
+        }
+
+        // if the duration is negative, we return 0
+        if unit.is_negative() {
+            return 0;
+        }
         // if the range isn't empty, then the duration is positive
         else {
             let range_duration = (self.end - self.start).whole_nanoseconds() as u128;
@@ -680,19 +773,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-18 03:17:12.200 UTC);
-    /// let end = datetime!(2022-04-18 03:17:17.600 UTC);
-    /// let mut seconds = (start..end).seconds();
-    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:13 UTC)));
-    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:14 UTC)));
-    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:15 UTC)));
-    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:16 UTC)));
-    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:17 UTC)));
-    /// assert_eq!(seconds.next(), None);
-    /// ```
     fn seconds(self) -> Seconds {
         Seconds {
             current: self.start.ceil_seconds(),
@@ -700,16 +780,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-18 03:17:17 UTC);
-    /// let end = datetime!(2022-04-18 03:19:42 UTC);
-    /// let mut minutes = (start..end).minutes();
-    /// assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:18:00 UTC)));
-    /// assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:19:00 UTC)));
-    /// assert_eq!(minutes.next(), None);
-    /// ```
     fn minutes(self) -> Minutes {
         Minutes {
             current: self.start.ceil_minutes(),
@@ -717,18 +787,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-18 03:17:00 UTC);
-    /// let end = datetime!(2022-04-18 07:42:00 UTC);
-    /// let mut hours = (start..end).hours();
-    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 04:00:00 UTC)));
-    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 05:00:00 UTC)));
-    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 06:00:00 UTC)));
-    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 07:00:00 UTC)));
-    /// assert_eq!(hours.next(), None);
-    /// ```
     fn hours(self) -> Hours {
         Hours {
             current: self.start.ceil_hours(),
@@ -736,16 +794,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-18 04:00:00 UTC);
-    /// let end = datetime!(2022-04-20 08:00:00 UTC);
-    /// let mut days = (start..end).days();
-    /// assert_eq!(days.next(), Some(datetime!(2022-04-19 00:00:00 UTC)));
-    /// assert_eq!(days.next(), Some(datetime!(2022-04-20 00:00:00 UTC)));
-    /// assert_eq!(days.next(), None);
-    /// ```
     fn days(self) -> Days {
         Days {
             current: self.start.ceil_days(),
@@ -753,16 +801,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-07 00:00:00 UTC);
-    /// let end = datetime!(2022-04-21 00:00:00 UTC);
-    /// let mut weeks = (start..end).monday_based_weeks();
-    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-11 00:00:00 UTC)));
-    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-18 00:00:00 UTC)));
-    /// assert_eq!(weeks.next(), None);
-    /// ```
     fn monday_based_weeks(self) -> MondayBasedWeeks {
         MondayBasedWeeks {
             current: self.start.ceil_monday_based_weeks(),
@@ -770,16 +808,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-07 00:00:00 UTC);
-    /// let end = datetime!(2022-04-21 00:00:00 UTC);
-    /// let mut weeks = (start..end).sunday_based_weeks();
-    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-10 00:00:00 UTC)));
-    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-17 00:00:00 UTC)));
-    /// assert_eq!(weeks.next(), None);
-    /// ```
     fn sunday_based_weeks(self) -> SundayBasedWeeks {
         SundayBasedWeeks {
             current: self.start.ceil_sunday_based_weeks(),
@@ -787,16 +815,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-13 00:00:00 UTC);
-    /// let end = datetime!(2022-06-26 00:00:00 UTC);
-    /// let mut months = (start..end).months();
-    /// assert_eq!(months.next(), Some(datetime!(2022-05-01 00:00:00 UTC)));
-    /// assert_eq!(months.next(), Some(datetime!(2022-06-01 00:00:00 UTC)));
-    /// assert_eq!(months.next(), None);
-    /// ```
     fn months(self) -> Months {
         Months {
             current: self.start.ceil_months(),
@@ -804,16 +822,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2020-06-01 00:00:00 UTC);
-    /// let end = datetime!(2022-09-01 00:00:00 UTC);
-    /// let mut years = (start..end).years();
-    /// assert_eq!(years.next(), Some(datetime!(2021-01-01 00:00:00 UTC)));
-    /// assert_eq!(years.next(), Some(datetime!(2022-01-01 00:00:00 UTC)));
-    /// assert_eq!(years.next(), None);
-    /// ```
     fn years(self) -> Years {
         Years {
             current: self.start.ceil_years(),
@@ -821,18 +829,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-18 03:17:12.200 UTC);
-    /// let end = datetime!(2022-04-18 03:17:17.600 UTC);
-    /// let mut seconds = (start..end).full_seconds();
-    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:13 UTC)));
-    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:14 UTC)));
-    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:15 UTC)));
-    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:16 UTC)));
-    /// assert_eq!(seconds.next(), None);
-    /// ```
     fn full_seconds(self) -> Seconds {
         Seconds {
             current: self.start.ceil_seconds(),
@@ -840,15 +836,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-18 03:17:17 UTC);
-    /// let end = datetime!(2022-04-18 03:19:42 UTC);
-    /// let mut minutes = (start..end).full_minutes();
-    /// assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:18:00 UTC)));
-    /// assert_eq!(minutes.next(), None);
-    /// ```
     fn full_minutes(self) -> Minutes {
         Minutes {
             current: self.start.ceil_minutes(),
@@ -856,17 +843,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-18 03:17:00 UTC);
-    /// let end = datetime!(2022-04-18 07:42:00 UTC);
-    /// let mut hours = (start..end).full_hours();
-    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 04:00:00 UTC)));
-    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 05:00:00 UTC)));
-    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 06:00:00 UTC)));
-    /// assert_eq!(hours.next(), None);
-    /// ```
     fn full_hours(self) -> Hours {
         Hours {
             current: self.start.ceil_hours(),
@@ -874,15 +850,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-18 04:00:00 UTC);
-    /// let end = datetime!(2022-04-20 08:00:00 UTC);
-    /// let mut days = (start..end).full_days();
-    /// assert_eq!(days.next(), Some(datetime!(2022-04-19 00:00:00 UTC)));
-    /// assert_eq!(days.next(), None);
-    /// ```
     fn full_days(self) -> Days {
         Days {
             current: self.start.ceil_days(),
@@ -890,15 +857,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-7 00:00:00 UTC);
-    /// let end = datetime!(2022-04-21 00:00:00 UTC);
-    /// let mut weeks = (start..end).full_monday_based_weeks();
-    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-11 00:00:00 UTC)));
-    /// assert_eq!(weeks.next(), None);
-    /// ```
     fn full_monday_based_weeks(self) -> MondayBasedWeeks {
         MondayBasedWeeks {
             current: self.start.ceil_monday_based_weeks(),
@@ -906,15 +864,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-7 00:00:00 UTC);
-    /// let end = datetime!(2022-04-21 00:00:00 UTC);
-    /// let mut weeks = (start..end).full_sunday_based_weeks();
-    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-10 00:00:00 UTC)));
-    /// assert_eq!(weeks.next(), None);
-    /// ```
     fn full_sunday_based_weeks(self) -> SundayBasedWeeks {
         SundayBasedWeeks {
             current: self.start.ceil_sunday_based_weeks(),
@@ -922,15 +871,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-13 00:00:00 UTC);
-    /// let end = datetime!(2022-06-26 00:00:00 UTC);
-    /// let mut months = (start..end).full_months();
-    /// assert_eq!(months.next(), Some(datetime!(2022-05-01 00:00:00 UTC)));
-    /// assert_eq!(months.next(), None);
-    /// ```
     fn full_months(self) -> Months {
         Months {
             current: self.start.ceil_months(),
@@ -938,15 +878,6 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2020-06-01 00:00:00 UTC);
-    /// let end = datetime!(2022-09-01 00:00:00 UTC);
-    /// let mut years = (start..end).full_years();
-    /// assert_eq!(years.next(), Some(datetime!(2021-01-01 00:00:00 UTC)));
-    /// assert_eq!(years.next(), None);
-    /// ```
     fn full_years(self) -> Years {
         Years {
             current: self.start.ceil_years(),
@@ -954,225 +885,66 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-18 03:17:12.200 UTC);
-    /// let end = datetime!(2022-04-18 03:17:17.600 UTC);
-    /// let mut seconds = (start..end).overlapping_seconds();
-    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:12 UTC)));
-    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:13 UTC)));
-    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:14 UTC)));
-    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:15 UTC)));
-    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:16 UTC)));
-    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:17 UTC)));
-    /// assert_eq!(seconds.next(), None);
-    /// ```
     fn overlapping_seconds(self) -> Seconds {
         Seconds {
             current: self.start.floor_seconds(),
-            end: self.end,
+            end: self.end.ceil_seconds(),
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-18 03:17:17 UTC);
-    /// let end = datetime!(2022-04-18 03:19:42 UTC);
-    /// let mut minutes = (start..end).overlapping_minutes();
-    /// assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:17:00 UTC)));
-    /// assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:18:00 UTC)));
-    /// assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:19:00 UTC)));
-    /// assert_eq!(minutes.next(), None);
-    /// ```
     fn overlapping_minutes(self) -> Minutes {
         Minutes {
             current: self.start.floor_minutes(),
-            end: self.end,
+            end: self.end.ceil_minutes(),
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-18 03:17:00 UTC);
-    /// let end = datetime!(2022-04-18 07:42:00 UTC);
-    /// let mut hours = (start..end).overlapping_hours();
-    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 03:00:00 UTC)));
-    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 04:00:00 UTC)));
-    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 05:00:00 UTC)));
-    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 06:00:00 UTC)));
-    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 07:00:00 UTC)));
-    /// assert_eq!(hours.next(), None);
-    /// ```
     fn overlapping_hours(self) -> Hours {
         Hours {
             current: self.start.floor_hours(),
-            end: self.end,
+            end: self.end.ceil_hours(),
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-18 04:00:00 UTC);
-    /// let end = datetime!(2022-04-20 08:00:00 UTC);
-    /// let mut days = (start..end).overlapping_days();
-    /// assert_eq!(days.next(), Some(datetime!(2022-04-18 00:00:00 UTC)));
-    /// assert_eq!(days.next(), Some(datetime!(2022-04-19 00:00:00 UTC)));
-    /// assert_eq!(days.next(), Some(datetime!(2022-04-20 00:00:00 UTC)));
-    /// assert_eq!(days.next(), None);
-    /// ```
     fn overlapping_days(self) -> Days {
         Days {
             current: self.start.floor_days(),
-            end: self.end,
+            end: self.end.ceil_days(),
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-07 00:00:00 UTC);
-    /// let end = datetime!(2022-04-21 00:00:00 UTC);
-    /// let mut weeks = (start..end).overlapping_monday_based_weeks();
-    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-04 00:00:00 UTC)));
-    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-11 00:00:00 UTC)));
-    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-18 00:00:00 UTC)));
-    /// assert_eq!(weeks.next(), None);
-    /// ```
     fn overlapping_monday_based_weeks(self) -> MondayBasedWeeks {
         MondayBasedWeeks {
             current: self.start.floor_monday_based_weeks(),
-            end: self.end,
+            end: self.end.ceil_monday_based_weeks(),
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-07 00:00:00 UTC);
-    /// let end = datetime!(2022-04-21 00:00:00 UTC);
-    /// let mut weeks = (start..end).overlapping_sunday_based_weeks();
-    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-03 00:00:00 UTC)));
-    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-10 00:00:00 UTC)));
-    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-17 00:00:00 UTC)));
-    /// assert_eq!(weeks.next(), None);
-    /// ```
     fn overlapping_sunday_based_weeks(self) -> SundayBasedWeeks {
         SundayBasedWeeks {
             current: self.start.floor_sunday_based_weeks(),
-            end: self.end,
+            end: self.end.ceil_sunday_based_weeks(),
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2022-04-13 00:00:00 UTC);
-    /// let end = datetime!(2022-06-26 00:00:00 UTC);
-    /// let mut months = (start..end).overlapping_months();
-    /// assert_eq!(months.next(), Some(datetime!(2022-04-01 00:00:00 UTC)));
-    /// assert_eq!(months.next(), Some(datetime!(2022-05-01 00:00:00 UTC)));
-    /// assert_eq!(months.next(), Some(datetime!(2022-06-01 00:00:00 UTC)));
-    /// assert_eq!(months.next(), None);
-    /// ```
     fn overlapping_months(self) -> Months {
         Months {
             current: self.start.floor_months(),
-            end: self.end,
+            end: self.end.ceil_months(),
         }
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let start = datetime!(2020-06-01 00:00:00 UTC);
-    /// let end = datetime!(2022-09-01 00:00:00 UTC);
-    /// let mut years = (start..end).overlapping_years();
-    /// assert_eq!(years.next(), Some(datetime!(2020-01-01 00:00:00 UTC)));
-    /// assert_eq!(years.next(), Some(datetime!(2021-01-01 00:00:00 UTC)));
-    /// assert_eq!(years.next(), Some(datetime!(2022-01-01 00:00:00 UTC)));
-    /// assert_eq!(years.next(), None);
-    /// ```
     fn overlapping_years(self) -> Years {
         Years {
             current: self.start.floor_years(),
-            end: self.end,
+            end: self.end.ceil_years(),
         }
     }
 
-    /// Here `range1` and `range2` overlap between the `2022-04-08 UTC` and the `2022-04-10 UTC`.
-    /// 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
-    /// let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
-    /// // ranges can't be copied, so we are using `clone()` here
-    /// assert!(range1.clone().overlaps(range2.clone()));
-    /// assert!(range2.clone().overlaps(range1.clone()));
-    /// ```
-    /// 
-    /// Overlap, as `range1` is contained within `range2`.
-    /// 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
-    /// let range2 = datetime!(2022-04-03 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
-    /// // ranges can't be copied, so we are using `clone()` here
-    /// assert!(range1.clone().overlaps(range2.clone()));
-    /// assert!(range2.clone().overlaps(range1.clone()));
-    /// ```
-    /// 
-    /// No overlap here, there is a gap between the two ranges.
-    /// 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
-    /// let range2 = datetime!(2022-04-12 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
-    /// // ranges can't be copied, so we are using `clone()` here
-    /// assert!(!range1.clone().overlaps(range2.clone()));
-    /// assert!(!range2.clone().overlaps(range1.clone()));
-    /// ```
-    /// 
-    /// Negative ranges dont't overlap.
-    /// 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let range1 = datetime!(2022-04-10 00:00:00 UTC)..datetime!(2022-04-06 00:00:00 UTC);
-    /// let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
-    /// // ranges can't be copied, so we are using `clone()` here
-    /// assert!(!range1.clone().overlaps(range2.clone()));
-    /// assert!(!range2.clone().overlaps(range1.clone()));
-    /// ```
     fn overlaps(self, other: Range<OffsetDateTime>) -> bool {
         self.start < self.end && other.start < other.end && self.start < other.end && other.start < self.end
     }
 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
-    /// let range2 = datetime!(2022-04-10 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
-    /// // ranges can't be copied, so we are using `clone()` here
-    /// assert!(range1.clone().left_adjacent_to(range2.clone()));
-    /// assert!(!range2.clone().left_adjacent_to(range1.clone()));
-    /// ```
-    /// 
-    /// ```rust
-    /// # use time::macros::datetime;
-    /// # use time::OffsetDateTimeRangeExt;
-    /// let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
-    /// let range2 = datetime!(2022-04-12 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
-    /// // ranges can't be copied, so we are using `clone()` here
-    /// assert!(!range1.clone().left_adjacent_to(range2.clone()));
-    /// assert!(!range2.clone().left_adjacent_to(range1.clone()));
-    /// ```
     fn left_adjacent_to(self, other: Range<OffsetDateTime>) -> bool {
         self.start < self.end && other.start < other.end && self.end == other.start
     }
@@ -1194,15 +966,14 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
         if self.start < self.end && self.start < date && date < self.end {
             // find the start offset to make sure each sub-range has the same offset as the original
             let start_offset = self.start.offset();
-            
+
             // update the offsets to match the original offset
-            self.end = self.end.to_offset(start_offset);
             date = date.to_offset(start_offset);
-            
+            self.end = self.end.to_offset(start_offset);
+
             // split the range
             Some((self.start..date, date..self.end))
         }
-
         // if the range is reversed or the date is outside of the range, return `None`
         else {
             None
@@ -1217,7 +988,7 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
 
         // find the start offset to make sure each sub-range has the same offset as the original
         let start_offset = self.start.offset();
-        
+
         // ensure the end is in the same offset, else the last range will end with a different offset compared to others
         self.end = self.end.to_offset(start_offset);
 
@@ -1227,9 +998,7 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
             // convert &OffsetDateTime to OffsetDateTime
             .copied()
             // filter out dates that are not in the range
-            .filter(|date| self.contains(date))
-            // filter out dates that are the same as the start or end of the range
-            .filter(|date| *date != self.start && *date != self.end)
+            .filter(|date| self.start < *date && *date < self.end)
             // make sure all dates have the same offset as the start of the range
             .map(|date| date.to_offset(start_offset))
             // collect the date into a vector
@@ -1256,19 +1025,11 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
     }
 
     fn split_by(self, unit: Duration) -> SplitDuration {
-        SplitDuration {
-            current: self.start,
-            end: self.end,
-            unit,
-        }
+        SplitDuration::new(self.start, self.end, unit)
     }
 
     fn divide_equally(self, number_of_parts: usize) -> SplitCount {
-        SplitCount {
-            current: self.start,
-            end: self.end,
-            number_of_parts,
-        }
+        SplitCount::new(self.start, self.end, number_of_parts)
     }
 
     fn intersection(self, other: Range<OffsetDateTime>) -> Option<Range<OffsetDateTime>> {
@@ -1293,10 +1054,171 @@ impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
     }
 
     fn difference(self, other: Range<OffsetDateTime>) -> Vec<Range<OffsetDateTime>> {
-        todo!()
+        self.difference_multiple(&[other])
     }
 
     fn difference_multiple(self, others: &[Range<OffsetDateTime>]) -> Vec<Range<OffsetDateTime>> {
-        todo!()
+        // if the range is reversed, return an empty vector
+        if self.end <= self.start {
+            return vec![];
+        }
+
+        // compute the difference
+        [&[self.clone()], others]
+            .concat()
+            .xor()
+            .into_iter()
+            .filter_map(|range| range.intersection(self.clone()))
+            .filter(|range| range.start < range.end)
+            .collect::<Vec<_>>()
+    }
+}
+
+/// Implementation of the `OffsetDateTimeRangeSliceExt` trait for `&[Range<OffsetDateTime>]`.
+impl OffsetDateTimeRangeSliceExt for [Range<OffsetDateTime>] {
+    fn intersection(&self) -> Option<Range<OffsetDateTime>> {
+        // we intersect all the ranges one after another
+        let mut intersection = self.first()?.clone();
+
+        for range in self.iter().skip(1).cloned() {
+            // if one of the intersection fails, return `None`
+            intersection = intersection.intersection(range)?;
+        }
+
+        // return the intersection
+        Some(intersection)
+    }
+
+    fn union(&self) -> Option<Range<OffsetDateTime>> {
+        // we union all the ranges one after another
+        let mut union = self.first()?.clone();
+
+        for range in self.iter().skip(1).cloned() {
+            // if one of the union fails, return `None`
+            union = union.union(range)?;
+        }
+
+        // return the union
+        Some(union)
+    }
+
+    fn merge(&self) -> Vec<Range<OffsetDateTime>> {
+        // if slice is empty, return an empty vector
+        if self.is_empty() {
+            return vec![];
+        }
+
+        // find the start offset
+        let start_offset = self[0].start.offset();
+
+        // clone the range slice
+        let mut ranges: Vec<Range<OffsetDateTime>> = self
+            .iter()
+            .filter(|range| range.start < range.end)
+            .map(|range| range.start.to_offset(start_offset)..range.end.to_offset(start_offset))
+            .collect();
+
+        // sort the ranges
+        ranges.sort_by(|a, b| a.start.cmp(&b.start));
+
+        // combine the ranges
+        let (mut merged, last_option): (Vec<Range<OffsetDateTime>>, Option<Range<OffsetDateTime>>) =
+            ranges.iter().fold(
+                (vec![], None),
+                |(mut partial_merge, current_option), range| {
+                    if let Some(current) = current_option {
+                        if range.start <= current.end {
+                            (
+                                partial_merge,
+                                Some(current.start..current.end.max(range.end)),
+                            )
+                        } else {
+                            partial_merge.push(current);
+                            (partial_merge, Some(range.clone()))
+                        }
+                    } else {
+                        (partial_merge, Some(range.clone()))
+                    }
+                },
+            );
+
+        // add the last range to the merged ranges if it exists
+        if let Some(last) = last_option {
+            merged.push(last);
+        }
+
+        // return the merged ranges
+        merged
+    }
+
+    fn xor(&self) -> Vec<Range<OffsetDateTime>> {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        enum Timestamp {
+            Start(OffsetDateTime),
+            End(OffsetDateTime),
+        }
+
+        // if slice is empty, return an empty vector
+        if self.is_empty() {
+            return vec![];
+        }
+
+        // find the start offset
+        let start_offset = self[0].start.offset();
+
+        // split the ranges into start and end timestamps
+        let mut timestamps: Vec<Timestamp> = vec![];
+
+        // keep only the ranges that are not reversed
+        let ranges_iter = self
+            .iter()
+            .filter(|range| range.start < range.end)
+            .map(|range| range.start.to_offset(start_offset)..range.end.to_offset(start_offset));
+
+        for range in ranges_iter {
+            timestamps.push(Timestamp::Start(range.start));
+            timestamps.push(Timestamp::End(range.end));
+        }
+
+        // sort the timestamps by when they occur
+        timestamps.sort_by(|a, b| {
+            match (a, b) {
+                (Timestamp::Start(a), Timestamp::Start(b)) => a.cmp(b),
+                (Timestamp::End(a), Timestamp::End(b)) => a.cmp(b),
+                (Timestamp::Start(a), Timestamp::End(b)) => a.cmp(b),
+                (Timestamp::End(a), Timestamp::Start(b)) => a.cmp(b),
+            }
+        });
+
+        let mut ranges = vec![];
+        let mut count: usize = 0;
+        let mut start: Option<OffsetDateTime> = None;
+
+        for timestamp in timestamps {
+            let current_timestamp = match timestamp {
+                Timestamp::Start(date) => {
+                    count += 1;
+                    date
+                }
+                Timestamp::End(date) => {
+                    count -= 1;
+                    date
+                }
+            };
+
+            if count == 1 {
+                start = Some(current_timestamp);
+            } else {
+                if let Some(start_timestamp) = start {
+                    if start_timestamp != current_timestamp {
+                        ranges.push(start_timestamp..current_timestamp)
+                    }
+
+                    start = None;
+                }
+            }
+        }
+
+        ranges.merge()
     }
 }

--- a/time/src/offset_date_time_range.rs
+++ b/time/src/offset_date_time_range.rs
@@ -1,14 +1,16 @@
-//! Implementations of useful methods for the [`Range<OffsetDateTime>`] and [`Vec<Range<OffsetDateTime>>`] structs.
+//! Implementations of useful methods for the [`Range<OffsetDateTime>`] and [`&[Range<OffsetDateTime>]`](https://doc.rust-lang.org/std/primitive.slice.html) structs.
 
 use std::ops::Range;
 use crate::{OffsetDateTime, Duration, util, Month, Weekday};
 use iter::*;
 
-/// Useful methods for the [`Range<OffsetDateTime>`] struct to expose.
-pub trait OffsetDateTimeRange {
+/// Extension of [`Range<OffsetDateTime>`] containing useful methods.
+/// 
+/// If you want to access these methods, you must import the [`OffsetDateTimeRangeExt`] trait.
+pub trait OffsetDateTimeRangeExt {
     /// Returns the length of the range using the specified duration as the unit.
     /// 
-    /// As an example, using `Duration::DAY` as unit wouldn't count how many days are in the range, but rather how many day-long ranges are in the range.
+    /// Attention, using `Duration::DAY` as unit wouldn't count how many days are in the range, but rather how many day-long ranges would fits inside.
     fn len(self, unit: Duration) -> usize;
 
     /// Returns an iterator of all the seconds that start within the range.
@@ -199,8 +201,10 @@ pub trait OffsetDateTimeRange {
     fn difference_multiple(self, others: &[Range<OffsetDateTime>]) -> Vec<Range<OffsetDateTime>>;
 }
 
-/// Useful methods for the [`[Range<OffsetDateTime>]`](https://doc.rust-lang.org/std/primitive.slice.html) struct to expose.
-pub trait OffsetDateTimeRangeSlice {
+/// Extension of [`&[Range<OffsetDateTime>]`](https://doc.rust-lang.org/std/primitive.slice.html) containing useful methods.
+/// 
+/// If you want to access these methods, you must import the [`OffsetDateTimeRangeSliceExt`] trait.
+pub trait OffsetDateTimeRangeSliceExt {
     /// Returns an intersection of all the ranges in the slice.
     /// 
     /// If there is no point where all the ranges intersect, the method will return `None`.
@@ -650,123 +654,320 @@ pub mod iter {
     }
 }
 
-impl OffsetDateTimeRange for Range<OffsetDateTime> {
+/// Implementation of the `OffsetDateTimeRange` trait for `Range<OffsetDateTime>`.
+impl OffsetDateTimeRangeExt for Range<OffsetDateTime> {
+
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// # use time::Duration;
+    /// let start = datetime!(2022-04-18 03:17:12.200 UTC);
+    /// let end = datetime!(2022-04-18 03:17:17.600 UTC);
+    /// assert_eq!((start..end).len(Duration::SECOND), 5);
+    /// ```
     fn len(self, unit: Duration) -> usize {
-        todo!()
+        // if the range start is after the range end, the range is empty
+        // and we return 0
+        if self.end <= self.start {
+            0
+        }
+        
+        // if the range isn't empty, then the duration is positive
+        else {
+            let range_duration = (self.end - self.start).whole_nanoseconds() as u128;
+            let unit_duration = unit.whole_nanoseconds() as u128;
+            (range_duration / unit_duration) as usize
+        }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-18 03:17:12.200 UTC);
+    /// let end = datetime!(2022-04-18 03:17:17.600 UTC);
+    /// let mut seconds = (start..end).seconds();
+    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:13 UTC)));
+    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:14 UTC)));
+    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:15 UTC)));
+    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:16 UTC)));
+    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:17 UTC)));
+    /// assert_eq!(seconds.next(), None);
+    /// ```
     fn seconds(self) -> Seconds {
         Seconds {
-            current: self.start.next_second(),
+            current: self.start.ceil_seconds(),
             end: self.end,
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-18 03:17:17 UTC);
+    /// let end = datetime!(2022-04-18 03:19:42 UTC);
+    /// let mut minutes = (start..end).minutes();
+    /// assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:18:00 UTC)));
+    /// assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:19:00 UTC)));
+    /// assert_eq!(minutes.next(), None);
+    /// ```
     fn minutes(self) -> Minutes {
         Minutes {
-            current: self.start.next_minute(),
+            current: self.start.ceil_minutes(),
             end: self.end,
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-18 03:17:00 UTC);
+    /// let end = datetime!(2022-04-18 07:42:00 UTC);
+    /// let mut hours = (start..end).hours();
+    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 04:00:00 UTC)));
+    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 05:00:00 UTC)));
+    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 06:00:00 UTC)));
+    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 07:00:00 UTC)));
+    /// assert_eq!(hours.next(), None);
+    /// ```
     fn hours(self) -> Hours {
         Hours {
-            current: self.start.next_hour(),
+            current: self.start.ceil_hours(),
             end: self.end,
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-18 04:00:00 UTC);
+    /// let end = datetime!(2022-04-20 08:00:00 UTC);
+    /// let mut days = (start..end).days();
+    /// assert_eq!(days.next(), Some(datetime!(2022-04-19 00:00:00 UTC)));
+    /// assert_eq!(days.next(), Some(datetime!(2022-04-20 00:00:00 UTC)));
+    /// assert_eq!(days.next(), None);
+    /// ```
     fn days(self) -> Days {
         Days {
-            current: self.start.next_day(),
+            current: self.start.ceil_days(),
             end: self.end,
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-07 00:00:00 UTC);
+    /// let end = datetime!(2022-04-21 00:00:00 UTC);
+    /// let mut weeks = (start..end).monday_based_weeks();
+    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-11 00:00:00 UTC)));
+    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-18 00:00:00 UTC)));
+    /// assert_eq!(weeks.next(), None);
+    /// ```
     fn monday_based_weeks(self) -> MondayBasedWeeks {
         MondayBasedWeeks {
-            current: self.start.next_monday_based_week(),
+            current: self.start.ceil_monday_based_weeks(),
             end: self.end,
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-07 00:00:00 UTC);
+    /// let end = datetime!(2022-04-21 00:00:00 UTC);
+    /// let mut weeks = (start..end).sunday_based_weeks();
+    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-10 00:00:00 UTC)));
+    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-17 00:00:00 UTC)));
+    /// assert_eq!(weeks.next(), None);
+    /// ```
     fn sunday_based_weeks(self) -> SundayBasedWeeks {
         SundayBasedWeeks {
-            current: self.start.next_sunday_based_week(),
+            current: self.start.ceil_sunday_based_weeks(),
             end: self.end,
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-13 00:00:00 UTC);
+    /// let end = datetime!(2022-06-26 00:00:00 UTC);
+    /// let mut months = (start..end).months();
+    /// assert_eq!(months.next(), Some(datetime!(2022-05-01 00:00:00 UTC)));
+    /// assert_eq!(months.next(), Some(datetime!(2022-06-01 00:00:00 UTC)));
+    /// assert_eq!(months.next(), None);
+    /// ```
     fn months(self) -> Months {
         Months {
-            current: self.start.next_month(),
+            current: self.start.ceil_months(),
             end: self.end,
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2020-06-01 00:00:00 UTC);
+    /// let end = datetime!(2022-09-01 00:00:00 UTC);
+    /// let mut years = (start..end).years();
+    /// assert_eq!(years.next(), Some(datetime!(2021-01-01 00:00:00 UTC)));
+    /// assert_eq!(years.next(), Some(datetime!(2022-01-01 00:00:00 UTC)));
+    /// assert_eq!(years.next(), None);
+    /// ```
     fn years(self) -> Years {
         Years {
-            current: self.start.next_year(),
+            current: self.start.ceil_years(),
             end: self.end,
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-18 03:17:12.200 UTC);
+    /// let end = datetime!(2022-04-18 03:17:17.600 UTC);
+    /// let mut seconds = (start..end).full_seconds();
+    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:13 UTC)));
+    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:14 UTC)));
+    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:15 UTC)));
+    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:16 UTC)));
+    /// assert_eq!(seconds.next(), None);
+    /// ```
     fn full_seconds(self) -> Seconds {
         Seconds {
-            current: self.start.next_second(),
+            current: self.start.ceil_seconds(),
             end: self.end.floor_seconds(),
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-18 03:17:17 UTC);
+    /// let end = datetime!(2022-04-18 03:19:42 UTC);
+    /// let mut minutes = (start..end).full_minutes();
+    /// assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:18:00 UTC)));
+    /// assert_eq!(minutes.next(), None);
+    /// ```
     fn full_minutes(self) -> Minutes {
         Minutes {
-            current: self.start.next_minute(),
+            current: self.start.ceil_minutes(),
             end: self.end.floor_minutes(),
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-18 03:17:00 UTC);
+    /// let end = datetime!(2022-04-18 07:42:00 UTC);
+    /// let mut hours = (start..end).full_hours();
+    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 04:00:00 UTC)));
+    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 05:00:00 UTC)));
+    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 06:00:00 UTC)));
+    /// assert_eq!(hours.next(), None);
+    /// ```
     fn full_hours(self) -> Hours {
         Hours {
-            current: self.start.next_hour(),
+            current: self.start.ceil_hours(),
             end: self.end.floor_hours(),
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-18 04:00:00 UTC);
+    /// let end = datetime!(2022-04-20 08:00:00 UTC);
+    /// let mut days = (start..end).full_days();
+    /// assert_eq!(days.next(), Some(datetime!(2022-04-19 00:00:00 UTC)));
+    /// assert_eq!(days.next(), None);
+    /// ```
     fn full_days(self) -> Days {
         Days {
-            current: self.start.next_day(),
+            current: self.start.ceil_days(),
             end: self.end.floor_days(),
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-7 00:00:00 UTC);
+    /// let end = datetime!(2022-04-21 00:00:00 UTC);
+    /// let mut weeks = (start..end).full_monday_based_weeks();
+    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-11 00:00:00 UTC)));
+    /// assert_eq!(weeks.next(), None);
+    /// ```
     fn full_monday_based_weeks(self) -> MondayBasedWeeks {
         MondayBasedWeeks {
-            current: self.start.next_monday_based_week(),
+            current: self.start.ceil_monday_based_weeks(),
             end: self.end.floor_monday_based_weeks(),
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-7 00:00:00 UTC);
+    /// let end = datetime!(2022-04-21 00:00:00 UTC);
+    /// let mut weeks = (start..end).full_sunday_based_weeks();
+    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-10 00:00:00 UTC)));
+    /// assert_eq!(weeks.next(), None);
+    /// ```
     fn full_sunday_based_weeks(self) -> SundayBasedWeeks {
         SundayBasedWeeks {
-            current: self.start.next_sunday_based_week(),
+            current: self.start.ceil_sunday_based_weeks(),
             end: self.end.floor_sunday_based_weeks(),
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-13 00:00:00 UTC);
+    /// let end = datetime!(2022-06-26 00:00:00 UTC);
+    /// let mut months = (start..end).full_months();
+    /// assert_eq!(months.next(), Some(datetime!(2022-05-01 00:00:00 UTC)));
+    /// assert_eq!(months.next(), None);
+    /// ```
     fn full_months(self) -> Months {
         Months {
-            current: self.start.next_month(),
+            current: self.start.ceil_months(),
             end: self.end.floor_months(),
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2020-06-01 00:00:00 UTC);
+    /// let end = datetime!(2022-09-01 00:00:00 UTC);
+    /// let mut years = (start..end).full_years();
+    /// assert_eq!(years.next(), Some(datetime!(2021-01-01 00:00:00 UTC)));
+    /// assert_eq!(years.next(), None);
+    /// ```
     fn full_years(self) -> Years {
         Years {
-            current: self.start.next_year(),
+            current: self.start.ceil_years(),
             end: self.end.floor_years(),
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-18 03:17:12.200 UTC);
+    /// let end = datetime!(2022-04-18 03:17:17.600 UTC);
+    /// let mut seconds = (start..end).overlapping_seconds();
+    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:12 UTC)));
+    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:13 UTC)));
+    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:14 UTC)));
+    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:15 UTC)));
+    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:16 UTC)));
+    /// assert_eq!(seconds.next(), Some(datetime!(2022-04-18 03:17:17 UTC)));
+    /// assert_eq!(seconds.next(), None);
+    /// ```
     fn overlapping_seconds(self) -> Seconds {
         Seconds {
             current: self.start.floor_seconds(),
@@ -774,6 +975,17 @@ impl OffsetDateTimeRange for Range<OffsetDateTime> {
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-18 03:17:17 UTC);
+    /// let end = datetime!(2022-04-18 03:19:42 UTC);
+    /// let mut minutes = (start..end).overlapping_minutes();
+    /// assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:17:00 UTC)));
+    /// assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:18:00 UTC)));
+    /// assert_eq!(minutes.next(), Some(datetime!(2022-04-18 03:19:00 UTC)));
+    /// assert_eq!(minutes.next(), None);
+    /// ```
     fn overlapping_minutes(self) -> Minutes {
         Minutes {
             current: self.start.floor_minutes(),
@@ -781,6 +993,19 @@ impl OffsetDateTimeRange for Range<OffsetDateTime> {
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-18 03:17:00 UTC);
+    /// let end = datetime!(2022-04-18 07:42:00 UTC);
+    /// let mut hours = (start..end).overlapping_hours();
+    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 03:00:00 UTC)));
+    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 04:00:00 UTC)));
+    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 05:00:00 UTC)));
+    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 06:00:00 UTC)));
+    /// assert_eq!(hours.next(), Some(datetime!(2022-04-18 07:00:00 UTC)));
+    /// assert_eq!(hours.next(), None);
+    /// ```
     fn overlapping_hours(self) -> Hours {
         Hours {
             current: self.start.floor_hours(),
@@ -788,6 +1013,17 @@ impl OffsetDateTimeRange for Range<OffsetDateTime> {
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-18 04:00:00 UTC);
+    /// let end = datetime!(2022-04-20 08:00:00 UTC);
+    /// let mut days = (start..end).overlapping_days();
+    /// assert_eq!(days.next(), Some(datetime!(2022-04-18 00:00:00 UTC)));
+    /// assert_eq!(days.next(), Some(datetime!(2022-04-19 00:00:00 UTC)));
+    /// assert_eq!(days.next(), Some(datetime!(2022-04-20 00:00:00 UTC)));
+    /// assert_eq!(days.next(), None);
+    /// ```
     fn overlapping_days(self) -> Days {
         Days {
             current: self.start.floor_days(),
@@ -795,6 +1031,17 @@ impl OffsetDateTimeRange for Range<OffsetDateTime> {
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-07 00:00:00 UTC);
+    /// let end = datetime!(2022-04-21 00:00:00 UTC);
+    /// let mut weeks = (start..end).overlapping_monday_based_weeks();
+    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-04 00:00:00 UTC)));
+    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-11 00:00:00 UTC)));
+    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-18 00:00:00 UTC)));
+    /// assert_eq!(weeks.next(), None);
+    /// ```
     fn overlapping_monday_based_weeks(self) -> MondayBasedWeeks {
         MondayBasedWeeks {
             current: self.start.floor_monday_based_weeks(),
@@ -802,6 +1049,17 @@ impl OffsetDateTimeRange for Range<OffsetDateTime> {
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-07 00:00:00 UTC);
+    /// let end = datetime!(2022-04-21 00:00:00 UTC);
+    /// let mut weeks = (start..end).overlapping_sunday_based_weeks();
+    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-03 00:00:00 UTC)));
+    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-10 00:00:00 UTC)));
+    /// assert_eq!(weeks.next(), Some(datetime!(2022-04-17 00:00:00 UTC)));
+    /// assert_eq!(weeks.next(), None);
+    /// ```
     fn overlapping_sunday_based_weeks(self) -> SundayBasedWeeks {
         SundayBasedWeeks {
             current: self.start.floor_sunday_based_weeks(),
@@ -809,6 +1067,17 @@ impl OffsetDateTimeRange for Range<OffsetDateTime> {
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2022-04-13 00:00:00 UTC);
+    /// let end = datetime!(2022-06-26 00:00:00 UTC);
+    /// let mut months = (start..end).overlapping_months();
+    /// assert_eq!(months.next(), Some(datetime!(2022-04-01 00:00:00 UTC)));
+    /// assert_eq!(months.next(), Some(datetime!(2022-05-01 00:00:00 UTC)));
+    /// assert_eq!(months.next(), Some(datetime!(2022-06-01 00:00:00 UTC)));
+    /// assert_eq!(months.next(), None);
+    /// ```
     fn overlapping_months(self) -> Months {
         Months {
             current: self.start.floor_months(),
@@ -816,6 +1085,17 @@ impl OffsetDateTimeRange for Range<OffsetDateTime> {
         }
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let start = datetime!(2020-06-01 00:00:00 UTC);
+    /// let end = datetime!(2022-09-01 00:00:00 UTC);
+    /// let mut years = (start..end).overlapping_years();
+    /// assert_eq!(years.next(), Some(datetime!(2020-01-01 00:00:00 UTC)));
+    /// assert_eq!(years.next(), Some(datetime!(2021-01-01 00:00:00 UTC)));
+    /// assert_eq!(years.next(), Some(datetime!(2022-01-01 00:00:00 UTC)));
+    /// assert_eq!(years.next(), None);
+    /// ```
     fn overlapping_years(self) -> Years {
         Years {
             current: self.start.floor_years(),
@@ -823,48 +1103,193 @@ impl OffsetDateTimeRange for Range<OffsetDateTime> {
         }
     }
 
+    /// Here `range1` and `range2` overlap between the `2022-04-08 UTC` and the `2022-04-10 UTC`.
+    /// 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+    /// let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+    /// // ranges can't be copied, so we are using `clone()` here
+    /// assert!(range1.clone().overlaps(range2.clone()));
+    /// assert!(range2.clone().overlaps(range1.clone()));
+    /// ```
+    /// 
+    /// Overlap, as `range1` is contained within `range2`.
+    /// 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+    /// let range2 = datetime!(2022-04-03 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+    /// // ranges can't be copied, so we are using `clone()` here
+    /// assert!(range1.clone().overlaps(range2.clone()));
+    /// assert!(range2.clone().overlaps(range1.clone()));
+    /// ```
+    /// 
+    /// No overlap here, there is a gap between the two ranges.
+    /// 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+    /// let range2 = datetime!(2022-04-12 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+    /// // ranges can't be copied, so we are using `clone()` here
+    /// assert!(!range1.clone().overlaps(range2.clone()));
+    /// assert!(!range2.clone().overlaps(range1.clone()));
+    /// ```
+    /// 
+    /// Negative ranges dont't overlap.
+    /// 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let range1 = datetime!(2022-04-10 00:00:00 UTC)..datetime!(2022-04-06 00:00:00 UTC);
+    /// let range2 = datetime!(2022-04-08 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+    /// // ranges can't be copied, so we are using `clone()` here
+    /// assert!(!range1.clone().overlaps(range2.clone()));
+    /// assert!(!range2.clone().overlaps(range1.clone()));
+    /// ```
     fn overlaps(self, other: Range<OffsetDateTime>) -> bool {
-        todo!()
+        self.start < self.end && other.start < other.end && self.start < other.end && other.start < self.end
     }
 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+    /// let range2 = datetime!(2022-04-10 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+    /// // ranges can't be copied, so we are using `clone()` here
+    /// assert!(range1.clone().left_adjacent_to(range2.clone()));
+    /// assert!(!range2.clone().left_adjacent_to(range1.clone()));
+    /// ```
+    /// 
+    /// ```rust
+    /// # use time::macros::datetime;
+    /// # use time::OffsetDateTimeRangeExt;
+    /// let range1 = datetime!(2022-04-06 00:00:00 UTC)..datetime!(2022-04-10 00:00:00 UTC);
+    /// let range2 = datetime!(2022-04-12 00:00:00 UTC)..datetime!(2022-04-13 00:00:00 UTC);
+    /// // ranges can't be copied, so we are using `clone()` here
+    /// assert!(!range1.clone().left_adjacent_to(range2.clone()));
+    /// assert!(!range2.clone().left_adjacent_to(range1.clone()));
+    /// ```
     fn left_adjacent_to(self, other: Range<OffsetDateTime>) -> bool {
-        todo!()
+        self.start < self.end && other.start < other.end && self.end == other.start
     }
 
     fn right_adjacent_to(self, other: Range<OffsetDateTime>) -> bool {
-        todo!()
+        self.start < self.end && other.start < other.end && self.start == other.end
     }
 
     fn engulfs(self, other: Range<OffsetDateTime>) -> bool {
-        todo!()
+        self.start < self.end && other.start < other.end && self.start <= other.start && other.end <= self.end
     }
 
     fn engulfed_by(self, other: Range<OffsetDateTime>) -> bool {
-        todo!()
+        self.start < self.end && other.start < other.end && other.start <= self.start && self.end <= other.end
     }
 
-    fn split_at(self, date: OffsetDateTime) -> Option<(Range<OffsetDateTime>, Range<OffsetDateTime>)> {
-        todo!()
+    fn split_at(mut self, mut date: OffsetDateTime) -> Option<(Range<OffsetDateTime>, Range<OffsetDateTime>)> {
+        // if the range is is the right order, and the date is within the range, return `Some`
+        if self.start < self.end && self.start < date && date < self.end {
+            // find the start offset to make sure each sub-range has the same offset as the original
+            let start_offset = self.start.offset();
+            
+            // update the offsets to match the original offset
+            self.end = self.end.to_offset(start_offset);
+            date = date.to_offset(start_offset);
+            
+            // split the range
+            Some((self.start..date, date..self.end))
+        }
+
+        // if the range is reversed or the date is outside of the range, return `None`
+        else {
+            None
+        }
     }
 
-    fn split_at_multiple(self, dates: &[OffsetDateTime]) -> Vec<Range<OffsetDateTime>> {
-        todo!()
+    fn split_at_multiple(mut self, dates: &[OffsetDateTime]) -> Vec<Range<OffsetDateTime>> {
+        // if the range is reversed, return an empty vector
+        if self.end <= self.start {
+            return vec![];
+        }
+
+        // find the start offset to make sure each sub-range has the same offset as the original
+        let start_offset = self.start.offset();
+        
+        // ensure the end is in the same offset, else the last range will end with a different offset compared to others
+        self.end = self.end.to_offset(start_offset);
+
+        let mut sorted_dates: Vec<OffsetDateTime> = dates
+            // iterate over the dates in the slice
+            .iter()
+            // convert &OffsetDateTime to OffsetDateTime
+            .copied()
+            // filter out dates that are not in the range
+            .filter(|date| self.contains(date))
+            // filter out dates that are the same as the start or end of the range
+            .filter(|date| *date != self.start && *date != self.end)
+            // make sure all dates have the same offset as the start of the range
+            .map(|date| date.to_offset(start_offset))
+            // collect the date into a vector
+            .collect();
+
+        // sort the dates
+        sorted_dates.sort();
+
+        // filter out any dates that are adjacent to each other
+        sorted_dates.dedup();
+
+        // generate the ranges and collect them into a vector
+        let mut ranges = vec![];
+        let mut tmp = self;
+
+        for date in sorted_dates {
+            ranges.push(tmp.start..date);
+            tmp = date..tmp.end;
+        }
+        ranges.push(tmp); // add the last range
+
+        // return the ranges
+        ranges
     }
 
     fn split_by(self, unit: Duration) -> SplitDuration {
-        todo!()
+        SplitDuration {
+            current: self.start,
+            end: self.end,
+            unit,
+        }
     }
 
     fn divide_equally(self, number_of_parts: usize) -> SplitCount {
-        todo!()
+        SplitCount {
+            current: self.start,
+            end: self.end,
+            number_of_parts,
+        }
     }
 
     fn intersection(self, other: Range<OffsetDateTime>) -> Option<Range<OffsetDateTime>> {
-        todo!()
+        let start = self.start.max(other.start);
+        let end = self.end.min(other.end);
+
+        if start < end {
+            Some(start..end)
+        } else {
+            None
+        }
     }
 
     fn union(self, other: Range<OffsetDateTime>) -> Option<Range<OffsetDateTime>> {
-        todo!()
+        if self.start < other.end && other.start < self.end {
+            let start = self.start.min(other.start);
+            let end = self.end.max(other.end);
+            Some(start..end)
+        } else {
+            None
+        }
     }
 
     fn difference(self, other: Range<OffsetDateTime>) -> Vec<Range<OffsetDateTime>> {

--- a/time/src/offset_date_time_range.rs
+++ b/time/src/offset_date_time_range.rs
@@ -1,0 +1,378 @@
+//! Implementations of useful methods for the [`Range<OffsetDateTime>`] and [`Vec<Range<OffsetDateTime>>`] structs.
+
+use std::ops::Range;
+use crate::{OffsetDateTime, Duration, util};
+use iter::*;
+
+/// Define useful methods for the [`Range<OffsetDateTime>`] struct to expose.
+pub trait OffsetDateTimeRange {
+    /// Returns an iterator of all the seconds that start within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn seconds(self) -> Seconds;
+
+    /// Returns an iterator of all the minutes that start within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn minutes(self) -> Minutes;
+
+    /// Returns an iterator of all the hours that start within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn hours(self) -> Hours;
+
+    /// Returns an iterator of all the days that start within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn days(self) -> Days;
+
+    /// Returns an iterator of all the monday-based weeks that start within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn monday_based_weeks(self) -> Weeks;
+
+    /// Returns an iterator of all the sunday-based weeks that start within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn sunday_based_weeks(self) -> Weeks;
+
+    /// Returns an iterator of all the months that start within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn months(self) -> Months;
+
+    /// Returns an iterator of all the years that start within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn years(self) -> Years;
+
+    /// Returns an iterator of all the seconds that start and end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn full_seconds(self) -> Seconds;
+
+    /// Returns an iterator of all the minutes that start and end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn full_minutes(self) -> Minutes;
+
+    /// Returns an iterator of all the hours that start and end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn full_hours(self) -> Hours;
+
+    /// Returns an iterator of all the days that start and end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn full_days(self) -> Days;
+
+    /// Returns an iterator of all the monday-based weeks that start and end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn full_monday_based_weeks(self) -> Weeks;
+
+    /// Returns an iterator of all the sunday-based weeks that start and end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn full_sunday_based_weeks(self) -> Weeks;
+
+    /// Returns an iterator of all the months that start and end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn full_months(self) -> Months;
+
+    /// Returns an iterator of all the years that start and end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn full_years(self) -> Years;
+
+    /// Returns an iterator of all the seconds that start or end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn overlapping_seconds(self) -> Seconds;
+
+    /// Returns an iterator of all the minutes that start or end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn overlapping_minutes(self) -> Minutes;
+
+    /// Returns an iterator of all the hours that start or end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn overlapping_hours(self) -> Hours;
+
+    /// Returns an iterator of all the days that start or end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn overlapping_days(self) -> Days;
+
+    /// Returns an iterator of all the monday-based weeks that start or end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn overlapping_monday_based_weeks(self) -> Weeks;
+
+    /// Returns an iterator of all the sunday-based weeks that start or end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn overlapping_sunday_based_weeks(self) -> Weeks;
+
+    /// Returns an iterator of all the months that start or end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn overlapping_months(self) -> Months;
+
+    /// Returns an iterator of all the years that start or end within the range.
+    /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
+    fn overlapping_years(self) -> Years;
+
+    /// Returns whether this range overlaps with the specified one.
+    fn overlaps(self, other: Range<OffsetDateTime>) -> bool;
+
+    /// Returns whether this range's end is equal to the specified one's start.
+    fn left_adjacent_to(self, other: Range<OffsetDateTime>) -> bool;
+
+    /// Returns whether this range's start is equal to the specified one's end.
+    fn right_adjacent_to(self, other: Range<OffsetDateTime>) -> bool;
+
+    /// Returns whether the specified range is contained within this range.
+    fn engulfs(self, other: Range<OffsetDateTime>) -> bool;
+
+    /// Returns whether this range is contained within the specified range.
+    fn engulfed_by(self, other: Range<OffsetDateTime>) -> bool;
+
+    /// Split the range into two ranges at the specified `OffsetDateTime`.
+    /// If the `OffsetDateTime` is not within the range, the method will panic.
+    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the range start.
+    fn split_at(self, date: OffsetDateTime) -> (Range<OffsetDateTime>, Range<OffsetDateTime>);
+
+    /// Split the range into two ranges at the specified `OffsetDateTime`.
+    /// If the `OffsetDateTime` is not within the range, the method will return `None`.
+    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
+    fn try_split_at(self, date: OffsetDateTime) -> Option<(Range<OffsetDateTime>, Range<OffsetDateTime>)>;
+
+    /// Split the range into multiple ranges at the specified `OffsetDateTime`.
+    /// The range will only be split at the specified `OffsetDateTime` if it is within the range.
+    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
+    fn split_at_multiple(self, dates: &[OffsetDateTime]) -> Vec<Range<OffsetDateTime>>;
+
+    /// Split the range into ranges of specified duration.
+    /// If the duration is not a multiple of the range's duration, the last range will be shorter.
+    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned by the iterator will have the same offset as this range start.
+    fn split_by(self, duration: Duration) -> SplitDuration;
+
+    /// Split the range into a list of ranges of equal duration.
+    /// If the number_of_parts is not a multiple of the range's duration, the first ranges returned will be longer than the last ones.
+    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned by the iterator will have the same offset as this range start.
+    fn divide_equally(self, number_of_parts: usize) -> SplitCount;
+
+    /// Returns a range that is the intersection of this range and the specified one.
+    /// If the ranges do not intersect, the method will return `None`.
+    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
+    fn intersection(self, other: Range<OffsetDateTime>) -> Option<Range<OffsetDateTime>>;
+
+    /// Returns a range that is the union of this range and the specified one.
+    /// If the ranges do not overlap, the method will return `None`.
+    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
+    fn union(self, other: Range<OffsetDateTime>) -> Option<Range<OffsetDateTime>>;
+
+    /// Returns a range that doesn't overlap with the specified one.
+    /// If the ranges completely overlap, the method will return `None`.
+    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
+    fn difference(self, other: Range<OffsetDateTime>) -> Option<Range<OffsetDateTime>>;
+
+    /// Returns a range that doesn't overlap with any of the specified one
+    /// If the ranges completely overlap, the method will return `None`.
+    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
+    fn difference_multiple(self, others: &[Range<OffsetDateTime>]) -> Vec<Range<OffsetDateTime>>;
+}
+
+/// Define useful methods for the [`[Range<OffsetDateTime>]`] struct to expose.
+trait OffsetDateTimeRangeSlice {
+    /// Returns an intersection of all the ranges in the slice.
+    /// If there is no point where all the ranges intersect, the method will return `None`.
+    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the first range start.
+    fn intersection(&self) -> Option<Range<OffsetDateTime>>;
+
+    /// Returns a range that is the union of all the ranges in the slice. If the intervals are adjacent, they will be merged.
+    /// If the ranges don't fully overlap, the method will return `None`.
+    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the first range start.
+    fn union(&self) -> Option<Range<OffsetDateTime>>;
+
+    /// Returns a list of ranges that are reduced to the minimum set of ranges that don't overlap.
+    /// This function combines oferlapping and adjacent ranges.
+    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the first range start.
+    fn merge(&self) -> Vec<Range<OffsetDateTime>>;
+
+    /// Returns a list of ranges that only appear in one of the specified ranges.
+    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the first range start.
+    fn xor(&self) -> Vec<Range<OffsetDateTime>>;
+}
+
+// impl OffsetDateTimeRangeSlice for [Range<OffsetDateTime>] {
+//     fn intersection(&self) -> Range<OffsetDateTime> {
+//         todo!();
+//     }
+// }
+
+/// [`Range<OffsetDateTime>`] related iterators.
+pub mod iter {
+    use alloc::collections::binary_heap::Iter;
+
+    use super::*;
+
+    /// An iterator of the seconds within a range.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct Seconds {
+        current: OffsetDateTime,
+        end: OffsetDateTime,
+        inclusive: bool,
+    }
+
+    impl Iterator for Seconds {
+        type Item = OffsetDateTime;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.current < self.end || (self.inclusive && self.current == self.end) {
+                let current = self.current;
+                self.current = current.checked_add(Duration::SECOND).unwrap();
+                Some(current)
+            } else {
+                None
+            }
+        }
+    }
+    
+    /// An iterator of the minutes within a range.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct Minutes {
+        current: OffsetDateTime,
+        end: OffsetDateTime,
+        inclusive: bool,
+    }
+
+    impl Iterator for Minutes {
+        type Item = OffsetDateTime;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.current < self.end || (self.inclusive && self.current == self.end) {
+                let current = self.current;
+                self.current = current.checked_add(Duration::MINUTE).unwrap();
+                Some(current)
+            } else {
+                None
+            }
+        }
+    }
+
+    /// An iterator of the hours within a range.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct Hours {
+        current: OffsetDateTime,
+        end: OffsetDateTime,
+        inclusive: bool,
+    }
+
+    impl Iterator for Hours {
+        type Item = OffsetDateTime;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.current < self.end || (self.inclusive && self.current == self.end) {
+                let current = self.current;
+                self.current = current.checked_add(Duration::HOUR).unwrap();
+                Some(current)
+            } else {
+                None
+            }
+        }
+    }
+
+    /// An iterator of the days within a range.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct Days {
+        current: OffsetDateTime,
+        end: OffsetDateTime,
+        inclusive: bool,
+    }
+
+    impl Iterator for Days {
+        type Item = OffsetDateTime;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.current < self.end || (self.inclusive && self.current == self.end) {
+                let current = self.current;
+                self.current = current.checked_add(Duration::DAY).unwrap();
+                Some(current)
+            } else {
+                None
+            }
+        }
+    }
+
+    /// An iterator of the weeks within a range.
+    /// Might be monday-based or sunday-based depending on the range.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct Weeks {
+        current: OffsetDateTime,
+        end: OffsetDateTime,
+        inclusive: bool,
+    }
+
+    impl Iterator for Weeks {
+        type Item = OffsetDateTime;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.current < self.end || (self.inclusive && self.current == self.end) {
+                let current = self.current;
+                self.current = current.checked_add(Duration::WEEK).unwrap();
+                Some(current)
+            } else {
+                None
+            }
+        }
+    }
+
+    /// An iterator of the months within a range.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct Months {
+        current: OffsetDateTime,
+        end: OffsetDateTime,
+        inclusive: bool,
+    }
+
+    impl Iterator for Months {
+        type Item = OffsetDateTime;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.current < self.end || (self.inclusive && self.current == self.end) {
+                let current = self.current;
+                self.current = current.checked_add(Duration::days(util::days_in_year_month(current.year(), current.month()) as i64)).unwrap();
+                Some(current)
+            } else {
+                None
+            }
+        }
+    }
+
+    /// An iterator of the years within a range.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct Years {
+        current: OffsetDateTime,
+        end: OffsetDateTime,
+        inclusive: bool,
+    }
+
+    impl Iterator for Years {
+        type Item = OffsetDateTime;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.current < self.end || (self.inclusive && self.current == self.end) {
+                let current = self.current;
+                self.current = current.checked_add(Duration::days(util::days_in_year(current.year()) as i64)).unwrap();
+                Some(current)
+            } else {
+                None
+            }
+        }
+    }
+
+    pub struct SplitDuration {
+    }
+
+    impl Iterator for SplitDuration {
+        type Item = Range<OffsetDateTime>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            todo!()
+        }
+    }
+
+    pub struct SplitCount {
+    }
+
+    impl Iterator for SplitCount {
+        type Item = Range<OffsetDateTime>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            todo!()
+        }
+    }
+}
+
+// TODO: implement the methods for Range<OffsetDateTime> and RangeInclusive<OffsetDateTime>

--- a/time/src/offset_date_time_range.rs
+++ b/time/src/offset_date_time_range.rs
@@ -1,104 +1,133 @@
 //! Implementations of useful methods for the [`Range<OffsetDateTime>`] and [`Vec<Range<OffsetDateTime>>`] structs.
 
 use std::ops::Range;
-use crate::{OffsetDateTime, Duration, util};
+use crate::{OffsetDateTime, Duration, util, Month, Weekday};
 use iter::*;
 
-/// Define useful methods for the [`Range<OffsetDateTime>`] struct to expose.
+/// Useful methods for the [`Range<OffsetDateTime>`] struct to expose.
 pub trait OffsetDateTimeRange {
+    /// Returns the length of the range using the specified duration as the unit.
+    /// 
+    /// As an example, using `Duration::DAY` as unit wouldn't count how many days are in the range, but rather how many day-long ranges are in the range.
+    fn len(self, unit: Duration) -> usize;
+
     /// Returns an iterator of all the seconds that start within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn seconds(self) -> Seconds;
 
     /// Returns an iterator of all the minutes that start within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn minutes(self) -> Minutes;
 
     /// Returns an iterator of all the hours that start within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn hours(self) -> Hours;
 
     /// Returns an iterator of all the days that start within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn days(self) -> Days;
 
     /// Returns an iterator of all the monday-based weeks that start within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
-    fn monday_based_weeks(self) -> Weeks;
+    fn monday_based_weeks(self) -> MondayBasedWeeks;
 
     /// Returns an iterator of all the sunday-based weeks that start within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
-    fn sunday_based_weeks(self) -> Weeks;
+    fn sunday_based_weeks(self) -> SundayBasedWeeks;
 
     /// Returns an iterator of all the months that start within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn months(self) -> Months;
 
     /// Returns an iterator of all the years that start within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn years(self) -> Years;
 
     /// Returns an iterator of all the seconds that start and end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn full_seconds(self) -> Seconds;
 
     /// Returns an iterator of all the minutes that start and end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn full_minutes(self) -> Minutes;
 
     /// Returns an iterator of all the hours that start and end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn full_hours(self) -> Hours;
 
     /// Returns an iterator of all the days that start and end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn full_days(self) -> Days;
 
     /// Returns an iterator of all the monday-based weeks that start and end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
-    fn full_monday_based_weeks(self) -> Weeks;
+    fn full_monday_based_weeks(self) -> MondayBasedWeeks;
 
     /// Returns an iterator of all the sunday-based weeks that start and end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
-    fn full_sunday_based_weeks(self) -> Weeks;
+    fn full_sunday_based_weeks(self) -> SundayBasedWeeks;
 
     /// Returns an iterator of all the months that start and end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn full_months(self) -> Months;
 
     /// Returns an iterator of all the years that start and end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn full_years(self) -> Years;
 
     /// Returns an iterator of all the seconds that start or end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn overlapping_seconds(self) -> Seconds;
 
     /// Returns an iterator of all the minutes that start or end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn overlapping_minutes(self) -> Minutes;
 
     /// Returns an iterator of all the hours that start or end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn overlapping_hours(self) -> Hours;
 
     /// Returns an iterator of all the days that start or end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn overlapping_days(self) -> Days;
 
     /// Returns an iterator of all the monday-based weeks that start or end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
-    fn overlapping_monday_based_weeks(self) -> Weeks;
+    fn overlapping_monday_based_weeks(self) -> MondayBasedWeeks;
 
     /// Returns an iterator of all the sunday-based weeks that start or end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
-    fn overlapping_sunday_based_weeks(self) -> Weeks;
+    fn overlapping_sunday_based_weeks(self) -> SundayBasedWeeks;
 
     /// Returns an iterator of all the months that start or end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn overlapping_months(self) -> Months;
 
     /// Returns an iterator of all the years that start or end within the range.
+    /// 
     /// The `OffsetDateTime` returned by the iterator will have the same offset as the range start.
     fn overlapping_years(self) -> Years;
 
@@ -118,166 +147,238 @@ pub trait OffsetDateTimeRange {
     fn engulfed_by(self, other: Range<OffsetDateTime>) -> bool;
 
     /// Split the range into two ranges at the specified `OffsetDateTime`.
-    /// If the `OffsetDateTime` is not within the range, the method will panic.
-    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the range start.
-    fn split_at(self, date: OffsetDateTime) -> (Range<OffsetDateTime>, Range<OffsetDateTime>);
-
-    /// Split the range into two ranges at the specified `OffsetDateTime`.
+    /// 
     /// If the `OffsetDateTime` is not within the range, the method will return `None`.
-    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
-    fn try_split_at(self, date: OffsetDateTime) -> Option<(Range<OffsetDateTime>, Range<OffsetDateTime>)>;
+    /// 
+    /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the range start.
+    fn split_at(self, date: OffsetDateTime) -> Option<(Range<OffsetDateTime>, Range<OffsetDateTime>)>;
 
     /// Split the range into multiple ranges at the specified `OffsetDateTime`.
+    /// 
     /// The range will only be split at the specified `OffsetDateTime` if it is within the range.
+    /// 
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
     fn split_at_multiple(self, dates: &[OffsetDateTime]) -> Vec<Range<OffsetDateTime>>;
 
     /// Split the range into ranges of specified duration.
-    /// If the duration is not a multiple of the range's duration, the last range will be shorter.
+    /// 
+    /// If the unit is not a multiple of the range's duration, the last range will be shorter.
+    /// 
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned by the iterator will have the same offset as this range start.
-    fn split_by(self, duration: Duration) -> SplitDuration;
+    fn split_by(self, unit: Duration) -> SplitDuration;
 
     /// Split the range into a list of ranges of equal duration.
+    /// 
     /// If the number_of_parts is not a multiple of the range's duration, the first ranges returned will be longer than the last ones.
+    /// 
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned by the iterator will have the same offset as this range start.
     fn divide_equally(self, number_of_parts: usize) -> SplitCount;
 
     /// Returns a range that is the intersection of this range and the specified one.
+    /// 
     /// If the ranges do not intersect, the method will return `None`.
+    /// 
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
     fn intersection(self, other: Range<OffsetDateTime>) -> Option<Range<OffsetDateTime>>;
 
     /// Returns a range that is the union of this range and the specified one.
+    /// 
     /// If the ranges do not overlap, the method will return `None`.
+    /// 
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
     fn union(self, other: Range<OffsetDateTime>) -> Option<Range<OffsetDateTime>>;
 
-    /// Returns a range that doesn't overlap with the specified one.
-    /// If the ranges completely overlap, the method will return `None`.
+    /// Returns a list of ranges that don't overlap with the specified one.
+    /// 
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
-    fn difference(self, other: Range<OffsetDateTime>) -> Option<Range<OffsetDateTime>>;
+    fn difference(self, other: Range<OffsetDateTime>) -> Vec<Range<OffsetDateTime>>;
 
-    /// Returns a range that doesn't overlap with any of the specified one
-    /// If the ranges completely overlap, the method will return `None`.
+    /// Returns a list of ranges that don't overlap with any of the specified one
+    /// 
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as this range start.
     fn difference_multiple(self, others: &[Range<OffsetDateTime>]) -> Vec<Range<OffsetDateTime>>;
 }
 
-/// Define useful methods for the [`[Range<OffsetDateTime>]`] struct to expose.
-trait OffsetDateTimeRangeSlice {
+/// Useful methods for the [`[Range<OffsetDateTime>]`](https://doc.rust-lang.org/std/primitive.slice.html) struct to expose.
+pub trait OffsetDateTimeRangeSlice {
     /// Returns an intersection of all the ranges in the slice.
+    /// 
     /// If there is no point where all the ranges intersect, the method will return `None`.
+    /// 
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the first range start.
     fn intersection(&self) -> Option<Range<OffsetDateTime>>;
 
     /// Returns a range that is the union of all the ranges in the slice. If the intervals are adjacent, they will be merged.
-    /// If the ranges don't fully overlap, the method will return `None`.
+    /// It essentially returns a range with start equal to the smallest start in the slice and end equal to the largest end in the slice.
+    /// 
+    /// If the ranges don't fully overlap, ie there are spots that are not covered by any range, the method will return `None`.
+    /// 
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the first range start.
     fn union(&self) -> Option<Range<OffsetDateTime>>;
 
     /// Returns a list of ranges that are reduced to the minimum set of ranges that don't overlap.
+    /// 
     /// This function combines oferlapping and adjacent ranges.
+    /// 
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the first range start.
     fn merge(&self) -> Vec<Range<OffsetDateTime>>;
 
     /// Returns a list of ranges that only appear in one of the specified ranges.
+    /// 
     /// The `OffsetDateTime` in the `Range<OffsetDateTime>` returned will have the same offset as the first range start.
     fn xor(&self) -> Vec<Range<OffsetDateTime>>;
 }
 
-// impl OffsetDateTimeRangeSlice for [Range<OffsetDateTime>] {
-//     fn intersection(&self) -> Range<OffsetDateTime> {
-//         todo!();
-//     }
-// }
-
 /// [`Range<OffsetDateTime>`] related iterators.
 pub mod iter {
-    use alloc::collections::binary_heap::Iter;
-
     use super::*;
 
     /// An iterator of the seconds within a range.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Seconds {
-        current: OffsetDateTime,
-        end: OffsetDateTime,
-        inclusive: bool,
+        pub(super) current: OffsetDateTime,
+        pub(super) end: OffsetDateTime,
     }
 
     impl Iterator for Seconds {
         type Item = OffsetDateTime;
 
         fn next(&mut self) -> Option<Self::Item> {
-            if self.current < self.end || (self.inclusive && self.current == self.end) {
+            if self.current < self.end {
                 let current = self.current;
-                self.current = current.checked_add(Duration::SECOND).unwrap();
+                self.current = current.next_second();
                 Some(current)
             } else {
                 None
             }
+        }
+    }
+
+    impl ExactSizeIterator for Seconds {
+        // We make the assumption that the range is not longer than usize::MAX seconds.
+        // We also assume that the iterator has been instantiated correctly, and starts at the beginning of a second.
+        fn len(&self) -> usize {
+            // if the range start is after the range end, the range is empty
+            // in that case, we return 0
+            if self.end < self.current {
+                return 0;
+            }
+
+            // get the duration of the range
+            let duration = self.end - self.current;
+
+            // basically a ceil function, but without f64 conversion
+            // this way we don't have to worry about rounding errors
+            let has_exceeded_second =
+                self.end.nanosecond() != 0;
+            
+            duration.whole_seconds() as usize + has_exceeded_second as usize
         }
     }
     
     /// An iterator of the minutes within a range.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Minutes {
-        current: OffsetDateTime,
-        end: OffsetDateTime,
-        inclusive: bool,
+        pub(super) current: OffsetDateTime,
+        pub(super) end: OffsetDateTime,
     }
 
     impl Iterator for Minutes {
         type Item = OffsetDateTime;
 
         fn next(&mut self) -> Option<Self::Item> {
-            if self.current < self.end || (self.inclusive && self.current == self.end) {
+            if self.current < self.end {
                 let current = self.current;
-                self.current = current.checked_add(Duration::MINUTE).unwrap();
+                self.current = current.next_minute();
                 Some(current)
             } else {
                 None
             }
+        }
+    }
+
+    impl ExactSizeIterator for Minutes {
+        // We make the assumption that the range is not longer than usize::MAX minutes.
+        // We also assume that the iterator has been instantiated correctly, and starts at the beginning of a minute.
+        fn len(&self) -> usize {
+            // if the range start is after the range end, the range is empty
+            // in that case, we return 0
+            if self.end < self.current {
+                return 0;
+            }
+
+            // get the duration of the range
+            let duration = self.end - self.current;
+
+            // basically a ceil function, but without f64 conversion
+            // this way we don't have to worry about rounding errors
+            let has_exceeded_minute =
+                self.end.second() != 0 ||
+                self.end.nanosecond() != 0;
+                
+            duration.whole_minutes() as usize + has_exceeded_minute as usize
         }
     }
 
     /// An iterator of the hours within a range.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Hours {
-        current: OffsetDateTime,
-        end: OffsetDateTime,
-        inclusive: bool,
+        pub(super) current: OffsetDateTime,
+        pub(super) end: OffsetDateTime,
     }
 
     impl Iterator for Hours {
         type Item = OffsetDateTime;
 
         fn next(&mut self) -> Option<Self::Item> {
-            if self.current < self.end || (self.inclusive && self.current == self.end) {
+            if self.current < self.end {
                 let current = self.current;
-                self.current = current.checked_add(Duration::HOUR).unwrap();
+                self.current = current.next_hour();
                 Some(current)
             } else {
                 None
             }
+        }
+    }
+
+    impl ExactSizeIterator for Hours {
+        // We make the assumption that the range is not longer than usize::MAX hours.
+        // We also assume that the iterator has been instantiated correctly, and starts at the beginning of an hour.
+        fn len(&self) -> usize {
+            // if the range start is after the range end, the range is empty
+            // in that case, we return 0
+            if self.end < self.current {
+                return 0;
+            }
+
+            // get the duration of the range
+            let duration = self.end - self.current;
+
+            // basically a ceil function, but without f64 conversion
+            // this way we don't have to worry about rounding errors
+            let has_exceeded_hour =
+                self.end.minute() != 0 ||
+                self.end.second() != 0 ||
+                self.end.nanosecond() != 0;
+                
+            duration.whole_hours() as usize + has_exceeded_hour as usize
         }
     }
 
     /// An iterator of the days within a range.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Days {
-        current: OffsetDateTime,
-        end: OffsetDateTime,
-        inclusive: bool,
+        pub(super) current: OffsetDateTime,
+        pub(super) end: OffsetDateTime,
     }
 
     impl Iterator for Days {
         type Item = OffsetDateTime;
 
         fn next(&mut self) -> Option<Self::Item> {
-            if self.current < self.end || (self.inclusive && self.current == self.end) {
+            if self.current < self.end {
                 let current = self.current;
-                self.current = current.checked_add(Duration::DAY).unwrap();
+                self.current = current.next_day();
                 Some(current)
             } else {
                 None
@@ -285,66 +386,193 @@ pub mod iter {
         }
     }
 
-    /// An iterator of the weeks within a range.
-    /// Might be monday-based or sunday-based depending on the range.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct Weeks {
-        current: OffsetDateTime,
-        end: OffsetDateTime,
-        inclusive: bool,
+    impl ExactSizeIterator for Days {
+        // We make the assumption that the range is not longer than usize::MAX days.
+        // We also assume that the iterator has been instantiated correctly, and starts at the beginning of a day.
+        fn len(&self) -> usize {
+            // if the range start is after the range end, the range is empty
+            // in that case, we return 0
+            if self.end < self.current {
+                return 0;
+            }
+
+            // get the duration of the range
+            let duration = self.end - self.current;
+
+            // basically a ceil function, but without f64 conversion
+            // this way we don't have to worry about rounding errors
+            let has_exceeded_day =
+                self.end.hour() != 0 ||
+                self.end.minute() != 0 ||
+                self.end.second() != 0 ||
+                self.end.nanosecond() != 0;
+            
+            duration.whole_days() as usize + has_exceeded_day as usize
+        }
     }
 
-    impl Iterator for Weeks {
+    /// An iterator of the monday-based weeks within a range.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct MondayBasedWeeks {
+        pub(super) current: OffsetDateTime,
+        pub(super) end: OffsetDateTime,
+    }
+
+    impl Iterator for MondayBasedWeeks {
         type Item = OffsetDateTime;
 
         fn next(&mut self) -> Option<Self::Item> {
-            if self.current < self.end || (self.inclusive && self.current == self.end) {
+            if self.current < self.end {
                 let current = self.current;
-                self.current = current.checked_add(Duration::WEEK).unwrap();
+                self.current = current.next_monday_based_week();
                 Some(current)
             } else {
                 None
             }
+        }
+    }
+
+    impl ExactSizeIterator for MondayBasedWeeks {
+        // We make the assumption that the range is not longer than usize::MAX weeks.
+        // We also assume that the iterator has been instantiated correctly, and starts at the beginning of a monday-based week.
+        fn len(&self) -> usize {
+            // if the range start is after the range end, the range is empty
+            // in that case, we return 0
+            if self.end < self.current {
+                return 0;
+            }
+
+            // get the duration of the range
+            let duration = self.end - self.current;
+
+            // basically a ceil function, but without f64 conversion
+            // this way we don't have to worry about rounding errors
+            let has_exceeded_week =
+                self.end.weekday() != Weekday::Monday ||
+                self.end.hour() != 0 ||
+                self.end.minute() != 0 ||
+                self.end.second() != 0 ||
+                self.end.nanosecond() != 0;
+                
+            duration.whole_weeks() as usize + has_exceeded_week as usize
+        }
+    }
+
+    /// An iterator of the sunday-based weeks within a range.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct SundayBasedWeeks {
+        pub(super) current: OffsetDateTime,
+        pub(super) end: OffsetDateTime,
+    }
+
+    impl Iterator for SundayBasedWeeks {
+        type Item = OffsetDateTime;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.current < self.end {
+                let current = self.current;
+                self.current = current.next_sunday_based_week();
+                Some(current)
+            } else {
+                None
+            }
+        }
+    }
+
+    impl ExactSizeIterator for SundayBasedWeeks {
+        // We make the assumption that the range is not longer than usize::MAX weeks.
+        // We also assume that the iterator has been instantiated correctly, and starts at the beginning of a sunday-based week.
+        fn len(&self) -> usize {
+            // if the range start is after the range end, the range is empty
+            // in that case, we return 0
+            if self.end < self.current {
+                return 0;
+            }
+
+            // get the duration of the range
+            let duration = self.end - self.current;
+
+            // basically a ceil function, but without f64 conversion
+            // this way we don't have to worry about rounding errors
+            let has_exceeded_week =
+                self.end.weekday() != Weekday::Sunday ||
+                self.end.hour() != 0 ||
+                self.end.minute() != 0 ||
+                self.end.second() != 0 ||
+                self.end.nanosecond() != 0;
+                
+            duration.whole_weeks() as usize + has_exceeded_week as usize
         }
     }
 
     /// An iterator of the months within a range.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Months {
-        current: OffsetDateTime,
-        end: OffsetDateTime,
-        inclusive: bool,
+        pub(super) current: OffsetDateTime,
+        pub(super) end: OffsetDateTime,
     }
 
     impl Iterator for Months {
         type Item = OffsetDateTime;
 
         fn next(&mut self) -> Option<Self::Item> {
-            if self.current < self.end || (self.inclusive && self.current == self.end) {
+            if self.current < self.end {
                 let current = self.current;
-                self.current = current.checked_add(Duration::days(util::days_in_year_month(current.year(), current.month()) as i64)).unwrap();
+                self.current = current.next_month();
                 Some(current)
             } else {
                 None
             }
+        }
+    }
+
+    impl ExactSizeIterator for Months {
+        // We make the assumption that the range is not longer than usize::MAX months.
+        // We also assume that the iterator has been instantiated correctly, and starts at the beginning of a month.
+        fn len(&self) -> usize {
+            // if the range start is after the range end, the range is empty
+            // in that case, we return 0
+            if self.end < self.current {
+                return 0;
+            }
+
+            // count the number of whole months
+            let whole_months = if self.current.year() == self.end.year() {
+                self.end.month() as usize - self.current.month() as usize
+            } else {
+                let whole_years = self.end.year() as usize - self.current.year() as usize - 1;
+                let start_months = 13 - self.current.month() as usize;
+                let end_months = self.end.month() as usize - 1;
+                start_months + (whole_years * 12) + end_months
+            };
+
+            // basically a ceil function, but without f64 conversion
+            // this way we don't have to worry about rounding errors
+            let has_exceeded_month =
+                self.end.day() != 1 ||
+                self.end.hour() != 0 ||
+                self.end.minute() != 0 ||
+                self.end.second() != 0 ||
+                self.end.nanosecond() != 0;
+            
+            whole_months + has_exceeded_month as usize
         }
     }
 
     /// An iterator of the years within a range.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Years {
-        current: OffsetDateTime,
-        end: OffsetDateTime,
-        inclusive: bool,
+        pub(super) current: OffsetDateTime,
+        pub(super) end: OffsetDateTime,
     }
 
     impl Iterator for Years {
         type Item = OffsetDateTime;
 
         fn next(&mut self) -> Option<Self::Item> {
-            if self.current < self.end || (self.inclusive && self.current == self.end) {
+            if self.current < self.end {
                 let current = self.current;
-                self.current = current.checked_add(Duration::days(util::days_in_year(current.year()) as i64)).unwrap();
+                self.current = current.next_year();
                 Some(current)
             } else {
                 None
@@ -352,18 +580,65 @@ pub mod iter {
         }
     }
 
+    impl ExactSizeIterator for Years {
+        // We make the assumption that the range is not longer than usize::MAX years.
+        // We also assume that the iterator has been instantiated correctly, and starts at the beginning of a year.
+        fn len(&self) -> usize {
+            // if the range start is after the range end, the range is empty
+            // in that case, we return 0
+            if self.end < self.current {
+                return 0;
+            }
+
+            // count the number of whole years
+            let whole_years = self.end.year() as usize - self.current.year() as usize;
+
+            // basically a ceil function, but without f64 conversion
+            // this way we don't have to worry about rounding errors
+            let has_exceeded_year =
+                self.end.month() != Month::January ||
+                self.end.day() != 1 ||
+                self.end.hour() != 0 ||
+                self.end.minute() != 0 ||
+                self.end.second() != 0 ||
+                self.end.nanosecond() != 0;
+                
+            whole_years + has_exceeded_year as usize
+        }
+    }
+
+    /// An iterator of the unit-wide ranges within a range.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct SplitDuration {
+        pub(super) current: OffsetDateTime,
+        pub(super) end: OffsetDateTime,
+        pub(super) unit: Duration,
     }
 
     impl Iterator for SplitDuration {
         type Item = Range<OffsetDateTime>;
 
         fn next(&mut self) -> Option<Self::Item> {
-            todo!()
+            if self.current < self.end {
+                let current = self.current;
+                self.current += self.unit;
+                if self.current > self.end {
+                    Some(current..self.end)
+                } else {
+                    Some(current..self.current)
+                }
+            } else {
+                None
+            }
         }
     }
 
+    /// An iterator of the  ranges within a range.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct SplitCount {
+        pub(super) current: OffsetDateTime,
+        pub(super) end: OffsetDateTime,
+        pub(super) number_of_parts: usize,
     }
 
     impl Iterator for SplitCount {
@@ -375,4 +650,228 @@ pub mod iter {
     }
 }
 
-// TODO: implement the methods for Range<OffsetDateTime> and RangeInclusive<OffsetDateTime>
+impl OffsetDateTimeRange for Range<OffsetDateTime> {
+    fn len(self, unit: Duration) -> usize {
+        todo!()
+    }
+
+    fn seconds(self) -> Seconds {
+        Seconds {
+            current: self.start.next_second(),
+            end: self.end,
+        }
+    }
+
+    fn minutes(self) -> Minutes {
+        Minutes {
+            current: self.start.next_minute(),
+            end: self.end,
+        }
+    }
+
+    fn hours(self) -> Hours {
+        Hours {
+            current: self.start.next_hour(),
+            end: self.end,
+        }
+    }
+
+    fn days(self) -> Days {
+        Days {
+            current: self.start.next_day(),
+            end: self.end,
+        }
+    }
+
+    fn monday_based_weeks(self) -> MondayBasedWeeks {
+        MondayBasedWeeks {
+            current: self.start.next_monday_based_week(),
+            end: self.end,
+        }
+    }
+
+    fn sunday_based_weeks(self) -> SundayBasedWeeks {
+        SundayBasedWeeks {
+            current: self.start.next_sunday_based_week(),
+            end: self.end,
+        }
+    }
+
+    fn months(self) -> Months {
+        Months {
+            current: self.start.next_month(),
+            end: self.end,
+        }
+    }
+
+    fn years(self) -> Years {
+        Years {
+            current: self.start.next_year(),
+            end: self.end,
+        }
+    }
+
+    fn full_seconds(self) -> Seconds {
+        Seconds {
+            current: self.start.next_second(),
+            end: self.end.floor_seconds(),
+        }
+    }
+
+    fn full_minutes(self) -> Minutes {
+        Minutes {
+            current: self.start.next_minute(),
+            end: self.end.floor_minutes(),
+        }
+    }
+
+    fn full_hours(self) -> Hours {
+        Hours {
+            current: self.start.next_hour(),
+            end: self.end.floor_hours(),
+        }
+    }
+
+    fn full_days(self) -> Days {
+        Days {
+            current: self.start.next_day(),
+            end: self.end.floor_days(),
+        }
+    }
+
+    fn full_monday_based_weeks(self) -> MondayBasedWeeks {
+        MondayBasedWeeks {
+            current: self.start.next_monday_based_week(),
+            end: self.end.floor_monday_based_weeks(),
+        }
+    }
+
+    fn full_sunday_based_weeks(self) -> SundayBasedWeeks {
+        SundayBasedWeeks {
+            current: self.start.next_sunday_based_week(),
+            end: self.end.floor_sunday_based_weeks(),
+        }
+    }
+
+    fn full_months(self) -> Months {
+        Months {
+            current: self.start.next_month(),
+            end: self.end.floor_months(),
+        }
+    }
+
+    fn full_years(self) -> Years {
+        Years {
+            current: self.start.next_year(),
+            end: self.end.floor_years(),
+        }
+    }
+
+    fn overlapping_seconds(self) -> Seconds {
+        Seconds {
+            current: self.start.floor_seconds(),
+            end: self.end,
+        }
+    }
+
+    fn overlapping_minutes(self) -> Minutes {
+        Minutes {
+            current: self.start.floor_minutes(),
+            end: self.end,
+        }
+    }
+
+    fn overlapping_hours(self) -> Hours {
+        Hours {
+            current: self.start.floor_hours(),
+            end: self.end,
+        }
+    }
+
+    fn overlapping_days(self) -> Days {
+        Days {
+            current: self.start.floor_days(),
+            end: self.end,
+        }
+    }
+
+    fn overlapping_monday_based_weeks(self) -> MondayBasedWeeks {
+        MondayBasedWeeks {
+            current: self.start.floor_monday_based_weeks(),
+            end: self.end,
+        }
+    }
+
+    fn overlapping_sunday_based_weeks(self) -> SundayBasedWeeks {
+        SundayBasedWeeks {
+            current: self.start.floor_sunday_based_weeks(),
+            end: self.end,
+        }
+    }
+
+    fn overlapping_months(self) -> Months {
+        Months {
+            current: self.start.floor_months(),
+            end: self.end,
+        }
+    }
+
+    fn overlapping_years(self) -> Years {
+        Years {
+            current: self.start.floor_years(),
+            end: self.end,
+        }
+    }
+
+    fn overlaps(self, other: Range<OffsetDateTime>) -> bool {
+        todo!()
+    }
+
+    fn left_adjacent_to(self, other: Range<OffsetDateTime>) -> bool {
+        todo!()
+    }
+
+    fn right_adjacent_to(self, other: Range<OffsetDateTime>) -> bool {
+        todo!()
+    }
+
+    fn engulfs(self, other: Range<OffsetDateTime>) -> bool {
+        todo!()
+    }
+
+    fn engulfed_by(self, other: Range<OffsetDateTime>) -> bool {
+        todo!()
+    }
+
+    fn split_at(self, date: OffsetDateTime) -> Option<(Range<OffsetDateTime>, Range<OffsetDateTime>)> {
+        todo!()
+    }
+
+    fn split_at_multiple(self, dates: &[OffsetDateTime]) -> Vec<Range<OffsetDateTime>> {
+        todo!()
+    }
+
+    fn split_by(self, unit: Duration) -> SplitDuration {
+        todo!()
+    }
+
+    fn divide_equally(self, number_of_parts: usize) -> SplitCount {
+        todo!()
+    }
+
+    fn intersection(self, other: Range<OffsetDateTime>) -> Option<Range<OffsetDateTime>> {
+        todo!()
+    }
+
+    fn union(self, other: Range<OffsetDateTime>) -> Option<Range<OffsetDateTime>> {
+        todo!()
+    }
+
+    fn difference(self, other: Range<OffsetDateTime>) -> Vec<Range<OffsetDateTime>> {
+        todo!()
+    }
+
+    fn difference_multiple(self, others: &[Range<OffsetDateTime>]) -> Vec<Range<OffsetDateTime>> {
+        todo!()
+    }
+}


### PR DESCRIPTION
I've started to implement proper ranges for the library. This pull request is not one that is ready to be merged with the main branch. Many functions don't have an implementation yet, and it still lacks some features I would like to add. But I would like some feedback before progressing in the direction I am going.

# What is new

Here is a quick summary of what is present:
- Extention of the `OffsetDateTime` struct, adding functions likes `floor_seconds()`, `ceil_seconds()` and `next_second()`. They are necessary to the `OffsetDateTimeRangeExt`.
- Extension of the `Range<OffsetDateTime>` struct with functions like `days()`, `full_days()`, `overlapping_days()`, `intersection()`, `union()`, ...
- Extension of `&[Range<OffsetDateTime>]` slices (no functions implemented yet).

Important notes about ranges:
- You need two `OffsetDateTime` to create one range, so it was decided that the ranges will always work with the offset of the start datetime.
- If the ranges are reversed (end < start), most methods on this range will return `None` or an empty `Vec`.

# Questions I might have

Should ranges implement the `Copy` trait ? The struct `Range<OffsetDateTime>` never changes, and doesn't implement the `Iterator` trait, so there shouldn't be any problem with this. I would like your feedback on the idea.

EDIT: You can't implement the `Copy` trait, as the `Range` struct is not defined inside the crate.

# Coming improvements

- Implementing missing functions
- Implementing `OffsetDateTimeExt` for `RangeInclusive`
- Parsing & Formatting for ranges
- More unit tests
- Double sided iterators
- Range creation macro ?
- Similar functions for millis, micros and nanos ?
