### PR TITLE
Add direct constructors for `OffsetDateTime`.

### DIFF
--- a/tests/offset_date_time.rs
+++ b/tests/offset_date_time.rs
@@ -6,6 +6,23 @@ use time::macros::{date, datetime, offset, time};
 use time::{Date, Duration, Month, OffsetDateTime, PrimitiveDateTime, Result, Weekday};
 
 #[test]
+fn new_utc() {
+    let dt = OffsetDateTime::new_utc(date!(2023 - 12 - 18), time!(10:13:44.250 AM));
+    assert_eq!(dt.year(), 2023);
+    assert_eq!(dt.millisecond(), 250);
+    assert_eq!(dt.offset(), offset!(UTC));
+}
+
+#[test]
+fn new_in_offset() {
+    let dt =
+        OffsetDateTime::new_in_offset(date!(2023 - 12 - 18), time!(10:13:44.250 AM), offset!(-4));
+    assert_eq!(dt.year(), 2023);
+    assert_eq!(dt.millisecond(), 250);
+    assert_eq!(dt.offset().whole_hours(), -4);
+}
+
+#[test]
 fn now_utc() {
     assert!(OffsetDateTime::now_utc().year() >= 2019);
     assert_eq!(OffsetDateTime::now_utc().offset(), offset!(UTC));
@@ -433,16 +450,12 @@ fn replace_year() -> Result<()> {
         datetime!(2022 - 02 - 18 12:00 +01).replace_year(2019),
         Ok(datetime!(2019 - 02 - 18 12:00 +01))
     );
-    assert!(
-        datetime!(2022 - 02 - 18 12:00 +01)
-            .replace_year(-1_000_000_000)
-            .is_err()
-    ); // -1_000_000_000 isn't a valid year
-    assert!(
-        datetime!(2022 - 02 - 18 12:00 +01)
-            .replace_year(1_000_000_000)
-            .is_err()
-    ); // 1_000_000_000 isn't a valid year
+    assert!(datetime!(2022 - 02 - 18 12:00 +01)
+        .replace_year(-1_000_000_000)
+        .is_err()); // -1_000_000_000 isn't a valid year
+    assert!(datetime!(2022 - 02 - 18 12:00 +01)
+        .replace_year(1_000_000_000)
+        .is_err()); // 1_000_000_000 isn't a valid year
     Ok(())
 }
 
@@ -452,11 +465,9 @@ fn replace_month() -> Result<()> {
         datetime!(2022 - 02 - 18 12:00 +01).replace_month(Month::January),
         Ok(datetime!(2022 - 01 - 18 12:00 +01))
     );
-    assert!(
-        datetime!(2022 - 01 - 30 12:00 +01)
-            .replace_month(Month::February)
-            .is_err()
-    ); // 30 isn't a valid day in February
+    assert!(datetime!(2022 - 01 - 30 12:00 +01)
+        .replace_month(Month::February)
+        .is_err()); // 30 isn't a valid day in February
     Ok(())
 }
 
@@ -477,11 +488,9 @@ fn replace_hour() -> Result<()> {
         datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01).replace_hour(7),
         Ok(datetime!(2022 - 02 - 18 07:02:03.004_005_006 +01))
     );
-    assert!(
-        datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01)
-            .replace_hour(24)
-            .is_err()
-    ); // 24 isn't a valid hour
+    assert!(datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01)
+        .replace_hour(24)
+        .is_err()); // 24 isn't a valid hour
     Ok(())
 }
 
@@ -491,11 +500,9 @@ fn replace_minute() -> Result<()> {
         datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01).replace_minute(7),
         Ok(datetime!(2022 - 02 - 18 01:07:03.004_005_006 +01))
     );
-    assert!(
-        datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01)
-            .replace_minute(60)
-            .is_err()
-    ); // 60 isn't a valid minute
+    assert!(datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01)
+        .replace_minute(60)
+        .is_err()); // 60 isn't a valid minute
     Ok(())
 }
 
@@ -505,11 +512,9 @@ fn replace_second() -> Result<()> {
         datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01).replace_second(7),
         Ok(datetime!(2022 - 02 - 18 01:02:07.004_005_006 +01))
     );
-    assert!(
-        datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01)
-            .replace_second(60)
-            .is_err()
-    ); // 60 isn't a valid second
+    assert!(datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01)
+        .replace_second(60)
+        .is_err()); // 60 isn't a valid second
     Ok(())
 }
 
@@ -519,11 +524,9 @@ fn replace_millisecond() -> Result<()> {
         datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01).replace_millisecond(7),
         Ok(datetime!(2022 - 02 - 18 01:02:03.007 +01))
     );
-    assert!(
-        datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01)
-            .replace_millisecond(1_000)
-            .is_err()
-    ); // 1_000 isn't a valid millisecond
+    assert!(datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01)
+        .replace_millisecond(1_000)
+        .is_err()); // 1_000 isn't a valid millisecond
     Ok(())
 }
 
@@ -533,11 +536,9 @@ fn replace_microsecond() -> Result<()> {
         datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01).replace_microsecond(7_008),
         Ok(datetime!(2022 - 02 - 18 01:02:03.007_008 +01))
     );
-    assert!(
-        datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01)
-            .replace_microsecond(1_000_000)
-            .is_err()
-    ); // 1_000_000 isn't a valid microsecond
+    assert!(datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01)
+        .replace_microsecond(1_000_000)
+        .is_err()); // 1_000_000 isn't a valid microsecond
     Ok(())
 }
 
@@ -547,11 +548,9 @@ fn replace_nanosecond() -> Result<()> {
         datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01).replace_nanosecond(7_008_009),
         Ok(datetime!(2022 - 02 - 18 01:02:03.007_008_009 +01))
     );
-    assert!(
-        datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01)
-            .replace_nanosecond(1_000_000_000)
-            .is_err()
-    ); // 1_000_000_000 isn't a valid nanosecond
+    assert!(datetime!(2022 - 02 - 18 01:02:03.004_005_006 +01)
+        .replace_nanosecond(1_000_000_000)
+        .is_err()); // 1_000_000_000 isn't a valid nanosecond
     Ok(())
 }
 

--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -71,65 +71,37 @@ impl OffsetDateTime {
     }
     // endregion now
 
-    /// Create a new `OffsetDateTime` with the given [[`Date`]], [`Time`], and [`UtcOffset`].
+    /// Create a new `OffsetDateTime` with the given [`Date`], [`Time`], and [`UtcOffset`].
     ///
     /// ```
     /// # use time::{Date, Month, OffsetDateTime, Time, UtcOffset};
     /// # use time_macros::datetime;
-    /// # fn main() -> Result<(), time::error::Error> {
-    /// let dt = OffsetDateTime::new(
+    /// let dt = OffsetDateTime::new_in_offset(
     ///     Date::from_calendar_date(2024, Month::January, 1)?,
     ///     Time::from_hms_nano(12, 59, 59, 500_000_000)?,
     ///     UtcOffset::from_hms(-5, 0, 0)?,
     /// );
     /// assert_eq!(dt, datetime!(2024-01-01 12:59:59.5 -5));
-    /// # Ok(())
-    /// # }
+    /// # Ok::<_, time::error::Error>(())
     /// ```
-    pub const fn new(date: Date, time: Time, offset: UtcOffset) -> Self {
+    pub const fn new_in_offset(date: Date, time: Time, offset: UtcOffset) -> Self {
         PrimitiveDateTime::new(date, time).assume_offset(offset)
     }
 
-    /// Create a new `OffsetDateTime` with the given [[`Date`]] and [`Time`] in the UTC timezone.
+    /// Create a new `OffsetDateTime` with the given [`Date`] and [`Time`] in the UTC timezone.
     ///
     /// ```
     /// # use time::{Date, Month, OffsetDateTime, Time};
     /// # use time_macros::datetime;
-    /// # fn main() -> Result<(), time::error::Error> {
     /// let dt = OffsetDateTime::new_utc(
     ///     Date::from_calendar_date(2024, Month::January, 1)?,
     ///     Time::from_hms_nano(12, 59, 59, 500_000_000)?,
     /// );
     /// assert_eq!(dt, datetime!(2024-01-01 12:59:59.5 UTC));
-    /// # Ok(())
-    /// # }
+    /// # Ok::<_, time::error::Error>(())
     /// ```
     pub const fn new_utc(date: Date, time: Time) -> Self {
         PrimitiveDateTime::new(date, time).assume_utc()
-    }
-
-    /// Create a new `OffsetDateTime` with the given [[`Date`]] and [`Time`] in the UTC timezone.
-    /// If the offset cannot be determined, an error is returned.
-    ///
-    /// ```
-    /// # use time::{Date, Month, OffsetDateTime, Time};
-    /// # fn main() -> Result<(), time::error::Error> {
-    /// # if false {
-    /// let dt = OffsetDateTime::new_local(
-    ///     Date::from_calendar_date(2024, Month::January, 1)?,
-    ///     Time::from_hms_nano(12, 59, 59, 500_000_000)?,
-    /// );
-    /// assert!(dt.is_ok());
-    /// # }
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[cfg(feature = "local-offset")]
-    pub fn new_local(date: Date, time: Time) -> Result<Self, error::IndeterminateOffset> {
-        match UtcOffset::current_local_offset() {
-            Ok(offset) => Ok(Self::new(date, time, offset)),
-            Err(err) => Err(err),
-        }
     }
 
     /// Convert the `OffsetDateTime` from the current [`UtcOffset`] to the provided [`UtcOffset`].

--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -71,6 +71,64 @@ impl OffsetDateTime {
     }
     // endregion now
 
+    /// Create a new `OffsetDateTime` with the given [[`Date`]], [`Time`], and [`UtcOffset`].
+    ///
+    /// ```
+    /// # use time::{Date, Month, OffsetDateTime, Time, UtcOffset};
+    /// # use time_macros::datetime;
+    /// # fn main() -> Result<(), time::error::Error> {
+    /// let dt = OffsetDateTime::new(
+    ///     Date::from_calendar_date(2024, Month::January, 1)?,
+    ///     Time::from_hms_nano(12, 59, 59, 500_000_000)?,
+    ///     UtcOffset::from_hms(-5, 0, 0)?,
+    /// );
+    /// assert_eq!(dt, datetime!(2024-01-01 12:59:59.5 -5));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new(date: Date, time: Time, offset: UtcOffset) -> Self {
+        PrimitiveDateTime::new(date, time).assume_offset(offset)
+    }
+
+    /// Create a new `OffsetDateTime` with the given [[`Date`]] and [`Time`] in the UTC timezone.
+    ///
+    /// ```
+    /// # use time::{Date, Month, OffsetDateTime, Time};
+    /// # use time_macros::datetime;
+    /// # fn main() -> Result<(), time::error::Error> {
+    /// let dt = OffsetDateTime::new_utc(
+    ///     Date::from_calendar_date(2024, Month::January, 1)?,
+    ///     Time::from_hms_nano(12, 59, 59, 500_000_000)?,
+    /// );
+    /// assert_eq!(dt, datetime!(2024-01-01 12:59:59.5 UTC));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_utc(date: Date, time: Time) -> Self {
+        PrimitiveDateTime::new(date, time).assume_utc()
+    }
+
+    /// Create a new `OffsetDateTime` with the given [[`Date`]] and [`Time`] in the UTC timezone.
+    /// If the offset cannot be determined, an error is returned.
+    ///
+    /// ```
+    /// # use time::{Date, Month, OffsetDateTime, Time};
+    /// # fn main() -> Result<(), time::error::Error> {
+    /// # if false {
+    /// let dt = OffsetDateTime::new_local(
+    ///     Date::from_calendar_date(2024, Month::January, 1)?,
+    ///     Time::from_hms_nano(12, 59, 59, 500_000_000)?,
+    /// );
+    /// assert!(dt.is_ok());
+    /// # }
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "local-offset")]
+    pub fn new_local(date: Date, time: Time) -> Result<Self, error::IndeterminateOffset> {
+        Ok(Self::new(date, time, UtcOffset::current_local_offset()?))
+    }
+
     /// Convert the `OffsetDateTime` from the current [`UtcOffset`] to the provided [`UtcOffset`].
     ///
     /// ```rust

--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -86,7 +86,7 @@ impl OffsetDateTime {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn new(date: Date, time: Time, offset: UtcOffset) -> Self {
+    pub const fn new(date: Date, time: Time, offset: UtcOffset) -> Self {
         PrimitiveDateTime::new(date, time).assume_offset(offset)
     }
 
@@ -104,7 +104,7 @@ impl OffsetDateTime {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn new_utc(date: Date, time: Time) -> Self {
+    pub const fn new_utc(date: Date, time: Time) -> Self {
         PrimitiveDateTime::new(date, time).assume_utc()
     }
 
@@ -126,7 +126,10 @@ impl OffsetDateTime {
     /// ```
     #[cfg(feature = "local-offset")]
     pub fn new_local(date: Date, time: Time) -> Result<Self, error::IndeterminateOffset> {
-        Ok(Self::new(date, time, UtcOffset::current_local_offset()?))
+        match UtcOffset::current_local_offset() {
+            Ok(offset) => Ok(Self::new(date, time, offset)),
+            Err(err) => Err(err),
+        }
     }
 
     /// Convert the `OffsetDateTime` from the current [`UtcOffset`] to the provided [`UtcOffset`].


### PR DESCRIPTION
Fixes #640

This PR adds new constructors to OffsetDateTime:
* `OffsetDateTime::new(date: Date, time: Time, offset: UtcOffset) -> Self`
* `OffsetDateTime::new_utc(date: Date, time: Time) -> Self`
* `OffsetDateTime::new_local(date: Date, time: Time) -> Result<Self, IndeterminateDateTime>`

Rationale for the PR can be found on the linked issue.