### PR TITLE
Relax serde back after upstream issue resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog]. This project adheres to [Semantic Ver
 
 ---
 
+## 0.3.27 [2023-08-22]
+
+This sets the `serde` dependency requirement to `>= 1.0.184` where the binaries have been removed.
+
 ## 0.3.26 [2023-08-18]
 
 This release contains only a single change. `serde` is required to be a version prior to 1.0.171.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.dependencies]
 time-core = { path = "time-core", version = "=0.1.1" }
-time-macros = { path = "time-macros", version = "=0.2.12" }
+time-macros = { path = "time-macros", version = "=0.2.13" }
 
 criterion = { version = "0.5.1", default-features = false }
 deranged = { version = "0.3.7", default-features = false }
@@ -16,8 +16,8 @@ num_threads = "0.1.2"
 quickcheck = { version = "1.0.3", default-features = false }
 quickcheck_macros = "1.0.0"
 rand = { version = "0.8.4", default-features = false }
-# <= 1.0.171 due to serde-rs/serde#2538
-serde = { version = ">= 1.0.126, <= 1.0.171", default-features = false }
+# ^1.0.184 due to serde-rs/serde#2538
+serde = { version = "1.0.184", default-features = false }
 serde_json = "1.0.68"
 serde_test = "1.0.126"
 trybuild = "1.0.68"

--- a/time-macros/Cargo.toml
+++ b/time-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time-macros"
-version = "0.2.12"
+version = "0.2.13"
 authors = ["Jacob Pratt <open-source@jhpratt.dev>", "Time contributors"]
 edition = "2021"
 rust-version = "1.67.0"

--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time"
-version = "0.3.26"
+version = "0.3.27"
 authors = ["Jacob Pratt <open-source@jhpratt.dev>", "Time contributors"]
 edition = "2021"
 rust-version = "1.67.0"


### PR DESCRIPTION
Fixes #614 

I recommend relaxing back now that the issue has been resolved `>= 1.0.184` 

EDIT: Current approach is set to minimum 1.0.184