### PR TITLE
Add doc links to main doc and formatting

### DIFF
--- a/time/src/format_description/mod.rs
+++ b/time/src/format_description/mod.rs
@@ -3,6 +3,9 @@
 //! The formatted value will be output to the provided writer. Format descriptions can be
 //! [well-known](crate::format_description::well_known) or obtained by using the
 //! [`format_description!`](crate::macros::format_description) macro or a function listed below.
+//!
+//! For examples, see the implementors of [Formattable](crate::formatting::Formattable),
+//! e.g. [well_known::Rfc3339].
 
 mod borrowed_format_item;
 mod component;

--- a/time/src/format_description/mod.rs
+++ b/time/src/format_description/mod.rs
@@ -5,7 +5,7 @@
 //! [`format_description!`](crate::macros::format_description) macro or a function listed below.
 //!
 //! For examples, see the implementors of [Formattable](crate::formatting::Formattable),
-//! e.g. [well_known::Rfc3339].
+//! e.g. [`well_known::Rfc3339`].
 
 mod borrowed_format_item;
 mod component;

--- a/time/src/formatting/formattable.rs
+++ b/time/src/formatting/formattable.rs
@@ -13,7 +13,7 @@ use crate::{error, Date, Time, UtcOffset};
 
 /// A type that describes a format.
 ///
-/// Implementors of [Formattable] are [format descriptions](crate::format_description).
+/// Implementors of [`Formattable]` are [format descriptions](crate::format_description).
 ///
 /// [Date::format] and [Time::format] each use a format description to generate
 /// a String from their data. See the respective methods for usage examples.

--- a/time/src/formatting/formattable.rs
+++ b/time/src/formatting/formattable.rs
@@ -13,9 +13,9 @@ use crate::{error, Date, Time, UtcOffset};
 
 /// A type that describes a format.
 ///
-/// Implementors of [`Formattable]` are [format descriptions](crate::format_description).
+/// Implementors of [`Formattable`] are [format descriptions](crate::format_description).
 ///
-/// [Date::format] and [Time::format] each use a format description to generate
+/// [`Date::format`] and [`Time::format`] each use a format description to generate
 /// a String from their data. See the respective methods for usage examples.
 #[cfg_attr(__time_03_docs, doc(notable_trait))]
 pub trait Formattable: sealed::Sealed {}

--- a/time/src/formatting/formattable.rs
+++ b/time/src/formatting/formattable.rs
@@ -11,7 +11,12 @@ use crate::formatting::{
 };
 use crate::{error, Date, Time, UtcOffset};
 
-/// A type that can be formatted.
+/// A type that describes a format.
+///
+/// Implementors of [Formattable] are [format descriptions](crate::format_description).
+///
+/// [Date::format] and [Time::format] each use a format description to generate
+/// a String from their data. See the respective methods for usage examples.
 #[cfg_attr(__time_03_docs, doc(notable_trait))]
 pub trait Formattable: sealed::Sealed {}
 impl Formattable for FormatItem<'_> {}

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -1,3 +1,7 @@
+//! A safe date and time library for Rust.
+//!
+//! [The book] is the main documentation for `time`.
+//!
 //! # Feature flags
 //!
 //! This crate exposes a number of features. These can be enabled or disabled as shown

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -1,7 +1,3 @@
-//! A safe date and time library for Rust.
-//!
-//! [The book] is the main documentation for `time`.
-//!
 //! # Feature flags
 //!
 //! This crate exposes a number of features. These can be enabled or disabled as shown


### PR DESCRIPTION
Hi, occasional user of this crate here! I've seen #327 and found the book reasonably helpful, but it was not at all obvious to me that the book existed at first.

This PR adds a link to the book at the top of the crate's rustdoc, as well as some intra-doc links for the formatting items.