### PR TITLE
Update `serde::format_description!()` docs

### DIFF
--- a/time/src/format_description/well_known/iso8601/adt_hack.rs
+++ b/time/src/format_description/well_known/iso8601/adt_hack.rs
@@ -11,7 +11,7 @@ use super::{Config, DateKind, FormattedComponents as FC, OffsetPrecision, TimePr
 #[doc(hidden)]
 pub type DoNotRelyOnWhatThisIs = u128;
 
-/// An encoded [`Config`] that can be used as a const parameter to [`Iso8601`].
+/// An encoded [`Config`] that can be used as a const parameter to [`Iso8601`](super::Iso8601).
 ///
 /// The type this is aliased to must not be relied upon. It can change in any release without
 /// notice.
@@ -49,10 +49,11 @@ impl<const CONFIG: EncodedConfig> Iso8601<CONFIG> {
 }
 
 impl Config {
-    /// Encode the configuration, permitting it to be used as a const parameter of [`Iso8601`].
+    /// Encode the configuration, permitting it to be used as a const parameter of
+    /// [`Iso8601`](super::Iso8601).
     ///
-    /// The value returned by this method must only be used as a const parameter to [`Iso8601`]. Any
-    /// other usage is unspecified behavior.
+    /// The value returned by this method must only be used as a const parameter to
+    /// [`Iso8601`](super::Iso8601). Any other usage is unspecified behavior.
     pub const fn encode(&self) -> EncodedConfig {
         let mut bytes = [0; EncodedConfig::BITS as usize / 8];
 

--- a/time/src/serde/mod.rs
+++ b/time/src/serde/mod.rs
@@ -27,23 +27,39 @@ use core::marker::PhantomData;
 #[cfg(feature = "serde-human-readable")]
 use serde::ser::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-/// Generate a custom serializer and deserializer from the provided string.
+/// Generate a custom serializer and deserializer from a format string or an existing format.
 ///
 /// The syntax accepted by this macro is the same as [`format_description::parse()`], which can
 /// be found in [the book](https://time-rs.github.io/book/api/format-description.html).
 ///
 /// # Usage
 ///
-/// Invoked as `serde::format_description!(mod_name, Date, "<format string>")`. This puts a
-/// module named `mod_name` in the current scope that can be used to format `Date` structs. A
-/// submodule (`mod_name::option`) is also generated for `Option<Date>`. Both modules are only
-/// visible in the current scope.
+/// Invoked as `serde::format_description!(mod_name, Date, FORMAT)` where `FORMAT` is either a
+/// `"<format string>"` or something that implements
+#[cfg_attr(
+    all(feature = "formatting", feature = "parsing"),
+    doc = "[`Formattable`](crate::formatting::Formattable) and \
+           [`Parsable`](crate::parsing::Parsable)"
+)]
+#[cfg_attr(
+    all(feature = "formatting", not(feature = "parsing")),
+    doc = "[`Formattable`](crate::formatting::Formattable)"
+)]
+#[cfg_attr(
+    all(not(feature = "formatting"), feature = "parsing"),
+    doc = "[`Parsable`](crate::parsing::Parsable)"
+)]
+/// . This puts a module named `mod_name` in the current scope that can be used to format
+/// `Date` structs. A submodule (`mod_name::option`) is also generated for `Option<Date>`. Both
+/// modules are only visible in the current scope.
 ///
 /// The returned `Option` will contain a deserialized value if present and `None` if the field
 /// is present but the value is `null` (or the equivalent in other formats). To return `None`
 /// when the field is not present, you should use `#[serde(default)]` on the field.
 ///
 /// # Examples
+///
+/// Using a format string:
 ///
 /// ```rust,no_run
 /// # use time::OffsetDateTime;
@@ -63,6 +79,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 ///
 /// // Makes a module `mod my_format { ... }`.
 /// serde::format_description!(my_format, OffsetDateTime, "hour=[hour], minute=[minute]");
+///
+/// # #[allow(dead_code)]
 #[cfg_attr(
     all(feature = "formatting", feature = "parsing"),
     doc = "#[derive(Serialize, Deserialize)]"
@@ -75,13 +93,113 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
     all(not(feature = "formatting"), feature = "parsing"),
     doc = "#[derive(Deserialize)]"
 )]
-/// # #[allow(dead_code)]
 /// struct SerializesWithCustom {
 ///     #[serde(with = "my_format")]
 ///     dt: OffsetDateTime,
 ///     #[serde(with = "my_format::option")]
 ///     maybe_dt: Option<OffsetDateTime>,
 /// }
+/// ```
+/// 
+/// \
+/// Define the format separately to be used in multiple places:
+/// ```rust,no_run
+/// # use time::OffsetDateTime;
+#[cfg_attr(
+    all(feature = "formatting", feature = "parsing"),
+    doc = "use ::serde::{Serialize, Deserialize};"
+)]
+#[cfg_attr(
+    all(feature = "formatting", not(feature = "parsing")),
+    doc = "use ::serde::Serialize;"
+)]
+#[cfg_attr(
+    all(not(feature = "formatting"), feature = "parsing"),
+    doc = "use ::serde::Deserialize;"
+)]
+/// use time::serde;
+/// use time::format_description::FormatItem;
+///
+/// const DATE_TIME_FOMRAT: &[FormatItem<'_>] = time::macros::format_description!(
+///     "hour=[hour], minute=[minute]"
+/// );
+///
+/// // Makes a module `mod my_format { ... }`.
+/// serde::format_description!(my_format, OffsetDateTime, DATE_TIME_FOMRAT);
+///
+/// # #[allow(dead_code)]
+#[cfg_attr(
+    all(feature = "formatting", feature = "parsing"),
+    doc = "#[derive(Serialize, Deserialize)]"
+)]
+#[cfg_attr(
+    all(feature = "formatting", not(feature = "parsing")),
+    doc = "#[derive(Serialize)]"
+)]
+#[cfg_attr(
+    all(not(feature = "formatting"), feature = "parsing"),
+    doc = "#[derive(Deserialize)]"
+)]
+/// struct SerializesWithCustom {
+///     #[serde(with = "my_format")]
+///     dt: OffsetDateTime,
+///     #[serde(with = "my_format::option")]
+///     maybe_dt: Option<OffsetDateTime>,
+/// }
+///
+/// fn main() {
+///     # #[allow(unused_variables)]
+///     let str_ts = OffsetDateTime::now_utc().format(DATE_TIME_FOMRAT).unwrap();
+/// }
+/// ```
+/// 
+/// \
+/// Customize the configuration of ISO 8601 formatting/parsing:
+/// ```rust,no_run
+/// # use time::OffsetDateTime;
+#[cfg_attr(
+    all(feature = "formatting", feature = "parsing"),
+    doc = "use ::serde::{Serialize, Deserialize};"
+)]
+#[cfg_attr(
+    all(feature = "formatting", not(feature = "parsing")),
+    doc = "use ::serde::Serialize;"
+)]
+#[cfg_attr(
+    all(not(feature = "formatting"), feature = "parsing"),
+    doc = "use ::serde::Deserialize;"
+)]
+/// use time::serde;
+/// use time::format_description::well_known::{iso8601, Iso8601};
+///
+/// const CONFIG: iso8601::EncodedConfig = iso8601::Config::DEFAULT
+///     .set_year_is_six_digits(false)
+///     .encode();
+/// const FORMAT: Iso8601<CONFIG> = Iso8601::<CONFIG>;
+///
+/// // Makes a module `mod my_format { ... }`.
+/// serde::format_description!(my_format, OffsetDateTime, FORMAT);
+///
+/// # #[allow(dead_code)]
+#[cfg_attr(
+    all(feature = "formatting", feature = "parsing"),
+    doc = "#[derive(Serialize, Deserialize)]"
+)]
+#[cfg_attr(
+    all(feature = "formatting", not(feature = "parsing")),
+    doc = "#[derive(Serialize)]"
+)]
+#[cfg_attr(
+    all(not(feature = "formatting"), feature = "parsing"),
+    doc = "#[derive(Deserialize)]"
+)]
+/// struct SerializesWithCustom {
+///     #[serde(with = "my_format")]
+///     dt: OffsetDateTime,
+///     #[serde(with = "my_format::option")]
+///     maybe_dt: Option<OffsetDateTime>,
+/// }
+/// # fn main() {}
 /// ```
 /// 
 /// [`format_description::parse()`]: crate::format_description::parse()

--- a/time/src/serde/mod.rs
+++ b/time/src/serde/mod.rs
@@ -39,18 +39,18 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg_attr(
     all(feature = "formatting", feature = "parsing"),
     doc = "[`Formattable`](crate::formatting::Formattable) and \
-           [`Parsable`](crate::parsing::Parsable)"
+           [`Parsable`](crate::parsing::Parsable)."
 )]
 #[cfg_attr(
     all(feature = "formatting", not(feature = "parsing")),
-    doc = "[`Formattable`](crate::formatting::Formattable)"
+    doc = "[`Formattable`](crate::formatting::Formattable)."
 )]
 #[cfg_attr(
     all(not(feature = "formatting"), feature = "parsing"),
-    doc = "[`Parsable`](crate::parsing::Parsable)"
+    doc = "[`Parsable`](crate::parsing::Parsable)."
 )]
-/// . This puts a module named `mod_name` in the current scope that can be used to format
-/// `Date` structs. A submodule (`mod_name::option`) is also generated for `Option<Date>`. Both
+/// This puts a module named `mod_name` in the current scope that can be used to format `Date`
+/// structs. A submodule (`mod_name::option`) is also generated for `Option<Date>`. Both
 /// modules are only visible in the current scope.
 ///
 /// The returned `Option` will contain a deserialized value if present and `None` if the field
@@ -101,7 +101,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// }
 /// ```
 /// 
-/// \
 /// Define the format separately to be used in multiple places:
 /// ```rust,no_run
 /// # use time::OffsetDateTime;
@@ -120,12 +119,12 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// use time::serde;
 /// use time::format_description::FormatItem;
 ///
-/// const DATE_TIME_FOMRAT: &[FormatItem<'_>] = time::macros::format_description!(
+/// const DATE_TIME_FORMAT: &[FormatItem<'_>] = time::macros::format_description!(
 ///     "hour=[hour], minute=[minute]"
 /// );
 ///
 /// // Makes a module `mod my_format { ... }`.
-/// serde::format_description!(my_format, OffsetDateTime, DATE_TIME_FOMRAT);
+/// serde::format_description!(my_format, OffsetDateTime, DATE_TIME_FORMAT);
 ///
 /// # #[allow(dead_code)]
 #[cfg_attr(
@@ -149,11 +148,10 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 ///
 /// fn main() {
 ///     # #[allow(unused_variables)]
-///     let str_ts = OffsetDateTime::now_utc().format(DATE_TIME_FOMRAT).unwrap();
+///     let str_ts = OffsetDateTime::now_utc().format(DATE_TIME_FORMAT).unwrap();
 /// }
 /// ```
 /// 
-/// \
 /// Customize the configuration of ISO 8601 formatting/parsing:
 /// ```rust,no_run
 /// # use time::OffsetDateTime;


### PR DESCRIPTION
Recent updates to the `serde::format_description!()` macro allow format descriptions other than format strings to be passed. This updates the documentation to reflect that.