### PR TITLE
Make minutes, seconds optional when deserializing `UtcOffset`

### DIFF
--- a/tests/serde/mod.rs
+++ b/tests/serde/mod.rs
@@ -769,40 +769,40 @@ fn utc_offset_error() {
 #[test]
 fn utc_offset_partial() {
     assert_de_tokens_error::<Compact<UtcOffset>>(
-        &[Token::Tuple { len: 3 }, Token::TupleEnd],
+        &[Token::Tuple { len: 0 }, Token::TupleEnd],
         "expected offset hours",
     );
     assert_de_tokens_error::<Readable<UtcOffset>>(
-        &[Token::Tuple { len: 3 }, Token::TupleEnd],
+        &[Token::Tuple { len: 0 }, Token::TupleEnd],
         "expected offset hours",
     );
 
-    let value = offset!(+23:0:0);
+    let value = offset!(+23);
     assert_de_tokens::<Compact<UtcOffset>>(
         &value.compact(),
-        &[Token::Tuple { len: 3 }, Token::I8(23), Token::TupleEnd],
+        &[Token::Tuple { len: 1 }, Token::I8(23), Token::TupleEnd],
     );
-    let value = offset!(+23:0:0);
+    let value = offset!(+23);
     assert_de_tokens::<Readable<UtcOffset>>(
         &value.readable(),
-        &[Token::Tuple { len: 3 }, Token::I8(23), Token::TupleEnd],
+        &[Token::Tuple { len: 1 }, Token::I8(23), Token::TupleEnd],
     );
 
-    let value = offset!(+23:58:0);
+    let value = offset!(+23:58);
     assert_de_tokens::<Compact<UtcOffset>>(
         &value.compact(),
         &[
-            Token::Tuple { len: 3 },
+            Token::Tuple { len: 2 },
             Token::I8(23),
             Token::I8(58),
             Token::TupleEnd,
         ],
     );
-    let value = offset!(+23:58:0);
+    let value = offset!(+23:58);
     assert_de_tokens::<Readable<UtcOffset>>(
         &value.readable(),
         &[
-            Token::Tuple { len: 3 },
+            Token::Tuple { len: 2 },
             Token::I8(23),
             Token::I8(58),
             Token::TupleEnd,

--- a/tests/serde/mod.rs
+++ b/tests/serde/mod.rs
@@ -777,18 +777,18 @@ fn utc_offset_partial() {
         "expected offset hours",
     );
 
-    let value = UtcOffset::from_hms(23, 0, 0).unwrap();
+    let value = offset!(+23:0:0);
     assert_de_tokens::<Compact<UtcOffset>>(
         &value.compact(),
         &[Token::Tuple { len: 3 }, Token::I8(23), Token::TupleEnd],
     );
-    let value = UtcOffset::from_hms(23, 0, 0).unwrap();
+    let value = offset!(+23:0:0);
     assert_de_tokens::<Readable<UtcOffset>>(
         &value.readable(),
         &[Token::Tuple { len: 3 }, Token::I8(23), Token::TupleEnd],
     );
 
-    let value = UtcOffset::from_hms(23, 58, 0).unwrap();
+    let value = offset!(+23:58:0);
     assert_de_tokens::<Compact<UtcOffset>>(
         &value.compact(),
         &[
@@ -798,8 +798,7 @@ fn utc_offset_partial() {
             Token::TupleEnd,
         ],
     );
-
-    let value = UtcOffset::from_hms(23, 58, 0).unwrap();
+    let value = offset!(+23:58:0);
     assert_de_tokens::<Readable<UtcOffset>>(
         &value.readable(),
         &[

--- a/tests/serde/mod.rs
+++ b/tests/serde/mod.rs
@@ -1,4 +1,6 @@
-use serde_test::{assert_de_tokens_error, assert_tokens, Compact, Configure, Readable, Token};
+use serde_test::{
+    assert_de_tokens, assert_de_tokens_error, assert_tokens, Compact, Configure, Readable, Token,
+};
 use time::macros::{date, datetime, offset, time};
 use time::{Date, Duration, Month, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset, Weekday};
 
@@ -770,36 +772,42 @@ fn utc_offset_partial() {
         &[Token::Tuple { len: 3 }, Token::TupleEnd],
         "expected offset hours",
     );
-    assert_de_tokens_error::<Compact<UtcOffset>>(
-        &[Token::Tuple { len: 3 }, Token::I8(23), Token::TupleEnd],
-        "expected offset minutes",
-    );
-    assert_de_tokens_error::<Compact<UtcOffset>>(
-        &[
-            Token::Tuple { len: 3 },
-            Token::I8(23),
-            Token::I8(58),
-            Token::TupleEnd,
-        ],
-        "expected offset seconds",
-    );
-
     assert_de_tokens_error::<Readable<UtcOffset>>(
         &[Token::Tuple { len: 3 }, Token::TupleEnd],
         "expected offset hours",
     );
-    assert_de_tokens_error::<Readable<UtcOffset>>(
+
+    let value = UtcOffset::from_hms(23, 0, 0).unwrap();
+    assert_de_tokens::<Compact<UtcOffset>>(
+        &value.compact(),
         &[Token::Tuple { len: 3 }, Token::I8(23), Token::TupleEnd],
-        "expected offset minutes",
     );
-    assert_de_tokens_error::<Readable<UtcOffset>>(
+    let value = UtcOffset::from_hms(23, 0, 0).unwrap();
+    assert_de_tokens::<Readable<UtcOffset>>(
+        &value.readable(),
+        &[Token::Tuple { len: 3 }, Token::I8(23), Token::TupleEnd],
+    );
+
+    let value = UtcOffset::from_hms(23, 58, 0).unwrap();
+    assert_de_tokens::<Compact<UtcOffset>>(
+        &value.compact(),
         &[
             Token::Tuple { len: 3 },
             Token::I8(23),
             Token::I8(58),
             Token::TupleEnd,
         ],
-        "expected offset seconds",
+    );
+
+    let value = UtcOffset::from_hms(23, 58, 0).unwrap();
+    assert_de_tokens::<Readable<UtcOffset>>(
+        &value.readable(),
+        &[
+            Token::Tuple { len: 3 },
+            Token::I8(23),
+            Token::I8(58),
+            Token::TupleEnd,
+        ],
     );
 }
 

--- a/time-macros/src/lib.rs
+++ b/time-macros/src/lib.rs
@@ -32,7 +32,7 @@
     clippy::redundant_pub_crate, // suggests bad style
     clippy::option_if_let_else, // suggests terrible code
 )]
-
+#[allow(unused_macros)]
 macro_rules! bug {
     () => { compile_error!("provide an error message to help fix a possible bug") };
     ($descr:literal $($rest:tt)?) => {

--- a/time/src/serde/mod.rs
+++ b/time/src/serde/mod.rs
@@ -100,7 +100,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 ///     maybe_dt: Option<OffsetDateTime>,
 /// }
 /// ```
-/// 
+///
 /// Define the format separately to be used in multiple places:
 /// ```rust,no_run
 /// # use time::OffsetDateTime;
@@ -151,7 +151,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 ///     let str_ts = OffsetDateTime::now_utc().format(DATE_TIME_FORMAT).unwrap();
 /// }
 /// ```
-/// 
+///
 /// Customize the configuration of ISO 8601 formatting/parsing:
 /// ```rust,no_run
 /// # use time::OffsetDateTime;
@@ -199,7 +199,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// }
 /// # fn main() {}
 /// ```
-/// 
+///
 /// [`format_description::parse()`]: crate::format_description::parse()
 #[cfg(all(feature = "macros", any(feature = "formatting", feature = "parsing"),))]
 pub use time_macros::serde_format_description as format_description;
@@ -404,10 +404,14 @@ impl<'a> Deserialize<'a> for Time {
 #[cfg(feature = "parsing")]
 const UTC_OFFSET_FORMAT: &[FormatItem<'_>] = &[
     FormatItem::Component(Component::OffsetHour(modifier::OffsetHour::default())),
-    FormatItem::Literal(b":"),
-    FormatItem::Component(Component::OffsetMinute(modifier::OffsetMinute::default())),
-    FormatItem::Literal(b":"),
-    FormatItem::Component(Component::OffsetSecond(modifier::OffsetSecond::default())),
+    FormatItem::Optional(&FormatItem::Compound(&[
+        FormatItem::Literal(b":"),
+        FormatItem::Component(Component::OffsetMinute(modifier::OffsetMinute::default())),
+        FormatItem::Optional(&FormatItem::Compound(&[
+            FormatItem::Literal(b":"),
+            FormatItem::Component(Component::OffsetSecond(modifier::OffsetSecond::default())),
+        ])),
+    ])),
 ];
 
 impl Serialize for UtcOffset {

--- a/time/src/serde/mod.rs
+++ b/time/src/serde/mod.rs
@@ -100,7 +100,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 ///     maybe_dt: Option<OffsetDateTime>,
 /// }
 /// ```
-///
+/// 
 /// Define the format separately to be used in multiple places:
 /// ```rust,no_run
 /// # use time::OffsetDateTime;
@@ -151,7 +151,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 ///     let str_ts = OffsetDateTime::now_utc().format(DATE_TIME_FORMAT).unwrap();
 /// }
 /// ```
-///
+/// 
 /// Customize the configuration of ISO 8601 formatting/parsing:
 /// ```rust,no_run
 /// # use time::OffsetDateTime;
@@ -199,7 +199,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// }
 /// # fn main() {}
 /// ```
-///
+/// 
 /// [`format_description::parse()`]: crate::format_description::parse()
 #[cfg(all(feature = "macros", any(feature = "formatting", feature = "parsing"),))]
 pub use time_macros::serde_format_description as format_description;

--- a/time/src/serde/visitor.rs
+++ b/time/src/serde/visitor.rs
@@ -167,8 +167,8 @@ impl<'a> de::Visitor<'a> for Visitor<UtcOffset> {
 
     fn visit_seq<A: de::SeqAccess<'a>>(self, mut seq: A) -> Result<UtcOffset, A::Error> {
         let hours = item!(seq, "offset hours")?;
-        let minutes = item!(seq, "offset minutes")?;
-        let seconds = item!(seq, "offset seconds")?;
+        let minutes = item!(seq, "offset minutes").unwrap_or(0);
+        let seconds = item!(seq, "offset seconds").unwrap_or(0);
 
         UtcOffset::from_hms(hours, minutes, seconds).map_err(ComponentRange::into_de_error)
     }

--- a/time/src/serde/visitor.rs
+++ b/time/src/serde/visitor.rs
@@ -167,8 +167,17 @@ impl<'a> de::Visitor<'a> for Visitor<UtcOffset> {
 
     fn visit_seq<A: de::SeqAccess<'a>>(self, mut seq: A) -> Result<UtcOffset, A::Error> {
         let hours = item!(seq, "offset hours")?;
-        let minutes = item!(seq, "offset minutes").unwrap_or(0);
-        let seconds = item!(seq, "offset seconds").unwrap_or(0);
+        let mut minutes = 0;
+        let mut seconds = 0;
+
+        if let Ok(Some(min)) = seq.next_element() {
+            minutes = min;
+            if let Ok(Some(sec)) = seq.next_element() {
+                seconds = sec;
+            }
+        };
+        // let minutes = item!(seq, "offset minutes").unwrap_or(0);
+        // let seconds = item!(seq, "offset seconds").unwrap_or(0);
 
         UtcOffset::from_hms(hours, minutes, seconds).map_err(ComponentRange::into_de_error)
     }

--- a/time/src/serde/visitor.rs
+++ b/time/src/serde/visitor.rs
@@ -176,8 +176,6 @@ impl<'a> de::Visitor<'a> for Visitor<UtcOffset> {
                 seconds = sec;
             }
         };
-        // let minutes = item!(seq, "offset minutes").unwrap_or(0);
-        // let seconds = item!(seq, "offset seconds").unwrap_or(0);
 
         UtcOffset::from_hms(hours, minutes, seconds).map_err(ComponentRange::into_de_error)
     }


### PR DESCRIPTION
* Update `UTC_OFFSET_FORMAT` to accept more formats
* Added `visit_i64` and `visit_u64` for `Visitor<UtcOffset>` to accept numeric hours
* Unsafe expose `UtcOffset::__from_hms_unchecked`  as `UtcOffset::from_hms_unchecked`