### PR TITLE
Add `--generate-link-to-definition` option when building on docs.rs

### DIFF
--- a/time-core/Cargo.toml
+++ b/time-core/Cargo.toml
@@ -10,4 +10,7 @@ categories = ["date-and-time"]
 license = "MIT OR Apache-2.0"
 description = "This crate is an implementation detail and should not be relied upon directly."
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]
+
 [dependencies]

--- a/time-macros/Cargo.toml
+++ b/time-macros/Cargo.toml
@@ -22,5 +22,8 @@ serde = []
 [lib]
 proc-macro = true
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]
+
 [dependencies]
 time-core = { workspace = true }

--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -19,7 +19,7 @@ bench = false
 [package.metadata.docs.rs]
 all-features = true
 targets = ["x86_64-unknown-linux-gnu"]
-rustdoc-args = ["--cfg", "__time_03_docs"]
+rustdoc-args = ["--cfg", "__time_03_docs", "--generate-link-to-definition"]
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This option generates links in source code pages, allowing to jump to definition and to jump back to doc. It makes browsing the source code pages much nicer. You can see it in action [here](https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_middle/lib.rs.html#90).