### PR TITLE
feat: add NAIVE_UNIX_EPOCH constant to PrimitiveDateTime

### DIFF
--- a/time/src/date_time.rs
+++ b/time/src/date_time.rs
@@ -220,6 +220,12 @@ impl DateTime<offset_kind::None> {
         time: Time::MAX,
         offset: (),
     };
+
+    pub const NAIVE_UNIX_EPOCH: Self = Self {
+        date: Date::__from_ordinal_date_unchecked(1970, 1),
+        time: Time::MIDNIGHT,
+        offset: (),
+    };
 }
 
 impl DateTime<offset_kind::Fixed> {

--- a/time/src/primitive_date_time.rs
+++ b/time/src/primitive_date_time.rs
@@ -50,6 +50,16 @@ impl PrimitiveDateTime {
     /// ```
     pub const MIN: Self = Self(Inner::MIN);
 
+    /// Midnight, 1 January, 1970 (without timezone!)
+    ///
+    /// ```rust
+    /// # use time::{PrimitiveDateTime, OffsetDateTime};
+    /// # use time_macros::datetime;
+    /// assert_eq!(PrimitiveDateTime::NAIVE_UNIX_EPOCH, datetime!(1970-01-01 0:00));
+    /// assert_eq!(PrimitiveDateTime::NAIVE_UNIX_EPOCH.assume_utc(), OffsetDateTime::UNIX_EPOCH);
+    /// ```
+    pub const NAIVE_UNIX_EPOCH: Self = Self(Inner::NAIVE_UNIX_EPOCH);
+
     /// The largest value that can be represented by `PrimitiveDateTime`.
     ///
     /// Depending on `large-dates` feature flag, value of this constant may vary.


### PR DESCRIPTION
I am not sure if this is acceptable in terms of interface `time` crate want to provide. I think `NAIVE` prefix is nice suggestion that developer is responsible for correctness of logic here and such constant can be useful. 