### PR TITLE
Fix new Rust 1.67 clippy errors

### DIFF
--- a/time/src/date_time.rs
+++ b/time/src/date_time.rs
@@ -93,9 +93,10 @@ impl MaybeOffset for offset_kind::None {
     type OffsetType = ();
     type OffsetKind = Self;
 
-    #[allow(clippy::undocumented_unsafe_blocks)] // false positive
-    // SAFETY: `()` is not `UtcOffset`.
-    const HAS_OFFSET: UnsafeBool = unsafe { UnsafeBool::new(false) };
+    const HAS_OFFSET: UnsafeBool = {
+        // SAFETY: `()` is not `UtcOffset`.
+        unsafe { UnsafeBool::new(false) }
+    };
 
     fn as_offset(_: ()) -> Option<UtcOffset> {
         None
@@ -114,9 +115,10 @@ impl MaybeOffset for offset_kind::Fixed {
     type OffsetType = UtcOffset;
     type OffsetKind = Self;
 
-    #[allow(clippy::undocumented_unsafe_blocks)] // false positive
-    // Safety: `UtcOffset` is the offset type.
-    const HAS_OFFSET: UnsafeBool = unsafe { UnsafeBool::new(true) };
+    const HAS_OFFSET: UnsafeBool = {
+        // Safety: `UtcOffset` is the offset type.
+        unsafe { UnsafeBool::new(true) }
+    };
 
     fn as_offset(offset: UtcOffset) -> Option<UtcOffset> {
         Some(offset)
@@ -830,7 +832,7 @@ impl<O: MaybeOffset> fmt::Display for DateTime<O> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", self.date, self.time)?;
         if let Some(offset) = O::as_offset(self.offset) {
-            write!(f, " {}", offset)?;
+            write!(f, " {offset}")?;
         }
         Ok(())
     }

--- a/time/src/formatting/mod.rs
+++ b/time/src/formatting/mod.rs
@@ -152,19 +152,13 @@ pub(crate) fn format_float(
         Some(digits_after_decimal) => {
             let digits_after_decimal = digits_after_decimal.get() as usize;
             let width = digits_before_decimal as usize + 1 + digits_after_decimal;
-            write!(
-                output,
-                "{value:0>width$.digits_after_decimal$}",
-                value = value,
-                width = width,
-                digits_after_decimal = digits_after_decimal,
-            )?;
+            write!(output, "{value:0>width$.digits_after_decimal$}",)?;
             Ok(width)
         }
         None => {
             let value = value.trunc() as u64;
             let width = digits_before_decimal as usize;
-            write!(output, "{value:0>width$}", value = value, width = width)?;
+            write!(output, "{value:0>width$}")?;
             Ok(width)
         }
     }

--- a/time/src/instant.rs
+++ b/time/src/instant.rs
@@ -156,6 +156,10 @@ impl Sub<Instant> for StdInstant {
     }
 }
 
+/// # Panics
+///
+/// This function may panic if the resulting point in time cannot be
+/// represented by the underlying [`std::time::Instant`].
 impl Add<Duration> for Instant {
     type Output = Self;
 
@@ -163,6 +167,7 @@ impl Add<Duration> for Instant {
         if duration.is_positive() {
             Self(self.0 + duration.unsigned_abs())
         } else if duration.is_negative() {
+            #[allow(clippy::unchecked_duration_subtraction)]
             Self(self.0 - duration.unsigned_abs())
         } else {
             debug_assert!(duration.is_zero());
@@ -190,11 +195,16 @@ impl Add<StdDuration> for Instant {
 impl_add_assign!(Instant: Duration, StdDuration);
 impl_add_assign!(StdInstant: Duration);
 
+/// # Panics
+///
+/// This function may panic if the resulting point in time cannot be
+/// represented by the underlying [`std::time::Instant`].
 impl Sub<Duration> for Instant {
     type Output = Self;
 
     fn sub(self, duration: Duration) -> Self::Output {
         if duration.is_positive() {
+            #[allow(clippy::unchecked_duration_subtraction)]
             Self(self.0 - duration.unsigned_abs())
         } else if duration.is_negative() {
             Self(self.0 + duration.unsigned_abs())
@@ -213,10 +223,15 @@ impl Sub<Duration> for StdInstant {
     }
 }
 
+/// # Panics
+///
+/// This function may panic if the resulting point in time cannot be
+/// represented by the underlying [`std::time::Instant`].
 impl Sub<StdDuration> for Instant {
     type Output = Self;
 
     fn sub(self, duration: StdDuration) -> Self::Output {
+        #[allow(clippy::unchecked_duration_subtraction)]
         Self(self.0 - duration)
     }
 }


### PR DESCRIPTION
Fixes new Clippy warnings that came with Rust 1.67.

Warnings:

 * [uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args)
 * [unchecked_duration_subtraction](https://rust-lang.github.io/rust-clippy/master/index.html#unchecked_duration_subtraction)

Also fixes a formatting issue: comments around [undocumented_unsafe_blocks](https://rust-lang.github.io/rust-clippy/master/index.html#undocumented_unsafe_blocks): `//false positive` was being considered part of the same comment block with the following `// SAFETY: ...` comment, so the latter was indented to be on the same level. Like

```rust
let x = 0; // first value
           // will be used later
```

Rust-analyzer and cargo fmt also seemingly disagreed on the correct way to format [time/src/formatting/mod.rs#L128](https://github.com/time-rs/time/blob/main/time/src/formatting/mod.rs#L128).