### PR TITLE
Add millis functions and serde for unix_timestamp

### DIFF
--- a/tests/offset_date_time.rs
+++ b/tests/offset_date_time.rs
@@ -76,6 +76,19 @@ fn from_unix_timestamp() {
 }
 
 #[test]
+fn from_unix_timestamp_millis() {
+    assert_eq!(
+        OffsetDateTime::from_unix_timestamp_millis(0),
+        Ok(OffsetDateTime::UNIX_EPOCH),
+    );
+    assert_eq!(
+        OffsetDateTime::from_unix_timestamp_millis(1_546_300_800_123),
+        Ok(datetime!(2019-01-01 0:00:00.123 UTC)),
+    );
+    assert!(OffsetDateTime::from_unix_timestamp_millis(i128::MAX).is_err());
+}
+
+#[test]
 fn from_unix_timestamp_nanos() {
     assert_eq!(
         OffsetDateTime::from_unix_timestamp_nanos(0),
@@ -110,6 +123,17 @@ fn unix_timestamp() {
         0,
     );
     assert_eq!(datetime!(1970-01-01 0:00 -1).unix_timestamp(), 3_600);
+}
+
+#[test]
+fn unix_timestamp_millis() {
+    assert_eq!(datetime!(1970-01-01 0:00 UTC).unix_timestamp_millis(), 0);
+    assert_eq!(
+        datetime!(1970-01-01 1:00 UTC)
+            .to_offset(offset!(-1))
+            .unix_timestamp_millis(),
+        3_600_000,
+    );
 }
 
 #[test]

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -103,6 +103,18 @@ fn unix_timestamp_roundtrip(odt: OffsetDateTime) -> TestResult {
 }
 
 #[quickcheck]
+fn unix_timestamp_millis_roundtrip(odt: OffsetDateTime) -> TestResult {
+    match odt.date() {
+        Date::MIN | Date::MAX => TestResult::discard(),
+        _ => TestResult::from_bool({
+            // nanoseconds are not stored in the millisecond Unix timestamp
+            let odt = odt - Duration::nanoseconds(odt.nanosecond().into());
+            OffsetDateTime::from_unix_timestamp_millis(odt.unix_timestamp_millis()) == Ok(odt)
+        }),
+    }
+}
+
+#[quickcheck]
 fn unix_timestamp_nanos_roundtrip(odt: OffsetDateTime) -> TestResult {
     match odt.date() {
         Date::MIN | Date::MAX => TestResult::discard(),

--- a/tests/serde/mod.rs
+++ b/tests/serde/mod.rs
@@ -9,6 +9,7 @@ mod macros;
 mod rfc2822;
 mod rfc3339;
 mod timestamps;
+mod timestamps_millis;
 
 #[test]
 fn time() {

--- a/tests/serde/timestamps_millis.rs
+++ b/tests/serde/timestamps_millis.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+use serde_test::{assert_de_tokens_error, Token};
+use time::macros::datetime;
+use time::serde::timestamp_millis;
+use time::OffsetDateTime;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Test {
+    #[serde(with = "timestamp_millis")]
+    dt: OffsetDateTime,
+}
+
+#[test]
+fn serialize_timestamp_millis() {
+    // serde_test tokens do not support i128, so test with json
+    let value = Test {
+        dt: datetime!(2000-01-01 00:00:00.123 UTC),
+    };
+    let value_json = r#"{"dt":946684800123}"#;
+
+    let parsed: Test = serde_json::from_str(value_json).unwrap();
+    let parsed_json = serde_json::to_string(&parsed).unwrap();
+    
+    assert_eq!(value, parsed);
+    assert_eq!(value_json, parsed_json);
+    assert_de_tokens_error::<Test>(
+        &[
+            Token::Struct {
+                name: "Test",
+                len: 1,
+            },
+            Token::Str("dt"),
+            Token::Str("bad"),
+            Token::StructEnd,
+        ],
+        "invalid type: string \"bad\", expected i128",
+    );
+}
+

--- a/time/src/date_time.rs
+++ b/time/src/date_time.rs
@@ -240,6 +240,26 @@ impl<O: MaybeOffset> DateTime<O> {
         })
     }
 
+    pub const fn from_unix_timestamp_millis(timestamp: i128) -> Result<Self, error::ComponentRange>
+    where
+        O: HasOffset,
+    {
+        let datetime = const_try!(Self::from_unix_timestamp(
+            div_floor!(timestamp, 1_000) as i64
+        ));
+
+        Ok(Self {
+            date: datetime.date,
+            time: Time::__from_hms_nanos_unchecked(
+                datetime.hour(),
+                datetime.minute(),
+                datetime.second(),
+                (timestamp * 1_000_000).rem_euclid(1_000_000_000) as u32,
+            ),
+            offset: UtcOffset::UTC,
+        })
+    }
+
     pub const fn from_unix_timestamp_nanos(timestamp: i128) -> Result<Self, error::ComponentRange>
     where
         O: HasOffset,

--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -130,6 +130,27 @@ impl OffsetDateTime {
         Ok(Self(const_try!(Inner::from_unix_timestamp(timestamp))))
     }
 
+    /// Construct an `OffsetDateTime` from the provided Unix timestamp (in milliseconds). Calling
+    /// `.offset()` on the resulting value is guaranteed to return UTC.
+    ///
+    /// ```rust
+    /// # use time::OffsetDateTime;
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     OffsetDateTime::from_unix_timestamp_millis(0),
+    ///     Ok(OffsetDateTime::UNIX_EPOCH),
+    /// );
+    /// assert_eq!(
+    ///     OffsetDateTime::from_unix_timestamp_millis(1_546_300_800_123),
+    ///     Ok(datetime!(2019-01-01 0:00:00.123 UTC)),
+    /// );
+    /// ```
+    pub const fn from_unix_timestamp_millis(timestamp: i128) -> Result<Self, error::ComponentRange> {
+        Ok(Self(const_try!(Inner::from_unix_timestamp_millis(
+            timestamp
+        ))))
+    }
+
     /// Construct an `OffsetDateTime` from the provided Unix timestamp (in nanoseconds). Calling
     /// `.offset()` on the resulting value is guaranteed to return UTC.
     ///
@@ -173,6 +194,20 @@ impl OffsetDateTime {
     /// ```
     pub const fn unix_timestamp(self) -> i64 {
         self.0.unix_timestamp()
+    }
+
+    /// Get the Unix timestamp in milliseconds.
+    ///
+    /// ```rust
+    /// use time_macros::datetime;
+    /// assert_eq!(datetime!(1970-01-01 0:00 UTC).unix_timestamp_millis(), 0);
+    /// assert_eq!(
+    ///     datetime!(1970-01-01 0:00 -1).unix_timestamp_millis(),
+    ///     3_600_000,
+    /// );
+    /// ```
+    pub const fn unix_timestamp_millis(self) -> i128 {
+        self.unix_timestamp() as i128 * 1_000 + self.millisecond() as i128
     }
 
     /// Get the Unix timestamp in nanoseconds.

--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -145,7 +145,9 @@ impl OffsetDateTime {
     ///     Ok(datetime!(2019-01-01 0:00:00.123 UTC)),
     /// );
     /// ```
-    pub const fn from_unix_timestamp_millis(timestamp: i128) -> Result<Self, error::ComponentRange> {
+    pub const fn from_unix_timestamp_millis(
+        timestamp: i128,
+    ) -> Result<Self, error::ComponentRange> {
         Ok(Self(const_try!(Inner::from_unix_timestamp_millis(
             timestamp
         ))))

--- a/time/src/serde/mod.rs
+++ b/time/src/serde/mod.rs
@@ -20,6 +20,7 @@ pub mod rfc2822;
 #[cfg(any(feature = "formatting", feature = "parsing"))]
 pub mod rfc3339;
 pub mod timestamp;
+pub mod timestamp_millis;
 mod visitor;
 
 use core::marker::PhantomData;

--- a/time/src/serde/timestamp_millis.rs
+++ b/time/src/serde/timestamp_millis.rs
@@ -1,0 +1,61 @@
+//! Treat an [`OffsetDateTime`] as a [Unix timestamp] with millisecond precision
+//! for the purposes of serde.
+//!
+//! Use this module in combination with serde's [`#[with]`][with] attribute.
+//!
+//! When deserializing, the offset is assumed to be UTC.
+//!
+//! [Unix timestamp]: https://en.wikipedia.org/wiki/Unix_time
+//! [with]: https://serde.rs/field-attrs.html#with
+
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::OffsetDateTime;
+
+/// Serialize an `OffsetDateTime` as its Unix timestamp with milliseconds
+pub fn serialize<S: Serializer>(
+    datetime: &OffsetDateTime,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    datetime.unix_timestamp_millis().serialize(serializer)
+}
+
+/// Deserialize an `OffsetDateTime` from its Unix timestamp with milliseconds
+pub fn deserialize<'a, D: Deserializer<'a>>(deserializer: D) -> Result<OffsetDateTime, D::Error> {
+    OffsetDateTime::from_unix_timestamp_millis(<_>::deserialize(deserializer)?)
+        .map_err(|err| de::Error::invalid_value(de::Unexpected::Signed(err.value), &err))
+}
+
+/// Treat an `Option<OffsetDateTime>` as a [Unix timestamp] with millisecond
+/// precision for the purposes of serde.
+///
+/// Use this module in combination with serde's [`#[with]`][with] attribute.
+///
+/// When deserializing, the offset is assumed to be UTC.
+///
+/// [Unix timestamp]: https://en.wikipedia.org/wiki/Unix_time
+/// [with]: https://serde.rs/field-attrs.html#with
+pub mod option {
+    #[allow(clippy::wildcard_imports)]
+    use super::*;
+
+    /// Serialize an `Option<OffsetDateTime>` as its Unix timestamp
+    pub fn serialize<S: Serializer>(
+        option: &Option<OffsetDateTime>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        option
+            .map(OffsetDateTime::unix_timestamp_millis)
+            .serialize(serializer)
+    }
+
+    /// Deserialize an `Option<OffsetDateTime>` from its Unix timestamp
+    pub fn deserialize<'a, D: Deserializer<'a>>(
+        deserializer: D,
+    ) -> Result<Option<OffsetDateTime>, D::Error> {
+        Option::deserialize(deserializer)?
+            .map(OffsetDateTime::from_unix_timestamp_millis)
+            .transpose()
+            .map_err(|err| de::Error::invalid_value(de::Unexpected::Signed(err.value), &err))
+    }
+}


### PR DESCRIPTION
Hi!

First off, thanks a lot for this excellent crate.

I've been happily using `time` for a few projects, but often have the need to deserialize and parse data featuring unix timestamps in millisecond format -- usually created in some java or kotlin application where this seems to be very common.

Instead of only doing local altering/parsing of this, it seems like it could be a good fit along with the existning nanosecond support.

I've tried to make the new code as close as possible to the existing nanosecond/second functions where possible.