### PR TITLE
Change PartialEq, PartialOrd, Eq, Ord and Hash on Time for much more efficient versions

### DIFF
--- a/tests/time.rs
+++ b/tests/time.rs
@@ -342,6 +342,22 @@ fn ordering() {
 }
 
 #[test]
+fn ordering_lexico_endianness() {
+    // Endianness of nanoseconds
+    assert!(time!(00:00:00.4) > time!(00:00:00.1));
+    // Endianness of one field wrt the others
+    // Hourt wrt others
+    assert!(time!(01:00:00) > time!(00:01:00.0));
+    assert!(time!(01:00:00) > time!(00:00:01.0));
+    assert!(time!(01:00:00) > time!(00:00:00.1));
+    // Minutes wrt to others
+    assert!(time!(00:01:00) > time!(00:00:01.0));
+    assert!(time!(00:01:00) > time!(00:00:00.1));
+    // Second wrt to others
+    assert!(time!(00:00:01) > time!(00:00:00.1));
+}
+
+#[test]
 fn issue_481() {
     assert_eq!(time!(0:00) - time!(01:00:00.1), (-3600.1).seconds());
     assert_eq!(


### PR DESCRIPTION
This PR is split in three commits:

1. Add a benchmarking function that actually measure execution time of the comparison, as others are drowned in noise and/or optimized away IMO.
2. Adds the implementations themselves. :warning: This adds unsafe code.
3. Adds a more controversial optimization, see the message commit for pros and cons. This one can be removed without changing anything to the benchmarks and assembly below but may prevent code to be as efficient in more complex workloads.

## Benchmark

```
Time: vec_sort          time:   [96.691 µs 96.966 µs 97.262 µs]
                        change: [-54.795% -54.630% -54.470%] (p = 0.00 < 0.00)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) high mild
  1 (1.00%) high severe
```

## Generated assembly

```rust
pub fn gt(x: &Time, y: &Time) -> bool {
    x > y
}
```
**Before:**

```assembly
	movzx eax, byte ptr [rsi + 4]
	cmp byte ptr [rdi + 4], al
	jae .LBB357_2
	xor eax, eax
	ret

.LBB357_2:
	mov al, 1
	jne .LBB357_10
	movzx ecx, byte ptr [rsi + 5]
	cmp byte ptr [rdi + 5], cl
	jae .LBB357_5
	xor eax, eax
	ret

.LBB357_5:
	jne .LBB357_10
	movzx ecx, byte ptr [rsi + 6]
	cmp byte ptr [rdi + 6], cl
	jae .LBB357_8
	xor eax, eax
	ret

.LBB357_8:
	jne .LBB357_10
	mov eax, dword ptr [rdi]
	cmp eax, dword ptr [rsi]
	seta al

.LBB357_10:
	ret
```

**After:**

```assembly
        mov rax, qword ptr [rdi]
        cmp rax, qword ptr [rsi]
        seta al
        ret
```