### PR TITLE
Fix Compilation on WebAssembly

### DIFF
--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -52,7 +52,7 @@ time-macros = { version = "=0.2.6", path = "../time-macros", optional = true }
 libc = { version = "0.2.98", optional = true }
 num_threads = { version = "0.1.2", optional = true }
 
-[target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
+[target.'cfg(all(target_family = "wasm", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 js-sys = { version = "0.3.58", optional = true }
 
 [dev-dependencies]

--- a/time/src/date_time.rs
+++ b/time/src/date_time.rs
@@ -270,7 +270,7 @@ impl<O: MaybeOffset> DateTime<O> {
         O: FixedOffset,
     {
         #[cfg(all(
-            target_arch = "wasm32",
+            target_family = "wasm",
             not(any(target_os = "emscripten", target_os = "wasi")),
             feature = "wasm-bindgen"
         ))]
@@ -279,7 +279,7 @@ impl<O: MaybeOffset> DateTime<O> {
         }
 
         #[cfg(not(all(
-            target_arch = "wasm32",
+            target_family = "wasm",
             not(any(target_os = "emscripten", target_os = "wasi")),
             feature = "wasm-bindgen"
         )))]
@@ -1082,8 +1082,9 @@ impl From<DateTime<offset_kind::Fixed>> for SystemTime {
 
 #[allow(clippy::fallible_impl_from)]
 #[cfg(all(
-    target_arch = "wasm32",
-    not(any(target_os = "emscripten", target_os = "wasi"))
+    target_family = "wasm",
+    not(any(target_os = "emscripten", target_os = "wasi")),
+    feature = "wasm-bindgen"
 ))]
 impl From<js_sys::Date> for DateTime<offset_kind::Fixed> {
     fn from(js_date: js_sys::Date) -> Self {
@@ -1095,8 +1096,9 @@ impl From<js_sys::Date> for DateTime<offset_kind::Fixed> {
 }
 
 #[cfg(all(
-    target_arch = "wasm32",
-    not(any(target_os = "emscripten", target_os = "wasi"))
+    target_family = "wasm",
+    not(any(target_os = "emscripten", target_os = "wasi")),
+    feature = "wasm-bindgen"
 ))]
 impl From<DateTime<offset_kind::Fixed>> for js_sys::Date {
     fn from(datetime: DateTime<offset_kind::Fixed>) -> Self {

--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -1148,7 +1148,7 @@ impl From<OffsetDateTime> for SystemTime {
 }
 
 #[cfg(all(
-    target_arch = "wasm32",
+    target_family = "wasm",
     not(any(target_os = "emscripten", target_os = "wasi")),
     feature = "wasm-bindgen"
 ))]
@@ -1159,7 +1159,7 @@ impl From<js_sys::Date> for OffsetDateTime {
 }
 
 #[cfg(all(
-    target_arch = "wasm32",
+    target_family = "wasm",
     not(any(target_os = "emscripten", target_os = "wasi")),
     feature = "wasm-bindgen"
 ))]

--- a/time/src/sys/local_offset_at/mod.rs
+++ b/time/src/sys/local_offset_at/mod.rs
@@ -6,7 +6,7 @@
 #[cfg_attr(target_family = "unix", path = "unix.rs")]
 #[cfg_attr(
     all(
-        target_arch = "wasm32",
+        target_family = "wasm",
         not(any(target_os = "emscripten", target_os = "wasi")),
         feature = "wasm-bindgen"
     ),


### PR DESCRIPTION
Apparently the latest version of `main` doesn't compile to WebAssembly if you don't activate the `wasm-bindgen` feature. Also nowadays the way to check for WebAssembly is different, so I also changed that across the board.