### PR TITLE
Force `Time` to be aligned on 8 bytes

### DIFF
--- a/tests/meta.rs
+++ b/tests/meta.rs
@@ -37,9 +37,9 @@ fn alignment() {
 
     assert_alignment!(Date, 4);
     assert_alignment!(Duration, 8);
-    assert_alignment!(OffsetDateTime, 4);
-    assert_alignment!(PrimitiveDateTime, 4);
-    assert_alignment!(Time, 4);
+    assert_alignment!(OffsetDateTime, 8);
+    assert_alignment!(PrimitiveDateTime, 8);
+    assert_alignment!(Time, 8);
     assert_alignment!(UtcOffset, 1);
     assert_alignment!(error::ComponentRange, 8);
     assert_alignment!(error::ConversionRange, 1);
@@ -115,7 +115,7 @@ fn size() {
     assert_size!(Date, 4, 8);
     assert_size!(Duration, 16, 16);
     assert_size!(OffsetDateTime, 16, 16);
-    assert_size!(PrimitiveDateTime, 12, 12);
+    assert_size!(PrimitiveDateTime, 16, 16);
     assert_size!(Time, 8, 8);
     assert_size!(UtcOffset, 3, 4);
     assert_size!(error::ComponentRange, 48, 48);

--- a/tests/time.rs
+++ b/tests/time.rs
@@ -342,6 +342,22 @@ fn ordering() {
 }
 
 #[test]
+fn ordering_lexico_endianness() {
+    // Endianness of nanoseconds
+    assert!(time!(00:00:00.4) > time!(00:00:00.1));
+    // Endianness of one field wrt the others
+    // Hourt wrt others
+    assert!(time!(01:00:00) > time!(00:01:00.0));
+    assert!(time!(01:00:00) > time!(00:00:01.0));
+    assert!(time!(01:00:00) > time!(00:00:00.1));
+    // Minutes wrt to others
+    assert!(time!(00:01:00) > time!(00:00:01.0));
+    assert!(time!(00:01:00) > time!(00:00:00.1));
+    // Second wrt to others
+    assert!(time!(00:00:01) > time!(00:00:00.1));
+}
+
+#[test]
 fn issue_481() {
     assert_eq!(time!(0:00) - time!(01:00:00.1), (-3600.1).seconds());
     assert_eq!(

--- a/time/src/time.rs
+++ b/time/src/time.rs
@@ -30,7 +30,9 @@ pub(crate) enum Padding {
 ///
 /// When comparing two `Time`s, they are assumed to be in the same calendar date.
 #[derive(Clone, Copy, Eq)]
-#[repr(C)]
+// The alignment is forced to 8 as an heuristic for performances. This is not
+// required for safety.
+#[repr(C, align(8))]
 pub struct Time {
     // The order of this struct's fields matter!
     // Do not change them.


### PR DESCRIPTION
This is split up and based on #598 

Benchmarks will highly depend on the architecture I guess, I'd love to see them run on one where reading an `u64` aligned on 4 bytes is costly/impossible but I don't have access to such an architecture at the moment.