### PR TITLE
Implement `Weekday::nth_next`

### DIFF
--- a/benchmarks/weekday.rs
+++ b/benchmarks/weekday.rs
@@ -25,26 +25,18 @@ setup_benchmark! {
     }
 
     fn nth(ben: &mut Bencher<'_>) {
-        ben.iter(|| Sunday.nth(0));
-        ben.iter(|| Sunday.nth(1));
-        ben.iter(|| Sunday.nth(2));
-        ben.iter(|| Sunday.nth(3));
-        ben.iter(|| Sunday.nth(4));
-        ben.iter(|| Sunday.nth(5));
-        ben.iter(|| Sunday.nth(6));
+        ben.iter(|| Sunday.nth_next(0));
+        ben.iter(|| Sunday.nth_next(1));
+        ben.iter(|| Sunday.nth_next(2));
+        ben.iter(|| Sunday.nth_next(3));
+        ben.iter(|| Sunday.nth_next(4));
+        ben.iter(|| Sunday.nth_next(5));
+        ben.iter(|| Sunday.nth_next(6));
 
-        ben.iter(|| Monday.nth(0));
-        ben.iter(|| Monday.nth(1));
-        ben.iter(|| Monday.nth(2));
-        ben.iter(|| Monday.nth(3));
-        ben.iter(|| Monday.nth(4));
-        ben.iter(|| Monday.nth(5));
-        ben.iter(|| Monday.nth(6));
-
-        ben.iter(|| Sunday.nth(7));
-        ben.iter(|| Sunday.nth(u8::MAX));
-        ben.iter(|| Monday.nth(7));
-        ben.iter(|| Monday.nth(u8::MAX));
+        ben.iter(|| Sunday.nth_next(7));
+        ben.iter(|| Sunday.nth_next(u8::MAX));
+        ben.iter(|| Monday.nth_next(7));
+        ben.iter(|| Monday.nth_next(u8::MAX));
     }
 
     fn number_from_monday(ben: &mut Bencher<'_>) {

--- a/benchmarks/weekday.rs
+++ b/benchmarks/weekday.rs
@@ -24,6 +24,29 @@ setup_benchmark! {
         ben.iter(|| Saturday.next());
     }
 
+    fn nth(ben: &mut Bencher<'_>) {
+        ben.iter(|| Sunday.nth(0));
+        ben.iter(|| Sunday.nth(1));
+        ben.iter(|| Sunday.nth(2));
+        ben.iter(|| Sunday.nth(3));
+        ben.iter(|| Sunday.nth(4));
+        ben.iter(|| Sunday.nth(5));
+        ben.iter(|| Sunday.nth(6));
+
+        ben.iter(|| Monday.nth(0));
+        ben.iter(|| Monday.nth(1));
+        ben.iter(|| Monday.nth(2));
+        ben.iter(|| Monday.nth(3));
+        ben.iter(|| Monday.nth(4));
+        ben.iter(|| Monday.nth(5));
+        ben.iter(|| Monday.nth(6));
+
+        ben.iter(|| Sunday.nth(7));
+        ben.iter(|| Sunday.nth(u8::MAX));
+        ben.iter(|| Monday.nth(7));
+        ben.iter(|| Monday.nth(u8::MAX));
+    }
+
     fn number_from_monday(ben: &mut Bencher<'_>) {
         ben.iter(|| Monday.number_from_monday());
         ben.iter(|| Tuesday.number_from_monday());

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1,5 +1,6 @@
 use quickcheck::{Arbitrary, TestResult};
 use quickcheck_macros::quickcheck;
+use time::Weekday::*;
 use time::{Date, Duration, Month, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset, Weekday};
 
 macro_rules! test_shrink {
@@ -113,6 +114,26 @@ fn unix_timestamp_nanos_roundtrip(odt: OffsetDateTime) -> TestResult {
 }
 
 #[quickcheck]
+fn number_from_monday_roundtrip(w: Weekday) -> bool {
+    Monday.nth_next(w.number_from_monday() + 7 - 1) == w
+}
+
+#[quickcheck]
+fn number_from_sunday_roundtrip(w: Weekday) -> bool {
+    Sunday.nth_next(w.number_from_sunday() + 7 - 1) == w
+}
+
+#[quickcheck]
+fn number_days_from_monday_roundtrip(w: Weekday) -> bool {
+    Monday.nth_next(w.number_days_from_monday()) == w
+}
+
+#[quickcheck]
+fn number_days_from_sunday_roundtrip(w: Weekday) -> bool {
+    Sunday.nth_next(w.number_days_from_sunday()) == w
+}
+
+#[quickcheck]
 fn weekday_supports_arbitrary(w: Weekday) -> bool {
     (1..=7).contains(&w.number_from_monday())
 }
@@ -120,7 +141,7 @@ fn weekday_supports_arbitrary(w: Weekday) -> bool {
 #[quickcheck]
 fn weekday_can_shrink(w: Weekday) -> bool {
     match w {
-        Weekday::Monday => w.shrink().next().is_none(),
+        Monday => w.shrink().next().is_none(),
         _ => w.shrink().next() == Some(w.previous()),
     }
 }

--- a/tests/weekday.rs
+++ b/tests/weekday.rs
@@ -1,3 +1,4 @@
+use quickcheck_macros::quickcheck;
 use time::Weekday::{self, *};
 
 #[test]
@@ -20,6 +21,30 @@ fn next() {
     assert_eq!(Thursday.next(), Friday);
     assert_eq!(Friday.next(), Saturday);
     assert_eq!(Saturday.next(), Sunday);
+}
+
+#[test]
+fn nth() {
+    assert_eq!(Sunday.nth(0), Sunday);
+    assert_eq!(Sunday.nth(1), Monday);
+    assert_eq!(Sunday.nth(2), Tuesday);
+    assert_eq!(Sunday.nth(3), Wednesday);
+    assert_eq!(Sunday.nth(4), Thursday);
+    assert_eq!(Sunday.nth(5), Friday);
+    assert_eq!(Sunday.nth(6), Saturday);
+
+    assert_eq!(Monday.nth(0), Monday);
+    assert_eq!(Monday.nth(1), Tuesday);
+    assert_eq!(Monday.nth(2), Wednesday);
+    assert_eq!(Monday.nth(3), Thursday);
+    assert_eq!(Monday.nth(4), Friday);
+    assert_eq!(Monday.nth(5), Saturday);
+    assert_eq!(Monday.nth(6), Sunday);
+
+    assert_eq!(Sunday.nth(7), Sunday);
+    assert_eq!(Sunday.nth(u8::MAX), Wednesday);
+    assert_eq!(Monday.nth(7), Monday);
+    assert_eq!(Monday.nth(u8::MAX), Thursday);
 }
 
 #[test]
@@ -64,6 +89,31 @@ fn number_days_from_sunday() {
     assert_eq!(Thursday.number_days_from_sunday(), 4);
     assert_eq!(Friday.number_days_from_sunday(), 5);
     assert_eq!(Saturday.number_days_from_sunday(), 6);
+}
+
+// Test operations that are expected to reverse each other.
+mod round_trip {
+    use super::*;
+
+    #[quickcheck]
+    fn number_from_monday(w: Weekday) -> bool {
+        Monday.nth(w.number_from_monday() + 7 - 1) == w
+    }
+
+    #[quickcheck]
+    fn number_from_sunday(w: Weekday) -> bool {
+        Sunday.nth(w.number_from_sunday() + 7 - 1) == w
+    }
+
+    #[quickcheck]
+    fn number_days_from_monday(w: Weekday) -> bool {
+        Monday.nth(w.number_days_from_monday()) == w
+    }
+
+    #[quickcheck]
+    fn number_days_from_sunday(w: Weekday) -> bool {
+        Sunday.nth(w.number_days_from_sunday()) == w
+    }
 }
 
 #[test]

--- a/tests/weekday.rs
+++ b/tests/weekday.rs
@@ -1,4 +1,3 @@
-use quickcheck_macros::quickcheck;
 use time::Weekday::{self, *};
 
 #[test]
@@ -24,27 +23,27 @@ fn next() {
 }
 
 #[test]
-fn nth() {
-    assert_eq!(Sunday.nth(0), Sunday);
-    assert_eq!(Sunday.nth(1), Monday);
-    assert_eq!(Sunday.nth(2), Tuesday);
-    assert_eq!(Sunday.nth(3), Wednesday);
-    assert_eq!(Sunday.nth(4), Thursday);
-    assert_eq!(Sunday.nth(5), Friday);
-    assert_eq!(Sunday.nth(6), Saturday);
+fn nth_next() {
+    assert_eq!(Sunday.nth_next(0), Sunday);
+    assert_eq!(Sunday.nth_next(1), Monday);
+    assert_eq!(Sunday.nth_next(2), Tuesday);
+    assert_eq!(Sunday.nth_next(3), Wednesday);
+    assert_eq!(Sunday.nth_next(4), Thursday);
+    assert_eq!(Sunday.nth_next(5), Friday);
+    assert_eq!(Sunday.nth_next(6), Saturday);
 
-    assert_eq!(Monday.nth(0), Monday);
-    assert_eq!(Monday.nth(1), Tuesday);
-    assert_eq!(Monday.nth(2), Wednesday);
-    assert_eq!(Monday.nth(3), Thursday);
-    assert_eq!(Monday.nth(4), Friday);
-    assert_eq!(Monday.nth(5), Saturday);
-    assert_eq!(Monday.nth(6), Sunday);
+    assert_eq!(Monday.nth_next(0), Monday);
+    assert_eq!(Monday.nth_next(1), Tuesday);
+    assert_eq!(Monday.nth_next(2), Wednesday);
+    assert_eq!(Monday.nth_next(3), Thursday);
+    assert_eq!(Monday.nth_next(4), Friday);
+    assert_eq!(Monday.nth_next(5), Saturday);
+    assert_eq!(Monday.nth_next(6), Sunday);
 
-    assert_eq!(Sunday.nth(7), Sunday);
-    assert_eq!(Sunday.nth(u8::MAX), Wednesday);
-    assert_eq!(Monday.nth(7), Monday);
-    assert_eq!(Monday.nth(u8::MAX), Thursday);
+    assert_eq!(Sunday.nth_next(7), Sunday);
+    assert_eq!(Sunday.nth_next(u8::MAX), Wednesday);
+    assert_eq!(Monday.nth_next(7), Monday);
+    assert_eq!(Monday.nth_next(u8::MAX), Thursday);
 }
 
 #[test]
@@ -89,31 +88,6 @@ fn number_days_from_sunday() {
     assert_eq!(Thursday.number_days_from_sunday(), 4);
     assert_eq!(Friday.number_days_from_sunday(), 5);
     assert_eq!(Saturday.number_days_from_sunday(), 6);
-}
-
-// Test operations that are expected to reverse each other.
-mod round_trip {
-    use super::*;
-
-    #[quickcheck]
-    fn number_from_monday(w: Weekday) -> bool {
-        Monday.nth(w.number_from_monday() + 7 - 1) == w
-    }
-
-    #[quickcheck]
-    fn number_from_sunday(w: Weekday) -> bool {
-        Sunday.nth(w.number_from_sunday() + 7 - 1) == w
-    }
-
-    #[quickcheck]
-    fn number_days_from_monday(w: Weekday) -> bool {
-        Monday.nth(w.number_days_from_monday()) == w
-    }
-
-    #[quickcheck]
-    fn number_days_from_sunday(w: Weekday) -> bool {
-        Sunday.nth(w.number_days_from_sunday()) == w
-    }
 }
 
 #[test]

--- a/time/src/weekday.rs
+++ b/time/src/weekday.rs
@@ -66,6 +66,26 @@ impl Weekday {
         }
     }
 
+    /// Get n-th next day.
+    ///
+    /// ```rust
+    /// # use time::Weekday;
+    /// assert_eq!(Weekday::Monday.nth(1), Weekday::Tuesday);
+    /// assert_eq!(Weekday::Sunday.nth(10), Weekday::Wednesday);
+    /// ```
+    pub const fn nth(self, n: u8) -> Self {
+        match (self.number_days_from_monday() + (n % 7)) % 7 {
+            0 => Monday,
+            1 => Tuesday,
+            2 => Wednesday,
+            3 => Thursday,
+            4 => Friday,
+            5 => Saturday,
+            6 => Sunday,
+            _ => unreachable!(),
+        }
+    }
+
     /// Get the one-indexed number of days from Monday.
     ///
     /// ```rust

--- a/time/src/weekday.rs
+++ b/time/src/weekday.rs
@@ -70,19 +70,21 @@ impl Weekday {
     ///
     /// ```rust
     /// # use time::Weekday;
-    /// assert_eq!(Weekday::Monday.nth(1), Weekday::Tuesday);
-    /// assert_eq!(Weekday::Sunday.nth(10), Weekday::Wednesday);
+    /// assert_eq!(Weekday::Monday.nth_next(1), Weekday::Tuesday);
+    /// assert_eq!(Weekday::Sunday.nth_next(10), Weekday::Wednesday);
     /// ```
-    pub const fn nth(self, n: u8) -> Self {
-        match (self.number_days_from_monday() + (n % 7)) % 7 {
+    pub const fn nth_next(self, n: u8) -> Self {
+        match (self.number_days_from_monday() + n % 7) % 7 {
             0 => Monday,
             1 => Tuesday,
             2 => Wednesday,
             3 => Thursday,
             4 => Friday,
             5 => Saturday,
-            6 => Sunday,
-            _ => unreachable!(),
+            val => {
+                debug_assert!(val == 6);
+                Sunday
+            }
         }
     }
 


### PR DESCRIPTION
Adds `Weekday::nth`, a `fn(Weekday, u8) -> Weekday` method.

This is similar to `Iterator::nth`: it returns the n-th next week day after the current one.

This is in place of four different methods with long names that would be opposites of `number_from_monday`, `number_from_sunday`, `num_days_from_monday`, `num_days_from_sunday`. I was bikeshedding the names in my mind and realized that making a single general method is likely more ergonomic, if only because of the amount of effort it was taking to write - and therefore understand - the fairly long descriptions of each method.

Closes https://github.com/time-rs/time/issues/542