### PR TITLE
chore(lib.rs): renamed no_coverage with coverate_attribute

### DIFF
--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -76,7 +76,7 @@
 
 #![doc(html_playground_url = "https://play.rust-lang.org")]
 #![cfg_attr(__time_03_docs, feature(doc_auto_cfg, doc_notable_trait))]
-#![cfg_attr(coverage_nightly, feature(no_coverage))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc(html_favicon_url = "https://avatars0.githubusercontent.com/u/55999857")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/55999857")]


### PR DESCRIPTION
Closed #619 

## What Changed

- replaced no_coverage with coverage_attribute due to no_coverage 

I would appreciate it if you could review when you have time.