### PR TITLE
Rework to use `datealgo` library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ time-core = { path = "time-core", version = "=0.1.2" }
 time-macros = { path = "time-macros", version = "=0.2.15" }
 
 criterion = { version = "0.5.1", default-features = false }
+
+datealgo = "0.2.0"
 deranged = { version = "0.3.9", default-features = false, features = [
     "powerfmt",
 ] }

--- a/time-macros/src/date.rs
+++ b/time-macros/src/date.rs
@@ -128,10 +128,15 @@ impl ToTokenTree for Date {
     fn into_token_tree(self) -> TokenTree {
         quote_group! {{
             const DATE: ::time::Date = unsafe {
-                ::time::Date::__from_ordinal_date_unchecked(
+                // FIXME
+                if let Ok(v) = ::time::Date::from_ordinal_date(
                     #(self.year),
                     #(self.ordinal),
-                )
+                ) {
+                    v
+                } else {
+                    ::core::hint::unreachable_unchecked()
+                }
             };
             DATE
         }}

--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -49,6 +49,7 @@ wasm-bindgen = ["dep:js-sys"]
 # If adding an optional dependency, be sure to use the `dep:` prefix above to avoid an implicit
 # feature gate.
 [dependencies]
+datealgo = { workspace = true }
 deranged = { workspace = true }
 itoa = { workspace = true, optional = true }
 powerfmt = { workspace = true }

--- a/time/src/date_time.rs
+++ b/time/src/date_time.rs
@@ -199,10 +199,10 @@ pub(crate) const fn maybe_offset_from_offset<O: MaybeOffset>(
 // endregion const trait methods hacks
 
 /// The Julian day of the Unix epoch.
-// Safety: `ordinal` is not zero.
+// Safety: `month` and `day` are not zero.
 #[allow(clippy::undocumented_unsafe_blocks)]
 const UNIX_EPOCH_JULIAN_DAY: i32 =
-    unsafe { Date::__from_ordinal_date_unchecked(1970, 1) }.to_julian_day();
+    unsafe { Date::__from_date_unchecked(1970, 1, 1) }.to_julian_day();
 
 pub struct DateTime<O: MaybeOffset> {
     pub(crate) date: Date,
@@ -237,8 +237,8 @@ impl DateTime<offset_kind::None> {
 
 impl DateTime<offset_kind::Fixed> {
     pub const UNIX_EPOCH: Self = Self {
-        // Safety: `ordinal` is not zero.
-        date: unsafe { Date::__from_ordinal_date_unchecked(1970, 1) },
+        // Safety: 1970-01-01 exists.
+        date: unsafe { Date::__from_date_unchecked(1970, 1, 1) },
         time: Time::MIDNIGHT,
         offset: UtcOffset::UTC,
     };
@@ -539,9 +539,13 @@ impl<O: MaybeOffset> DateTime<O> {
             return None;
         }
 
+        // FIXME: optimize
+        let rd = datealgo::date_to_rd((year, 1, 1)) + ordinal as i32;
+        let (y, m, d) = datealgo::rd_to_date(rd);
+
         Some(DateTime {
-            // Safety: `ordinal` is not zero.
-            date: unsafe { Date::__from_ordinal_date_unchecked(year, ordinal) },
+            // Safety: `m` and `d` are not zero.
+            date: unsafe { Date::__from_date_unchecked(y, m, d) },
             time,
             offset,
         })

--- a/time/src/formatting/mod.rs
+++ b/time/src/formatting/mod.rs
@@ -283,7 +283,7 @@ fn fmt_year(
     }: modifier::Year,
 ) -> Result<usize, io::Error> {
     let full_year = if iso_week_based {
-        date.iso_year_week().0
+        date.to_iso_week_date().0
     } else {
         date.year()
     };

--- a/time/src/parsing/parsed.rs
+++ b/time/src/parsing/parsed.rs
@@ -736,8 +736,8 @@ impl TryFrom<Parsed> for Date {
         /// Get the value needed to adjust the ordinal day for Sunday and Monday-based week
         /// numbering.
         const fn adjustment(year: i32) -> i16 {
-            // Safety: `ordinal` is not zero.
-            match unsafe { Date::__from_ordinal_date_unchecked(year, 1) }.weekday() {
+            // Safety: `month` and `day` are not zero.
+            match unsafe { Date::__from_date_unchecked(year, 1, 1) }.weekday() {
                 Weekday::Monday => 7,
                 Weekday::Tuesday => 1,
                 Weekday::Wednesday => 2,


### PR DESCRIPTION
This pull does quite a big root-canal rework:

- `Date` internal representation is changed from `(year: 21 bits, ordinal: 9 bits)` to `(year: 21 bits, month: 4 bits, day: 5 bits)`
- All internal date manipulation algorithms replaced by calling into `datealgo` library

The results of this are performance gains:

| Benchmark | Time | Change | Comment |
| --------- | ---- | ------ | ------- |
| Date: from_calendar_date | 7.4313 ns | -25.644% | **Performance has improved** | 
| Date: from_ordinal_date | 11.771 ns | +31.051% | *Performance has regressed* | 
| Date: from_iso_week_date | 15.810 ns | -19.704% | **Performance has improved** | 
| Date: from_julian_day | 9.2566 ns | -38.340% | **Performance has improved** | 
| Date: year | 2.1663 ns | +2.6444% | No change in performance detected. | 
| Date: month | 1.8139 ns | -55.446% | **Performance has improved** |
| Date: day | 2.0914 ns | -42.576% | **Performance has improved** |
| Date: ordinal | 4.1022 ns | +149.47% | *Performance has regressed* | 
| Date: iso_week | 10.260 ns | +4.8933% | No change in performance detected. | 
| Date: sunday_based_week | 7.7664 ns | -2.8478% | No change in performance detected. |
| Date: monday_based_week | 7.4018 ns  | -10.981% | **Performance has improved** | 
| Date: to_calendar_date | 1.8292 ns | -61.345% | **Performance has improved** | 
| Date: to_ordinal_date | 4.1561 ns | +150.49% | *Performance has regressed* | 
| Date: to_iso_week_date | 10.139 ns | -1.0213% | No change in performance detected. | 
| Date: weekday | 4.9401 ns | -23.894% | **Performance has improved** | 
| Date: next_day | 2.5907 ns | -42.514% | **Performance has improved** | 
| Date: previous_day | ns 2.0693 | +3.5332% | No change in performance detected. | 
| Date: to_julian_day | 3.0313 ns | -31.273% | **Performance has improved** | 
| Date: midnight | 1.7777 ns | -28.381% | **Performance has improved** |
| Date: with_time | 1.9008 ns | +4.5041% | No change in performance detected. | 
| Date: with_hms | 7.3927 ns | -2.9789% | No change in performance detected. | 
| Date: with_hms_milli | 8.1539 ns | +2.3146% | No change in performance detected. | 
| Date: with_hms_micro | 10.025 ns | +11.291% | No change in performance detected. | 
| Date: with_hms_nano | 7.8717 ns | -0.9628% | No change in performance detected. | 
| Date: add | 9.2316 ns | -39.057% | **Performance has improved** | 
| Date: add_std | 8.0633 ns | -47.409% | **Performance has improved** | 
| Date: add_assign | 11.474 ns | -33.455% | **Performance has improved** | 
| Date: add_assign_std | 8.4556 ns | -43.950% | **Performance has improved** | 
| Date: sub | 9.1271 ns | -36.140% | **Performance has improved** | 
| Date: sub_std | 7.6889 ns | -47.200% | **Performance has improved** | 
| Date: sub_assign | 10.856 ns | -38.463% | **Performance has improved** | 
| Date: sub_assign_std | 11.638 ns | -36.007% | **Performance has improved** | 
| Date: sub_self | 7.4871 ns | -17.402% | **Performance has improved** | 
| Date: partial_ord | 326.20 ps | -3.2359% | No change in performance detected.
| Date: ord | 337.50 ps | +3.7494% | No change in performance detected. | 

As can be seen, the performance gains are quite sizeable. The only regressions are `from_ordinal_date`, `ordinal` and `to_ordinal_date`, all of which are obvious. Ordinal based operations are not terribly common, so I would expect the improvements in real world usage to be a clear net positive.

Disclaimer: I am the creator of the `datealgo` library, although I do not claim credit for the algorithms themselves.

----

**NOTE:** Pull is still a draft, so code has a bunch of `FIXME` comments and other things. Also, performance results are preliminary as benchmarks are noisy, so more careful benchmarking is still needed. However, I wanted to get this out early, in order to get feedback before completing the rest.