### PR TITLE
Add from_unix_timestamp_millis/_micros for convenience

### DIFF
--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -157,18 +157,61 @@ impl OffsetDateTime {
         Ok(Self(const_try!(Inner::from_unix_timestamp(timestamp))))
     }
 
+    /// Construct an `OffsetDateTime` from the provided Unix timestamp (in milliseconds). Calling
+    /// `.offset()` on the resulting value is guaranteed to return UTC.
+    ///
+    /// ```rust
+    /// # use time::OffsetDateTime;
+    /// # use time_macros::datetime;
+    ///
+    /// const TIMESTAMP_MILLIS: i64 = 1_546_300_800_000;
+    ///
+    /// assert_eq!(
+    ///     OffsetDateTime::from_unix_timestamp_millis(TIMESTAMP_MILLIS),
+    ///     Ok(datetime!(2019-01-01 0:00 UTC)),
+    /// );
+    /// ```
+    pub const fn from_unix_timestamp_millis(timestamp: i64) -> Result<Self, error::ComponentRange> {
+        Ok(Self(const_try!(Inner::from_unix_timestamp_millis(
+            timestamp
+        ))))
+    }
+
+    /// Construct an `OffsetDateTime` from the provided Unix timestamp (in milliseconds). Calling
+    /// `.offset()` on the resulting value is guaranteed to return UTC.
+    ///
+    /// ```rust
+    /// # use time::OffsetDateTime;
+    /// # use time_macros::datetime;
+    ///
+    /// const TIMESTAMP_MICROS: i64 = 1_546_300_800_000_000;
+    ///
+    /// assert_eq!(
+    ///     OffsetDateTime::from_unix_timestamp_micros(TIMESTAMP_MICROS),
+    ///     Ok(datetime!(2019-01-01 0:00 UTC)),
+    /// );
+    /// ```
+    pub const fn from_unix_timestamp_micros(timestamp: i64) -> Result<Self, error::ComponentRange> {
+        Ok(Self(const_try!(Inner::from_unix_timestamp_micros(
+            timestamp
+        ))))
+    }
+
     /// Construct an `OffsetDateTime` from the provided Unix timestamp (in nanoseconds). Calling
     /// `.offset()` on the resulting value is guaranteed to return UTC.
     ///
     /// ```rust
     /// # use time::OffsetDateTime;
     /// # use time_macros::datetime;
+    ///
+    /// const TIMESTAMP_NANOS: i128 = 1_546_300_800_000_000_000;
+    ///
     /// assert_eq!(
     ///     OffsetDateTime::from_unix_timestamp_nanos(0),
     ///     Ok(OffsetDateTime::UNIX_EPOCH),
     /// );
     /// assert_eq!(
-    ///     OffsetDateTime::from_unix_timestamp_nanos(1_546_300_800_000_000_000),
+    ///     OffsetDateTime::from_unix_timestamp_nanos(TIMESTAMP_NANOS),
     ///     Ok(datetime!(2019-01-01 0:00 UTC)),
     /// );
     /// ```


### PR DESCRIPTION
It would be much more convenient to have these than parsing text to offset, calculating stuff just for it to be serialized again.

Tests, docs and clippy seem to pass locally(I guess it's configured different in CI).
Other than that - feel free to edit or benchmark, but I doubt it will seriously impact anything: in the end it just uses different remaining digits

I would really want to merge it though since doing stuff like:
```
let parsed_unix_ts = format!("{}000", value.__realtime_timestamp)
            .parse::<i128>()
            .expect("Failed to parse timestamp");
        let timestamp = OffsetDateTime::from_unix_timestamp_nanos(parsed_unix_ts)

``` 
is pure evil