### PR TITLE
Added closing markdown tag

### DIFF
--- a/time/src/primitive_date_time.rs
+++ b/time/src/primitive_date_time.rs
@@ -110,6 +110,7 @@ impl PrimitiveDateTime {
     /// ```rust
     /// # use time_macros::{datetime, time};
     /// assert_eq!(datetime!(2019-01-01 0:00).time(), time!(0:00));
+    /// ```
     pub const fn time(self) -> Time {
         self.0.time()
     }


### PR DESCRIPTION
I was doing a exercism level and noticed this small thing. I also checked for more issues with `rg -i '/// ```' .` as to double-check if every opening tag has a closing one and from a quick view it looks good :)