### PR TITLE
Add support for only hours in time format with tests

### DIFF
--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -621,6 +621,7 @@ fn iso_8601_error() {
 fn parse_time() -> time::Result<()> {
     let format_input_output = [
         (fd::parse("[hour repr:12] [period]")?, "01 PM", time!(1 PM)),
+        (fd::parse("[hour]")?, "12", time!(12:00)),
         (
             fd::parse("[hour]:[minute]:[second]")?,
             "13:02:03",
@@ -668,12 +669,6 @@ fn parse_time_err() -> time::Result<()> {
     ));
     assert!(matches!(
         Time::parse("", &fd::parse("")?),
-        Err(error::Parse::TryFromParsed(
-            error::TryFromParsed::InsufficientInformation { .. }
-        ))
-    ));
-    assert!(matches!(
-        Time::parse("12", &fd::parse("[hour]")?),
         Err(error::Parse::TryFromParsed(
             error::TryFromParsed::InsufficientInformation { .. }
         ))
@@ -1010,6 +1005,16 @@ fn parse_offset_err() -> time::Result<()> {
 }
 
 #[test]
+fn parse_primitive_date_time() -> time::Result<()> {
+    assert_eq!(
+        PrimitiveDateTime::parse("2023-07-27 23", &fd::parse("[year]-[month]-[day] [hour]")?),
+        Ok(datetime!(2023-07-27 23:00))
+    );
+
+    Ok(())
+}
+
+#[test]
 fn parse_primitive_date_time_err() -> time::Result<()> {
     assert!(matches!(
         PrimitiveDateTime::parse("", &fd::parse("")?),
@@ -1025,6 +1030,13 @@ fn parse_primitive_date_time_err() -> time::Result<()> {
         Err(error::Parse::ParseFromDescription(
             error::ParseFromDescription::InvalidComponent("hour")
         ))
+    ));
+    assert!(matches!(
+        PrimitiveDateTime::parse(
+            "2023-07-27 23:30", 
+            &fd::parse("[year]-[month]-[day] [hour]")?
+        ),
+        Err(error::Parse::UnexpectedTrailingCharacters { .. })
     ));
 
     Ok(())

--- a/time/src/parsing/parsed.rs
+++ b/time/src/parsing/parsed.rs
@@ -793,7 +793,7 @@ impl TryFrom<Parsed> for Time {
         {
             return Ok(Self::from_hms_nano(hour, 0, 0, 0)?);
         }
-        let minute = parsed.minute().ok_or(InsufficientInformation)?;
+        let minute = parsed.minute().unwrap_or(0);
         let second = parsed.second().unwrap_or(0);
         let subsecond = parsed.subsecond().unwrap_or(0);
         Ok(Self::from_hms_nano(hour, minute, second, subsecond)?)


### PR DESCRIPTION
Per issue #603 add support for just hours in the time format. This allows leaving out the minutes when parsing a time or datetime object. 

If it is necessary to add more tests for specific cases or if the enhancement needs to be implemented through a different method than this simple change, please let me know.

The time macro was not adjusted as I think it does not makes sense to make `time!(12)` convert to 12:00 instead of 00:12. The user can simply write out the desired time.