### PR TITLE
Switch UNIX implementation of local_offset_at to the tz crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ itoa = "1.0.1"
 js-sys = "0.3.58"
 libc = "0.2.98"
 num_threads = "0.1.2"
+once_cell = { version = "1.18.0", default-features = false }
 quickcheck = { version = "1.0.3", default-features = false }
 quickcheck_macros = "1.0.0"
 rand = { version = "0.8.4", default-features = false }
@@ -23,6 +24,7 @@ serde = { version = "1.0.126", default-features = false }
 serde_json = "1.0.68"
 serde_test = "1.0.126"
 trybuild = "1.0.68"
+tz-rs = { version = "0.6.14", default-features = false }
 
 [profile.dev]
 debug = 0

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -101,12 +101,6 @@ macro_rules! require_all_features {
 }
 
 require_all_features! {
-    use std::sync::Mutex;
-
-    /// A lock to ensure that certain tests don't run in parallel, which could lead to a test
-    /// unexpectedly failing.
-    static SOUNDNESS_LOCK: Mutex<()> = Mutex::new(());
-
     /// Construct a non-exhaustive modifier.
     macro_rules! modifier {
         ($name:ident {

--- a/tests/offset_date_time.rs
+++ b/tests/offset_date_time.rs
@@ -14,16 +14,7 @@ fn now_utc() {
 #[cfg_attr(miri, ignore)]
 #[test]
 fn now_local() {
-    use time::util::local_offset::*;
-
-    let _guard = crate::SOUNDNESS_LOCK.lock().unwrap();
-
-    // Safety: Technically not sound. However, this is a test, and it's highly improbable that we
-    // will run into issues with setting an environment variable a few times.
-    unsafe { set_soundness(Soundness::Unsound) };
     assert!(OffsetDateTime::now_local().is_ok());
-    // Safety: We're setting it back to sound.
-    unsafe { set_soundness(Soundness::Sound) };
 }
 
 #[test]

--- a/tests/utc_offset.rs
+++ b/tests/utc_offset.rs
@@ -147,50 +147,11 @@ fn neg() {
 #[cfg_attr(miri, ignore)]
 #[test]
 fn local_offset_at() {
-    use time::util::local_offset::*;
-
-    let _guard = crate::SOUNDNESS_LOCK.lock().unwrap();
-
-    // Safety: Technically not sound. However, this is a test, and it's highly improbable that we
-    // will run into issues with setting an environment variable a few times.
-    unsafe { set_soundness(Soundness::Unsound) };
     assert!(UtcOffset::local_offset_at(OffsetDateTime::UNIX_EPOCH).is_ok());
-    // Safety: We're setting it back to sound.
-    unsafe { set_soundness(Soundness::Sound) };
 }
 
 #[cfg_attr(miri, ignore)]
 #[test]
 fn current_local_offset() {
-    use time::util::local_offset::*;
-
-    let _guard = crate::SOUNDNESS_LOCK.lock().unwrap();
-
-    // Safety: Technically not sound. However, this is a test, and it's highly improbable that we
-    // will run into issues with setting an environment variable a few times.
-    unsafe { set_soundness(Soundness::Unsound) };
     assert!(UtcOffset::current_local_offset().is_ok());
-    // Safety: We're setting it back to sound.
-    unsafe { set_soundness(Soundness::Sound) };
-}
-
-// Note: This behavior is not guaranteed and will hopefully be changed in the future.
-#[test]
-#[cfg_attr(
-    any(
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "illumos",
-        not(target_family = "unix")
-    ),
-    ignore
-)]
-fn local_offset_error_when_multithreaded() {
-    let _guard = crate::SOUNDNESS_LOCK.lock().unwrap();
-
-    std::thread::spawn(|| {
-        assert!(UtcOffset::current_local_offset().is_err());
-    })
-    .join()
-    .expect("failed to join thread");
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -81,8 +81,6 @@ fn weeks_in_year() {
 fn local_offset_soundness() {
     use time::util::local_offset::*;
 
-    let _guard = crate::SOUNDNESS_LOCK.lock().unwrap();
-
     assert_eq!(get_soundness(), Soundness::Sound);
     // Safety: Technically not sound. However, this is a test, and it's highly improbable that we
     // will run into issues with setting an environment variable a few times.

--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -26,7 +26,7 @@ default = ["std"]
 alloc = ["serde?/alloc"]
 formatting = ["dep:itoa", "std", "time-macros?/formatting"]
 large-dates = ["time-macros?/large-dates"]
-local-offset = ["std", "dep:libc", "dep:num_threads"]
+local-offset = ["std", "dep:libc", "dep:num_threads", "dep:once_cell", "dep:tz-rs", "tz-rs?/std", "once_cell?/std"]
 macros = ["dep:time-macros"]
 parsing = ["time-macros?/parsing"]
 quickcheck = ["dep:quickcheck", "alloc"]
@@ -51,6 +51,8 @@ time-macros = { workspace = true, optional = true }
 [target.'cfg(target_family = "unix")'.dependencies]
 libc = { workspace = true, optional = true }
 num_threads = { workspace = true, optional = true }
+once_cell = { workspace = true, optional = true }
+tz-rs = { workspace = true, optional = true }
 
 [target.'cfg(all(target_family = "wasm", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 js-sys = { workspace = true, optional = true }

--- a/time/src/sys/local_offset_at/unix.rs
+++ b/time/src/sys/local_offset_at/unix.rs
@@ -1,157 +1,42 @@
 //! Get the system's UTC offset on Unix.
 
-use core::mem::MaybeUninit;
+use std::io;
+use std::path::Path;
 
-use crate::util::local_offset::{self, Soundness};
+use once_cell::sync::OnceCell;
+use tz::{TimeZone, TzError};
+
 use crate::{OffsetDateTime, UtcOffset};
 
-/// Whether the operating system has a thread-safe environment. This allows bypassing the check for
-/// if the process is multi-threaded.
-// This is the same value as `cfg!(target_os = "x")`.
-// Use byte-strings to work around current limitations of const eval.
-const OS_HAS_THREAD_SAFE_ENVIRONMENT: bool = match std::env::consts::OS.as_bytes() {
-    // https://github.com/illumos/illumos-gate/blob/0fb96ba1f1ce26ff8b286f8f928769a6afcb00a6/usr/src/lib/libc/port/gen/getenv.c
-    b"illumos"
-    // https://github.com/NetBSD/src/blob/f45028636a44111bc4af44d460924958a4460844/lib/libc/stdlib/getenv.c
-    // https://github.com/NetBSD/src/blob/f45028636a44111bc4af44d460924958a4460844/lib/libc/stdlib/setenv.c
-    | b"netbsd"
-    // https://github.com/apple-oss-distributions/Libc/blob/d526593760f0f79dfaeb8b96c3c8a42c791156ff/stdlib/FreeBSD/getenv.c
-    // https://github.com/apple-oss-distributions/Libc/blob/d526593760f0f79dfaeb8b96c3c8a42c791156ff/stdlib/FreeBSD/setenv.c
-    | b"macos"
-    => true,
-    _ => false,
-};
+static TZ: OnceCell<TimeZone> = OnceCell::new();
 
-/// Convert the given Unix timestamp to a `libc::tm`. Returns `None` on any error.
-///
-/// # Safety
-///
-/// This method must only be called when the process is single-threaded.
-///
-/// This method will remain `unsafe` until `std::env::set_var` is deprecated or has its behavior
-/// altered. This method is, on its own, safe. It is the presence of a safe, unsound way to set
-/// environment variables that makes it unsafe.
-unsafe fn timestamp_to_tm(timestamp: i64) -> Option<libc::tm> {
-    extern "C" {
-        #[cfg_attr(target_os = "netbsd", link_name = "__tzset50")]
-        fn tzset();
+/// Try to obtain a [`tz::TimeZone`] instance based on the current environment or system
+/// configuration.
+fn try_get_timezone() -> Result<TimeZone, TzError> {
+    if let Ok(var) = std::env::var("TZ") {
+        return TimeZone::from_posix_tz(&var);
     }
 
-    // The exact type of `timestamp` beforehand can vary, so this conversion is necessary.
-    #[allow(clippy::useless_conversion)]
-    let timestamp = timestamp.try_into().ok()?;
-
-    let mut tm = MaybeUninit::uninit();
-
-    // Update timezone information from system. `localtime_r` does not do this for us.
+    // The GNU libc by default uses either `/etc/localtime` or `/usr/local/etc/localtime` depending
+    // on how it was configured, though there doesn't seem to be any way to detect which one it
+    // would use.
     //
-    // Safety: tzset is thread-safe.
-    unsafe { tzset() };
-
-    // Safety: We are calling a system API, which mutates the `tm` variable. If a null
-    // pointer is returned, an error occurred.
-    let tm_ptr = unsafe { libc::localtime_r(&timestamp, tm.as_mut_ptr()) };
-
-    if tm_ptr.is_null() {
-        None
-    } else {
-        // Safety: The value was initialized, as we no longer have a null pointer.
-        Some(unsafe { tm.assume_init() })
-    }
-}
-
-/// Convert a `libc::tm` to a `UtcOffset`. Returns `None` on any error.
-// This is available to any target known to have the `tm_gmtoff` extension.
-#[cfg(any(
-    target_os = "redox",
-    target_os = "linux",
-    target_os = "l4re",
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "watchos",
-    target_os = "freebsd",
-    target_os = "dragonfly",
-    target_os = "openbsd",
-    target_os = "netbsd",
-    target_os = "haiku",
-))]
-fn tm_to_offset(_unix_timestamp: i64, tm: libc::tm) -> Option<UtcOffset> {
-    let seconds = tm.tm_gmtoff.try_into().ok()?;
-    UtcOffset::from_whole_seconds(seconds).ok()
-}
-
-/// Convert a `libc::tm` to a `UtcOffset`. Returns `None` on any error.
-///
-/// This method can return an incorrect value, as it only approximates the `tm_gmtoff` field. The
-/// reason for this is that daylight saving time does not start on the same date every year, nor are
-/// the rules for daylight saving time the same for every year. This implementation assumes 1970 is
-/// equivalent to every other year, which is not always the case.
-#[cfg(not(any(
-    target_os = "redox",
-    target_os = "linux",
-    target_os = "l4re",
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "watchos",
-    target_os = "freebsd",
-    target_os = "dragonfly",
-    target_os = "openbsd",
-    target_os = "netbsd",
-    target_os = "haiku",
-)))]
-fn tm_to_offset(unix_timestamp: i64, tm: libc::tm) -> Option<UtcOffset> {
-    use crate::Date;
-
-    let mut tm = tm;
-    if tm.tm_sec == 60 {
-        // Leap seconds are not currently supported.
-        tm.tm_sec = 59;
+    // https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html#index-localtime-1
+    for path in ["/etc/localtime", "/usr/local/etc/localtime"] {
+        if Path::new(path).exists() {
+            return TimeZone::from_posix_tz(&format!(":{path}"));
+        }
     }
 
-    let local_timestamp =
-        Date::from_ordinal_date(1900 + tm.tm_year, u16::try_from(tm.tm_yday).ok()? + 1)
-            .ok()?
-            .with_hms(
-                tm.tm_hour.try_into().ok()?,
-                tm.tm_min.try_into().ok()?,
-                tm.tm_sec.try_into().ok()?,
-            )
-            .ok()?
-            .assume_utc()
-            .unix_timestamp();
-
-    let diff_secs = (local_timestamp - unix_timestamp).try_into().ok()?;
-
-    UtcOffset::from_whole_seconds(diff_secs).ok()
+    Err(io::Error::from(io::ErrorKind::NotFound).into())
 }
 
 /// Obtain the system's UTC offset.
 pub(super) fn local_offset_at(datetime: OffsetDateTime) -> Option<UtcOffset> {
-    // Continue to obtaining the UTC offset if and only if the call is sound or the user has
-    // explicitly opted out of soundness.
-    //
-    // Soundness can be guaranteed either by knowledge of the operating system or knowledge that the
-    // process is single-threaded. If the process is single-threaded, then the environment cannot
-    // be mutated by a different thread in the process while execution of this function is taking
-    // place, which can cause a segmentation fault by dereferencing a dangling pointer.
-    //
-    // If the `num_threads` crate is incapable of determining the number of running threads, then
-    // we conservatively return `None` to avoid a soundness bug.
+    let tz = TZ.get_or_try_init(try_get_timezone).ok()?;
 
-    if OS_HAS_THREAD_SAFE_ENVIRONMENT
-        || local_offset::get_soundness() == Soundness::Unsound
-        || num_threads::is_single_threaded() == Some(true)
-    {
-        let unix_timestamp = datetime.unix_timestamp();
-        // Safety: We have just confirmed that the process is single-threaded or the user has
-        // explicitly opted out of soundness.
-        let tm = unsafe { timestamp_to_tm(unix_timestamp) }?;
-        tm_to_offset(unix_timestamp, tm)
-    } else {
-        None
+    match tz.find_local_time_type(datetime.unix_timestamp()) {
+        Ok(ltt) => UtcOffset::from_whole_seconds(ltt.ut_offset()).ok(),
+        Err(_) => None,
     }
 }


### PR DESCRIPTION
The tz crate is a pure Rust reimplementation of the libc time related functions which lets us soundly get the local timezone even on UNIX systems where using the libc functions directly would be unsound.