### PR TITLE
Calculate next/prev weekday occurrences

### DIFF
--- a/tests/date.rs
+++ b/tests/date.rs
@@ -982,3 +982,45 @@ fn replace_day() {
     assert!(date!(2022 - 02 - 18).replace_day(0).is_err()); // 0 isn't a valid day
     assert!(date!(2022 - 02 - 18).replace_day(30).is_err()); // 30 isn't a valid day in February
 }
+
+#[test]
+fn next_occurrence_test() {
+    assert_eq!(date!(2023 - 06 - 25).next_occurrence(Weekday::Monday), date!(2023 - 06 - 26));
+    assert_eq!(date!(2023 - 06 - 26).next_occurrence(Weekday::Monday), date!(2023 - 07 - 03));
+    assert_eq!(date!(2023 - 06 - 27).next_occurrence(Weekday::Monday), date!(2023 - 07 - 03));
+    assert_eq!(date!(2023 - 06 - 28).next_occurrence(Weekday::Monday), date!(2023 - 07 - 03));
+    assert_eq!(date!(2023 - 06 - 29).next_occurrence(Weekday::Monday), date!(2023 - 07 - 03));
+    assert_eq!(date!(2023 - 06 - 30).next_occurrence(Weekday::Monday), date!(2023 - 07 - 03));
+    assert_eq!(date!(2023 - 07 - 01).next_occurrence(Weekday::Monday), date!(2023 - 07 - 03));
+    assert_eq!(date!(2023 - 07 - 02).next_occurrence(Weekday::Monday), date!(2023 - 07 - 03));
+    assert_eq!(date!(2023 - 07 - 03).next_occurrence(Weekday::Monday), date!(2023 - 07 - 10));
+}
+
+#[test]
+fn prev_occurrence_test() {
+    assert_eq!(date!(2023 - 07 - 07).prev_occurrence(Weekday::Thursday), date!(2023 - 07 - 06));
+    assert_eq!(date!(2023 - 07 - 06).prev_occurrence(Weekday::Thursday), date!(2023 - 06 - 29));
+    assert_eq!(date!(2023 - 07 - 05).prev_occurrence(Weekday::Thursday), date!(2023 - 06 - 29));
+    assert_eq!(date!(2023 - 07 - 04).prev_occurrence(Weekday::Thursday), date!(2023 - 06 - 29));
+    assert_eq!(date!(2023 - 07 - 03).prev_occurrence(Weekday::Thursday), date!(2023 - 06 - 29));
+    assert_eq!(date!(2023 - 07 - 02).prev_occurrence(Weekday::Thursday), date!(2023 - 06 - 29));
+    assert_eq!(date!(2023 - 07 - 01).prev_occurrence(Weekday::Thursday), date!(2023 - 06 - 29));
+    assert_eq!(date!(2023 - 06 - 30).prev_occurrence(Weekday::Thursday), date!(2023 - 06 - 29));
+    assert_eq!(date!(2023 - 06 - 29).prev_occurrence(Weekday::Thursday), date!(2023 - 06 - 22));
+}
+
+#[test]
+fn nth_next_occurrence_test() {
+    assert_eq!(date!(2023 - 06 - 25).nth_next_occurrence(Weekday::Monday, 5), date!(2023 - 07 - 24));
+    assert_eq!(date!(2023 - 06 - 26).nth_next_occurrence(Weekday::Monday, 5), date!(2023 - 07 - 31));
+
+    assert!(date!(2023 - 06 - 25).checked_nth_next_occurrence(Weekday::Monday, 0).is_none())
+}
+
+#[test]
+fn nth_prev_occurrence_test() {
+    assert_eq!(date!(2023 - 06 - 27).nth_prev_occurrence(Weekday::Monday, 3), date!(2023 - 06 - 12));
+    assert_eq!(date!(2023 - 06 - 26).nth_prev_occurrence(Weekday::Monday, 3), date!(2023 - 06 - 05));
+
+    assert!(date!(2023 - 06 - 27).checked_nth_prev_occurrence(Weekday::Monday, 0).is_none())
+}

--- a/tests/date.rs
+++ b/tests/date.rs
@@ -1013,14 +1013,46 @@ fn prev_occurrence_test() {
 fn nth_next_occurrence_test() {
     assert_eq!(date!(2023 - 06 - 25).nth_next_occurrence(Weekday::Monday, 5), date!(2023 - 07 - 24));
     assert_eq!(date!(2023 - 06 - 26).nth_next_occurrence(Weekday::Monday, 5), date!(2023 - 07 - 31));
-
-    assert!(date!(2023 - 06 - 25).checked_nth_next_occurrence(Weekday::Monday, 0).is_none())
 }
 
 #[test]
 fn nth_prev_occurrence_test() {
     assert_eq!(date!(2023 - 06 - 27).nth_prev_occurrence(Weekday::Monday, 3), date!(2023 - 06 - 12));
     assert_eq!(date!(2023 - 06 - 26).nth_prev_occurrence(Weekday::Monday, 3), date!(2023 - 06 - 05));
+}
 
-    assert!(date!(2023 - 06 - 27).checked_nth_prev_occurrence(Weekday::Monday, 0).is_none())
+#[test]
+#[should_panic]
+fn next_occurrence_overflow_test() {
+    date!(+999999 - 12 - 25).next_occurrence(Weekday::Saturday);
+}
+
+#[test]
+#[should_panic]
+fn prev_occurrence_overflow_test() {
+    date!(-999999 - 01 - 07).prev_occurrence(Weekday::Sunday);
+}
+
+#[test]
+#[should_panic]
+fn nth_next_occurrence_overflow_test() {
+    date!(+999999 - 12 - 25).nth_next_occurrence(Weekday::Saturday, 1);
+}
+
+#[test]
+#[should_panic]
+fn nth_next_occurence_zeroth_occurence_test() {
+    date!(2023 - 06 - 25).nth_next_occurrence(Weekday::Monday, 0);
+}
+
+#[test]
+#[should_panic]
+fn nth_prev_occurence_zeroth_occurence_test() {
+    date!(2023 - 06 - 27).nth_prev_occurrence(Weekday::Monday, 0);
+}
+
+#[test]
+#[should_panic]
+fn nth_prev_occurrence_overflow_test() {
+    date!(-999999 - 01 - 07).nth_prev_occurrence(Weekday::Sunday, 1);
 }

--- a/time/src/date.rs
+++ b/time/src/date.rs
@@ -529,6 +529,82 @@ impl Date {
         }
     }
 
+    /// Calculates the first occurrence of a weekday that is strictly later than a given `Date`.
+    /// 
+    /// # Panics
+    /// Panics if an overflow occurred.
+    ///
+    /// # Examples
+    /// ```
+    /// # use time::Weekday;
+    /// # use time_macros::date;
+    /// assert_eq!(date!(2023 - 06 - 28).next_occurrence(Weekday::Monday), date!(2023 - 07 - 03));
+    /// assert_eq!(date!(2023 - 06 - 19).next_occurrence(Weekday::Monday), date!(2023 - 06 - 26));
+    /// ```
+    pub const fn next_occurrence(self, weekday: Weekday) -> Self {
+        expect_opt!(
+            self.checked_next_occurrence(weekday),
+            "overflow calculating the next occurrence of a weekday"
+        )
+    }
+
+    /// Calculates the first occurrence of a weekday that is strictly earlier than a given `Date`.
+    /// 
+    /// # Panics
+    /// Panics if an overflow occurred.
+    ///
+    /// # Examples
+    /// ```
+    /// # use time::Weekday;
+    /// # use time_macros::date;
+    /// assert_eq!(date!(2023 - 06 - 28).prev_occurrence(Weekday::Monday), date!(2023 - 06 - 26));
+    /// assert_eq!(date!(2023 - 06 - 19).prev_occurrence(Weekday::Monday), date!(2023 - 06 - 12));
+    /// ```
+    pub const fn prev_occurrence(self, weekday: Weekday) -> Self {
+        expect_opt!(
+            self.checked_prev_occurrence(weekday),
+            "overflow calculating the previous occurrence of a weekday"
+        )
+    }
+
+    /// Calculates the `n`th occurrence of a weekday that is strictly later than a given `Date`.
+    /// 
+    /// # Panics
+    /// Panics if an overflow occurred or if `n == 0`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use time::Weekday;
+    /// # use time_macros::date;
+    /// assert_eq!(date!(2023 - 06 - 25).nth_next_occurrence(Weekday::Monday, 5), date!(2023 - 07 - 24));
+    /// assert_eq!(date!(2023 - 06 - 26).nth_next_occurrence(Weekday::Monday, 5), date!(2023 - 07 - 31));
+    /// ```
+    pub const fn nth_next_occurrence(self, weekday: Weekday, n: u8) -> Self {
+        expect_opt!(
+            self.checked_nth_next_occurrence(weekday, n),
+            "overflow calculating the next occurrence of a weekday"
+        )
+    }
+
+    /// Calculates the `n`th occurrence of a weekday that is strictly earlier than a given `Date`.
+    /// 
+    /// # Panics
+    /// Panics if an overflow occurred or if `n == 0`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use time::Weekday;
+    /// # use time_macros::date;
+    /// assert_eq!(date!(2023 - 06 - 27).nth_prev_occurrence(Weekday::Monday, 3), date!(2023 - 06 - 12));
+    /// assert_eq!(date!(2023 - 06 - 26).nth_prev_occurrence(Weekday::Monday, 3), date!(2023 - 06 - 05));
+    /// ```
+    pub const fn nth_prev_occurrence(self, weekday: Weekday, n: u8) -> Self {
+        expect_opt!(
+            self.checked_nth_prev_occurrence(weekday, n),
+            "overflow calculating the previous occurrence of a weekday"
+        )
+    }
+
     /// Get the Julian day for the date.
     ///
     /// The algorithm to perform this conversion is derived from one provided by Peter Baum; it is
@@ -637,6 +713,110 @@ impl Date {
         let julian_day = const_try_opt!(self.to_julian_day().checked_sub(whole_days as _));
         if let Ok(date) = Self::from_julian_day(julian_day) {
             Some(date)
+        } else {
+            None
+        }
+    }
+
+    /// Calculates the first occurrence of a weekday that is strictly later than a given `Date`.
+    /// Returns `None` if an overflow occurred.
+    ///
+    /// # Examples
+    /// ```
+    /// # use time::Weekday;
+    /// # use time_macros::date;
+    /// assert_eq!(date!(2023 - 06 - 28).checked_next_occurrence(Weekday::Monday), Some(date!(2023 - 07 - 03)));
+    /// assert_eq!(date!(2023 - 06 - 19).checked_next_occurrence(Weekday::Monday), Some(date!(2023 - 06 - 26)));
+    /// ```
+    pub const fn checked_next_occurrence(self, weekday: Weekday) -> Option<Self> {
+        let day_diff = match weekday as i8 - self.weekday() as i8 {
+            1 | -6 => 1,
+            2 | -5 => 2,
+            3 | -4 => 3,
+            4 | -3 => 4,
+            5 | -2 => 5,
+            6 | -1 => 6,
+            val => {
+                debug_assert!(val == 0);
+                7
+            }
+        };
+
+        self.checked_add(Duration::days(day_diff))
+    }
+
+    /// Calculates the first occurrence of a weekday that is strictly earlier than a given `Date`.
+    /// Returns `None` if an overflow occurred.
+    ///
+    /// # Examples
+    /// ```
+    /// # use time::Weekday;
+    /// # use time_macros::date;
+    /// assert_eq!(date!(2023 - 06 - 28).checked_prev_occurrence(Weekday::Monday), Some(date!(2023 - 06 - 26)));
+    /// assert_eq!(date!(2023 - 06 - 19).checked_prev_occurrence(Weekday::Monday), Some(date!(2023 - 06 - 12)));
+    /// ```
+    pub const fn checked_prev_occurrence(self, weekday: Weekday) -> Option<Self> {
+        let day_diff = match weekday as i8 - self.weekday() as i8 {
+            1 | -6 => 6,
+            2 | -5 => 5,
+            3 | -4 => 4,
+            4 | -3 => 3,
+            5 | -2 => 2,
+            6 | -1 => 1,
+            val => {
+                debug_assert!(val == 0);
+                7
+            }
+        };
+
+        self.checked_sub(Duration::days(day_diff))
+    }
+
+    /// Calculates the `n`th occurrence of a weekday that is strictly later than a given `Date`.
+    /// Returns `None` if an overflow occurred or if `n == 0`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use time::Weekday;
+    /// # use time_macros::date;
+    /// assert_eq!(date!(2023 - 06 - 25).checked_nth_next_occurrence(Weekday::Monday, 5), Some(date!(2023 - 07 - 24)));
+    /// assert_eq!(date!(2023 - 06 - 26).checked_nth_next_occurrence(Weekday::Monday, 5), Some(date!(2023 - 07 - 31)));
+    ///
+    /// assert!(date!(2023 - 06 - 25).checked_nth_next_occurrence(Weekday::Monday, 0).is_none())
+    /// ```
+    pub const fn checked_nth_next_occurrence(self, weekday: Weekday, n: u8) -> Option<Self> {
+        if n == 0 {
+            return None;
+        }
+
+        let next_occ = self.checked_next_occurrence(weekday);
+        if let Some(val) = next_occ {
+            val.checked_add(Duration::weeks(n as i64 - 1))
+        } else {
+            None
+        }
+    }
+
+    /// Calculates the `n`th occurrence of a weekday that is strictly earlier than a given `Date`.
+    /// Returns `None` if an overflow occurred or if `n == 0`.
+    ///
+    /// # Examples
+    /// ```
+    /// # use time::Weekday;
+    /// # use time_macros::date;
+    /// assert_eq!(date!(2023 - 06 - 27).checked_nth_prev_occurrence(Weekday::Monday, 3), Some(date!(2023 - 06 - 12)));
+    /// assert_eq!(date!(2023 - 06 - 26).checked_nth_prev_occurrence(Weekday::Monday, 3), Some(date!(2023 - 06 - 05)));
+    ///
+    /// assert!(date!(2023 - 06 - 27).checked_nth_prev_occurrence(Weekday::Monday, 0).is_none())
+    /// ```
+    pub const fn checked_nth_prev_occurrence(self, weekday: Weekday, n: u8) -> Option<Self> {
+        if n == 0 {
+            return None;
+        }
+
+        let next_occ = self.checked_prev_occurrence(weekday);
+        if let Some(val) = next_occ {
+            val.checked_sub(Duration::weeks(n as i64 - 1))
         } else {
             None
         }

--- a/time/src/date.rs
+++ b/time/src/date.rs
@@ -530,7 +530,7 @@ impl Date {
     }
 
     /// Calculates the first occurrence of a weekday that is strictly later than a given `Date`.
-    /// 
+    ///
     /// # Panics
     /// Panics if an overflow occurred.
     ///
@@ -538,8 +538,14 @@ impl Date {
     /// ```
     /// # use time::Weekday;
     /// # use time_macros::date;
-    /// assert_eq!(date!(2023 - 06 - 28).next_occurrence(Weekday::Monday), date!(2023 - 07 - 03));
-    /// assert_eq!(date!(2023 - 06 - 19).next_occurrence(Weekday::Monday), date!(2023 - 06 - 26));
+    /// assert_eq!(
+    ///     date!(2023 - 06 - 28).next_occurrence(Weekday::Monday),
+    ///     date!(2023 - 07 - 03)
+    /// );
+    /// assert_eq!(
+    ///     date!(2023 - 06 - 19).next_occurrence(Weekday::Monday),
+    ///     date!(2023 - 06 - 26)
+    /// );
     /// ```
     pub const fn next_occurrence(self, weekday: Weekday) -> Self {
         expect_opt!(
@@ -549,7 +555,7 @@ impl Date {
     }
 
     /// Calculates the first occurrence of a weekday that is strictly earlier than a given `Date`.
-    /// 
+    ///
     /// # Panics
     /// Panics if an overflow occurred.
     ///
@@ -557,8 +563,14 @@ impl Date {
     /// ```
     /// # use time::Weekday;
     /// # use time_macros::date;
-    /// assert_eq!(date!(2023 - 06 - 28).prev_occurrence(Weekday::Monday), date!(2023 - 06 - 26));
-    /// assert_eq!(date!(2023 - 06 - 19).prev_occurrence(Weekday::Monday), date!(2023 - 06 - 12));
+    /// assert_eq!(
+    ///     date!(2023 - 06 - 28).prev_occurrence(Weekday::Monday),
+    ///     date!(2023 - 06 - 26)
+    /// );
+    /// assert_eq!(
+    ///     date!(2023 - 06 - 19).prev_occurrence(Weekday::Monday),
+    ///     date!(2023 - 06 - 12)
+    /// );
     /// ```
     pub const fn prev_occurrence(self, weekday: Weekday) -> Self {
         expect_opt!(
@@ -568,7 +580,7 @@ impl Date {
     }
 
     /// Calculates the `n`th occurrence of a weekday that is strictly later than a given `Date`.
-    /// 
+    ///
     /// # Panics
     /// Panics if an overflow occurred or if `n == 0`.
     ///
@@ -576,8 +588,14 @@ impl Date {
     /// ```
     /// # use time::Weekday;
     /// # use time_macros::date;
-    /// assert_eq!(date!(2023 - 06 - 25).nth_next_occurrence(Weekday::Monday, 5), date!(2023 - 07 - 24));
-    /// assert_eq!(date!(2023 - 06 - 26).nth_next_occurrence(Weekday::Monday, 5), date!(2023 - 07 - 31));
+    /// assert_eq!(
+    ///     date!(2023 - 06 - 25).nth_next_occurrence(Weekday::Monday, 5),
+    ///     date!(2023 - 07 - 24)
+    /// );
+    /// assert_eq!(
+    ///     date!(2023 - 06 - 26).nth_next_occurrence(Weekday::Monday, 5),
+    ///     date!(2023 - 07 - 31)
+    /// );
     /// ```
     pub const fn nth_next_occurrence(self, weekday: Weekday, n: u8) -> Self {
         expect_opt!(
@@ -587,7 +605,7 @@ impl Date {
     }
 
     /// Calculates the `n`th occurrence of a weekday that is strictly earlier than a given `Date`.
-    /// 
+    ///
     /// # Panics
     /// Panics if an overflow occurred or if `n == 0`.
     ///
@@ -595,8 +613,14 @@ impl Date {
     /// ```
     /// # use time::Weekday;
     /// # use time_macros::date;
-    /// assert_eq!(date!(2023 - 06 - 27).nth_prev_occurrence(Weekday::Monday, 3), date!(2023 - 06 - 12));
-    /// assert_eq!(date!(2023 - 06 - 26).nth_prev_occurrence(Weekday::Monday, 3), date!(2023 - 06 - 05));
+    /// assert_eq!(
+    ///     date!(2023 - 06 - 27).nth_prev_occurrence(Weekday::Monday, 3),
+    ///     date!(2023 - 06 - 12)
+    /// );
+    /// assert_eq!(
+    ///     date!(2023 - 06 - 26).nth_prev_occurrence(Weekday::Monday, 3),
+    ///     date!(2023 - 06 - 05)
+    /// );
     /// ```
     pub const fn nth_prev_occurrence(self, weekday: Weekday, n: u8) -> Self {
         expect_opt!(
@@ -720,15 +744,7 @@ impl Date {
 
     /// Calculates the first occurrence of a weekday that is strictly later than a given `Date`.
     /// Returns `None` if an overflow occurred.
-    ///
-    /// # Examples
-    /// ```
-    /// # use time::Weekday;
-    /// # use time_macros::date;
-    /// assert_eq!(date!(2023 - 06 - 28).checked_next_occurrence(Weekday::Monday), Some(date!(2023 - 07 - 03)));
-    /// assert_eq!(date!(2023 - 06 - 19).checked_next_occurrence(Weekday::Monday), Some(date!(2023 - 06 - 26)));
-    /// ```
-    pub const fn checked_next_occurrence(self, weekday: Weekday) -> Option<Self> {
+    pub(crate) const fn checked_next_occurrence(self, weekday: Weekday) -> Option<Self> {
         let day_diff = match weekday as i8 - self.weekday() as i8 {
             1 | -6 => 1,
             2 | -5 => 2,
@@ -747,15 +763,7 @@ impl Date {
 
     /// Calculates the first occurrence of a weekday that is strictly earlier than a given `Date`.
     /// Returns `None` if an overflow occurred.
-    ///
-    /// # Examples
-    /// ```
-    /// # use time::Weekday;
-    /// # use time_macros::date;
-    /// assert_eq!(date!(2023 - 06 - 28).checked_prev_occurrence(Weekday::Monday), Some(date!(2023 - 06 - 26)));
-    /// assert_eq!(date!(2023 - 06 - 19).checked_prev_occurrence(Weekday::Monday), Some(date!(2023 - 06 - 12)));
-    /// ```
-    pub const fn checked_prev_occurrence(self, weekday: Weekday) -> Option<Self> {
+    pub(crate) const fn checked_prev_occurrence(self, weekday: Weekday) -> Option<Self> {
         let day_diff = match weekday as i8 - self.weekday() as i8 {
             1 | -6 => 6,
             2 | -5 => 5,
@@ -774,17 +782,7 @@ impl Date {
 
     /// Calculates the `n`th occurrence of a weekday that is strictly later than a given `Date`.
     /// Returns `None` if an overflow occurred or if `n == 0`.
-    ///
-    /// # Examples
-    /// ```
-    /// # use time::Weekday;
-    /// # use time_macros::date;
-    /// assert_eq!(date!(2023 - 06 - 25).checked_nth_next_occurrence(Weekday::Monday, 5), Some(date!(2023 - 07 - 24)));
-    /// assert_eq!(date!(2023 - 06 - 26).checked_nth_next_occurrence(Weekday::Monday, 5), Some(date!(2023 - 07 - 31)));
-    ///
-    /// assert!(date!(2023 - 06 - 25).checked_nth_next_occurrence(Weekday::Monday, 0).is_none())
-    /// ```
-    pub const fn checked_nth_next_occurrence(self, weekday: Weekday, n: u8) -> Option<Self> {
+    pub(crate) const fn checked_nth_next_occurrence(self, weekday: Weekday, n: u8) -> Option<Self> {
         if n == 0 {
             return None;
         }
@@ -799,17 +797,7 @@ impl Date {
 
     /// Calculates the `n`th occurrence of a weekday that is strictly earlier than a given `Date`.
     /// Returns `None` if an overflow occurred or if `n == 0`.
-    ///
-    /// # Examples
-    /// ```
-    /// # use time::Weekday;
-    /// # use time_macros::date;
-    /// assert_eq!(date!(2023 - 06 - 27).checked_nth_prev_occurrence(Weekday::Monday, 3), Some(date!(2023 - 06 - 12)));
-    /// assert_eq!(date!(2023 - 06 - 26).checked_nth_prev_occurrence(Weekday::Monday, 3), Some(date!(2023 - 06 - 05)));
-    ///
-    /// assert!(date!(2023 - 06 - 27).checked_nth_prev_occurrence(Weekday::Monday, 0).is_none())
-    /// ```
-    pub const fn checked_nth_prev_occurrence(self, weekday: Weekday, n: u8) -> Option<Self> {
+    pub(crate) const fn checked_nth_prev_occurrence(self, weekday: Weekday, n: u8) -> Option<Self> {
         if n == 0 {
             return None;
         }


### PR DESCRIPTION
This PR adds functionality to improve date arithmetic. It includes:
- `next_occurrence` for getting the closest occurrence after a given `Date`,
- `prev_occurrence` for getting the closest occurrence before a given `Date`,
- `nth_next_occurrence` for getting the nth occurrence after a given `Date`,
- `nth_prev_occurrence` for getting the nth occurrence before a given `Date`,
- checked versions of the methods above,
- tests for these methods,
- docs and doctests for these methods.

Addresses #593 without closing.