### PR TITLE
Remove unnecessary floating point remainder

### DIFF
--- a/time/src/duration.rs
+++ b/time/src/duration.rs
@@ -326,7 +326,10 @@ impl Duration {
         if seconds.is_nan() {
             crate::expect_failed("passed NaN to `time::Duration::seconds_f64`");
         }
-        Self::new_unchecked(seconds as _, ((seconds % 1.) * 1_000_000_000.) as _)
+        let seconds_truncated = seconds as i64;
+        // This only works because we handle the overflow condition above.
+        let nanoseconds = ((seconds - seconds_truncated as f64) * 1_000_000_000.) as i32;
+        Self::new_unchecked(seconds_truncated, nanoseconds)
     }
 
     /// Creates a new `Duration` from the specified number of seconds represented as `f32`.
@@ -343,7 +346,10 @@ impl Duration {
         if seconds.is_nan() {
             crate::expect_failed("passed NaN to `time::Duration::seconds_f32`");
         }
-        Self::new_unchecked(seconds as _, ((seconds % 1.) * 1_000_000_000.) as _)
+        let seconds_truncated = seconds as i64;
+        // This only works because we handle the overflow condition above.
+        let nanoseconds = ((seconds - seconds_truncated as f32) * 1_000_000_000.) as i32;
+        Self::new_unchecked(seconds_truncated, nanoseconds)
     }
 
     /// Create a new `Duration` with the given number of milliseconds.


### PR DESCRIPTION
Because the code handles all the edge cases already, we can simply cast the integer seconds back to a floating point number to truncate it, instead of using `seconds % 1.0` which is not only slower, but also bloats the binary, especially on `no_std`, as it brings in an implementation of `fmod` / `fmodf`.