### PR TITLE
Update use of libc::timespec to prepare for future libc version

### DIFF
--- a/src/sys.rs
+++ b/src/sys.rs
@@ -512,19 +512,22 @@ mod inner {
     mod unix {
         use std::fmt;
         use std::cmp::Ordering;
+        use std::mem::zeroed;
         use std::ops::{Add, Sub};
         use libc;
 
         use Duration;
 
         pub fn get_time() -> (i64, i32) {
-            let mut tv = libc::timespec { tv_sec: 0, tv_nsec: 0 };
+            // SAFETY: libc::timespec is zero initializable.
+            let mut tv: libc::timespec = unsafe { zeroed() };
             unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, &mut tv); }
             (tv.tv_sec as i64, tv.tv_nsec as i32)
         }
 
         pub fn get_precise_ns() -> u64 {
-            let mut ts = libc::timespec { tv_sec: 0, tv_nsec: 0 };
+            // SAFETY: libc::timespec is zero initializable.
+            let mut ts: libc::timespec = unsafe { zeroed() };
             unsafe {
                 libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts);
             }
@@ -552,10 +555,8 @@ mod inner {
         impl SteadyTime {
             pub fn now() -> SteadyTime {
                 let mut t = SteadyTime {
-                    t: libc::timespec {
-                        tv_sec: 0,
-                        tv_nsec: 0,
-                    }
+                    // SAFETY: libc::timespec is zero initializable.
+                    t: unsafe { zeroed() }
                 };
                 unsafe {
                     assert_eq!(0, libc::clock_gettime(libc::CLOCK_MONOTONIC,


### PR DESCRIPTION
In a future release of the `libc` crate, `libc::timespec` will contains private padding fields on 32-bit `*-linux-musl` targets and so the struct will no longer be able to be created using the literal initializer syntax.

The only uses in this crate of `libc::timespec` in this way were zero initializing the struct. Thus, these can be replaced by a call to `std::mem::zeroed()` which is compatible with both current versions of the `libc` crate as well as the future version which will contain those private padding fields.

I tested this locally both with a modified `libc`/`i686-unknown-linux-musl` target and with the current `libc`/`i686-unknown-linux-musl` target. The code builds and all tests pass. The GH workflow required disabling a `deny(warnings)` for new warnings that are emitted since the last time the branch was built [but it succeeded](https://github.com/wesleywiser/time/actions/runs/3533827579/jobs/5929960898) other than the `test-old` tasks which failed because of dependency resolution errors with the `cfg-if` crate. 

Related to https://github.com/rust-lang/libc/pull/2088