### PR TITLE
add support for bincode v2

### DIFF
--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -31,6 +31,7 @@ macros = ["dep:time-macros"]
 parsing = ["time-macros?/parsing"]
 quickcheck = ["dep:quickcheck", "alloc"]
 rand = ["dep:rand"]
+bincode = ["dep:bincode"]
 serde = ["dep:serde", "time-macros?/serde"]
 serde-human-readable = ["serde", "formatting", "parsing"]
 # Deprecated in favor of using the relevant flags directly.
@@ -44,6 +45,7 @@ wasm-bindgen = ["dep:js-sys"]
 itoa = { version = "1.0.1", optional = true }
 quickcheck = { version = "1.0.3", default-features = false, optional = true }
 rand = { version = "0.8.4", optional = true, default-features = false }
+bincode = { version = "2.0.0-rc", default-features = false, optional = true }
 serde = { version = "1.0.126", optional = true, default-features = false }
 time-core = { version = "=0.1.0", path = "../time-core" }
 time-macros = { version = "=0.2.8", path = "../time-macros", optional = true }

--- a/time/src/date.rs
+++ b/time/src/date.rs
@@ -32,6 +32,7 @@ pub(crate) const MAX_YEAR: i32 = if cfg!(feature = "large-dates") {
 /// inclusive by enabling the `large-dates` crate feature. Doing so has performance implications
 /// and introduces some ambiguities when parsing.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(bincode, derive(bincode::Encode, bincode::Decode))]
 pub struct Date {
     /// Bitpacked field containing both the year and ordinal.
     // |     xx     | xxxxxxxxxxxxxxxxxxxxx | xxxxxxxxx |

--- a/time/src/date_time.rs
+++ b/time/src/date_time.rs
@@ -25,7 +25,9 @@ use crate::{error, util, Date, Duration, Month, Time, UtcOffset, Weekday};
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub(crate) mod offset_kind {
+    #[cfg_attr(bincode, derive(bincode::Encode, bincode::Decode))]
     pub enum None {}
+    #[cfg_attr(bincode, derive(bincode::Encode, bincode::Decode))]
     pub enum Fixed {}
 }
 
@@ -190,6 +192,7 @@ pub(crate) const fn maybe_offset_from_offset<O: MaybeOffset>(
 /// The Julian day of the Unix epoch.
 const UNIX_EPOCH_JULIAN_DAY: i32 = Date::__from_ordinal_date_unchecked(1970, 1).to_julian_day();
 
+#[cfg_attr(bincode, derive(bincode::Encode, bincode::Decode))]
 pub struct DateTime<O: MaybeOffset> {
     pub(crate) date: Date,
     pub(crate) time: Time,

--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -21,12 +21,14 @@ use crate::parsing::Parsable;
 use crate::{error, Date, DateTime, Duration, Month, PrimitiveDateTime, Time, UtcOffset, Weekday};
 
 /// The actual type doing all the work.
+#[cfg_attr(bincode, derive(bincode::Encode, bincode::Decode))]
 type Inner = DateTime<offset_kind::Fixed>;
 
 /// A [`PrimitiveDateTime`] with a [`UtcOffset`].
 ///
 /// All comparisons are performed using the UTC time.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(bincode, derive(bincode::Encode, bincode::Decode))]
 pub struct OffsetDateTime(pub(crate) Inner);
 
 impl OffsetDateTime {

--- a/time/src/time.rs
+++ b/time/src/time.rs
@@ -17,6 +17,7 @@ use crate::{error, Duration};
 /// perform niche value optimization.
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(bincode, derive(bincode::Encode, bincode::Decode))]
 pub(crate) enum Padding {
     #[allow(clippy::missing_docs_in_private_items)]
     Optimize,
@@ -29,6 +30,7 @@ pub(crate) enum Padding {
 ///
 /// When comparing two `Time`s, they are assumed to be in the same calendar date.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(bincode, derive(bincode::Encode, bincode::Decode))]
 pub struct Time {
     #[allow(clippy::missing_docs_in_private_items)]
     hour: u8,


### PR DESCRIPTION
Hey!
I don’t know if this is the kind of PR you would be willing to merge, but I would really like to use bincode in our workflow, and the only blocking crate is time, so I was wondering if it would be possible to add the support of bincode under a feature flag.