### PR TITLE
Adds support to serialize and deserialize timestamps with different resolutions

### DIFF
--- a/tests/serde/timestamps.rs
+++ b/tests/serde/timestamps.rs
@@ -16,6 +16,18 @@ struct TestMilliseconds {
     dt: OffsetDateTime,
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct TestMicroseconds {
+    #[serde(with = "timestamp::microseconds")]
+    dt: OffsetDateTime,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct TestNanoseconds {
+    #[serde(with = "timestamp::nanoseconds")]
+    dt: OffsetDateTime,
+}
+
 #[test]
 fn serialize_timestamp() {
     let value = Test {
@@ -45,6 +57,10 @@ fn serialize_timestamp() {
         ],
         "invalid type: string \"bad\", expected i64",
     );
+}
+
+#[test]
+fn serialize_timestamp_milliseconds() {
     let value_milliseconds = TestMilliseconds {
         dt: datetime!(2000-01-01 00:00:00.999 UTC),
     };
@@ -61,6 +77,59 @@ fn serialize_timestamp() {
         "invalid type: string \"bad\", expected i128",
     );
     // serde_test does not support I128, see: https://github.com/serde-rs/test/issues/18
-    let serde_milliseconds: TestMilliseconds = serde_json::from_str(r#"{"dt":946684800999}"#).unwrap();
-    assert_eq!(value_milliseconds.dt, serde_milliseconds.dt);
+    let milliseconds_str = r#"{"dt":946684800999}"#;
+    let deserialized_milliseconds: TestMilliseconds = serde_json::from_str(milliseconds_str).unwrap();
+    let serialized_milliseconds = serde_json::to_string(&value_milliseconds).unwrap();
+    assert_eq!(value_milliseconds.dt, deserialized_milliseconds.dt);
+    assert_eq!(serialized_milliseconds, milliseconds_str);
+}
+
+#[test]
+fn serialize_timestamp_microseconds() {
+    let value_microseconds = TestMicroseconds {
+        dt: datetime!(2000-01-01 00:00:00.999_999 UTC),
+    };
+    assert_de_tokens_error::<TestMicroseconds>(
+        &[
+            Token::Struct {
+                name: "TestMicroseconds",
+                len: 1,
+            },
+            Token::Str("dt"),
+            Token::Str("bad"),
+            Token::StructEnd,
+        ],
+        "invalid type: string \"bad\", expected i128",
+    );
+    // serde_test does not support I128, see: https://github.com/serde-rs/test/issues/18
+    let microseconds_str = r#"{"dt":946684800999999}"#;
+    let deserialized_microseconds: TestMicroseconds = serde_json::from_str(microseconds_str).unwrap();
+    let serialized_microseconds = serde_json::to_string(&value_microseconds).unwrap();
+    assert_eq!(value_microseconds.dt, deserialized_microseconds.dt);
+    assert_eq!(serialized_microseconds, microseconds_str);
+}
+
+#[test]
+fn serialize_timestamp_nanoseconds() {
+    let value_nanoseconds = TestNanoseconds {
+        dt: datetime!(2000-01-01 00:00:00.999_999_999 UTC),
+    };
+    assert_de_tokens_error::<TestNanoseconds>(
+        &[
+            Token::Struct {
+                name: "TestNanoseconds",
+                len: 1,
+            },
+            Token::Str("dt"),
+            Token::Str("bad"),
+            Token::StructEnd,
+        ],
+        "invalid type: string \"bad\", expected i128",
+    );
+    // serde_test does not support I128, see: https://github.com/serde-rs/test/issues/18
+    let nanoseconds_str = r#"{"dt":946684800999999999}"#;
+    let deserialized_nanoseconds: TestNanoseconds = serde_json::from_str(nanoseconds_str).unwrap();
+    let serialized_nanoseconds = serde_json::to_string(&value_nanoseconds).unwrap();
+    assert_eq!(value_nanoseconds.dt, deserialized_nanoseconds.dt);
+    assert_eq!(serialized_nanoseconds, nanoseconds_str);
 }

--- a/tests/serde/timestamps.rs
+++ b/tests/serde/timestamps.rs
@@ -10,6 +10,12 @@ struct Test {
     dt: OffsetDateTime,
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct TestMilliseconds {
+    #[serde(with = "timestamp::milliseconds")]
+    dt: OffsetDateTime,
+}
+
 #[test]
 fn serialize_timestamp() {
     let value = Test {
@@ -39,4 +45,22 @@ fn serialize_timestamp() {
         ],
         "invalid type: string \"bad\", expected i64",
     );
+    let value_milliseconds = TestMilliseconds {
+        dt: datetime!(2000-01-01 00:00:00.999 UTC),
+    };
+    assert_de_tokens_error::<TestMilliseconds>(
+        &[
+            Token::Struct {
+                name: "TestMilliseconds",
+                len: 1,
+            },
+            Token::Str("dt"),
+            Token::Str("bad"),
+            Token::StructEnd,
+        ],
+        "invalid type: string \"bad\", expected i128",
+    );
+    // serde_test does not support I128, see: https://github.com/serde-rs/test/issues/18
+    let serde_milliseconds: TestMilliseconds = serde_json::from_str(r#"{"dt":946684800999}"#).unwrap();
+    assert_eq!(value_milliseconds.dt, serde_milliseconds.dt);
 }

--- a/time/src/serde/timestamp/microseconds.rs
+++ b/time/src/serde/timestamp/microseconds.rs
@@ -1,4 +1,5 @@
-//! Treat an [`OffsetDateTime`] as a [Unix timestamp] for the purposes of serde.
+//! Treat an [`OffsetDateTime`] as a [Unix timestamp] with microseconds for
+//! the purposes of serde.
 //!
 //! Use this module in combination with serde's [`#[with]`][with] attribute.
 //!
@@ -7,30 +8,28 @@
 //! [Unix timestamp]: https://en.wikipedia.org/wiki/Unix_time
 //! [with]: https://serde.rs/field-attrs.html#with
 
-pub mod milliseconds;
-pub mod microseconds;
-pub mod nanoseconds;
-
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::OffsetDateTime;
 
-/// Serialize an `OffsetDateTime` as its Unix timestamp
+/// Serialize an `OffsetDateTime` as its Unix timestamp with microseconds
 pub fn serialize<S: Serializer>(
     datetime: &OffsetDateTime,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    datetime.unix_timestamp().serialize(serializer)
+    let timestamp = datetime.unix_timestamp_nanos() / 1_000;
+    timestamp.serialize(serializer)
 }
 
-/// Deserialize an `OffsetDateTime` from its Unix timestamp
+/// Deserialize an `OffsetDateTime` from its Unix timestamp with microseconds
 pub fn deserialize<'a, D: Deserializer<'a>>(deserializer: D) -> Result<OffsetDateTime, D::Error> {
-    OffsetDateTime::from_unix_timestamp(<_>::deserialize(deserializer)?)
+    let value: i128 = <_>::deserialize(deserializer)?;
+    OffsetDateTime::from_unix_timestamp_nanos(value * 1_000)
         .map_err(|err| de::Error::invalid_value(de::Unexpected::Signed(err.value), &err))
 }
 
-/// Treat an `Option<OffsetDateTime>` as a [Unix timestamp] for the purposes of
-/// serde.
+/// Treat an `Option<OffsetDateTime>` as a [Unix timestamp] with microseconds
+/// for the purposes of serde.
 ///
 /// Use this module in combination with serde's [`#[with]`][with] attribute.
 ///
@@ -42,22 +41,22 @@ pub mod option {
     #[allow(clippy::wildcard_imports)]
     use super::*;
 
-    /// Serialize an `Option<OffsetDateTime>` as its Unix timestamp
+    /// Serialize an `Option<OffsetDateTime>` as its Unix timestamp with microseconds
     pub fn serialize<S: Serializer>(
         option: &Option<OffsetDateTime>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         option
-            .map(OffsetDateTime::unix_timestamp)
+            .map(|timestamp| timestamp.unix_timestamp_nanos() / 1_000)
             .serialize(serializer)
     }
 
-    /// Deserialize an `Option<OffsetDateTime>` from its Unix timestamp
+    /// Deserialize an `Option<OffsetDateTime>` from its Unix timestamp with microseconds
     pub fn deserialize<'a, D: Deserializer<'a>>(
         deserializer: D,
     ) -> Result<Option<OffsetDateTime>, D::Error> {
         Option::deserialize(deserializer)?
-            .map(OffsetDateTime::from_unix_timestamp)
+            .map(|value: i128| OffsetDateTime::from_unix_timestamp_nanos(value * 1_000))
             .transpose()
             .map_err(|err| de::Error::invalid_value(de::Unexpected::Signed(err.value), &err))
     }

--- a/time/src/serde/timestamp/milliseconds.rs
+++ b/time/src/serde/timestamp/milliseconds.rs
@@ -1,0 +1,62 @@
+//! Treat an [`OffsetDateTime`] as a [Unix timestamp] for the purposes of serde.
+//!
+//! Use this module in combination with serde's [`#[with]`][with] attribute.
+//!
+//! When deserializing, the offset is assumed to be UTC.
+//!
+//! [Unix timestamp]: https://en.wikipedia.org/wiki/Unix_time
+//! [with]: https://serde.rs/field-attrs.html#with
+
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::OffsetDateTime;
+
+/// Serialize an `OffsetDateTime` as its Unix timestamp
+pub fn serialize<S: Serializer>(
+    datetime: &OffsetDateTime,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let timestamp = datetime.unix_timestamp_nanos() / 1_000_000;
+    timestamp.serialize(serializer)
+}
+
+/// Deserialize an `OffsetDateTime` from its Unix timestamp
+pub fn deserialize<'a, D: Deserializer<'a>>(deserializer: D) -> Result<OffsetDateTime, D::Error> {
+    let value: i128 = <_>::deserialize(deserializer)?;
+    OffsetDateTime::from_unix_timestamp_nanos(value * 1_000_000)
+        .map_err(|err| de::Error::invalid_value(de::Unexpected::Signed(err.value), &err))
+}
+
+/// Treat an `Option<OffsetDateTime>` as a [Unix timestamp] for the purposes of
+/// serde.
+///
+/// Use this module in combination with serde's [`#[with]`][with] attribute.
+///
+/// When deserializing, the offset is assumed to be UTC.
+///
+/// [Unix timestamp]: https://en.wikipedia.org/wiki/Unix_time
+/// [with]: https://serde.rs/field-attrs.html#with
+pub mod option {
+    #[allow(clippy::wildcard_imports)]
+    use super::*;
+
+    /// Serialize an `Option<OffsetDateTime>` as its Unix timestamp
+    pub fn serialize<S: Serializer>(
+        option: &Option<OffsetDateTime>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        option
+            .map(|timestamp| timestamp.unix_timestamp_nanos() / 1_000_000)
+            .serialize(serializer)
+    }
+
+    /// Deserialize an `Option<OffsetDateTime>` from its Unix timestamp
+    pub fn deserialize<'a, D: Deserializer<'a>>(
+        deserializer: D,
+    ) -> Result<Option<OffsetDateTime>, D::Error> {
+        Option::deserialize(deserializer)?
+            .map(|value: i128| OffsetDateTime::from_unix_timestamp_nanos(value * 1_000_000))
+            .transpose()
+            .map_err(|err| de::Error::invalid_value(de::Unexpected::Signed(err.value), &err))
+    }
+}

--- a/time/src/serde/timestamp/milliseconds.rs
+++ b/time/src/serde/timestamp/milliseconds.rs
@@ -1,4 +1,5 @@
-//! Treat an [`OffsetDateTime`] as a [Unix timestamp] for the purposes of serde.
+//! Treat an [`OffsetDateTime`] as a [Unix timestamp] with milliseconds for
+//! the purposes of serde.
 //!
 //! Use this module in combination with serde's [`#[with]`][with] attribute.
 //!
@@ -11,7 +12,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::OffsetDateTime;
 
-/// Serialize an `OffsetDateTime` as its Unix timestamp
+/// Serialize an `OffsetDateTime` as its Unix timestamp with milliseconds
 pub fn serialize<S: Serializer>(
     datetime: &OffsetDateTime,
     serializer: S,
@@ -20,15 +21,15 @@ pub fn serialize<S: Serializer>(
     timestamp.serialize(serializer)
 }
 
-/// Deserialize an `OffsetDateTime` from its Unix timestamp
+/// Deserialize an `OffsetDateTime` from its Unix timestamp with milliseconds
 pub fn deserialize<'a, D: Deserializer<'a>>(deserializer: D) -> Result<OffsetDateTime, D::Error> {
     let value: i128 = <_>::deserialize(deserializer)?;
     OffsetDateTime::from_unix_timestamp_nanos(value * 1_000_000)
         .map_err(|err| de::Error::invalid_value(de::Unexpected::Signed(err.value), &err))
 }
 
-/// Treat an `Option<OffsetDateTime>` as a [Unix timestamp] for the purposes of
-/// serde.
+/// Treat an `Option<OffsetDateTime>` as a [Unix timestamp] with milliseconds
+/// for the purposes of serde.
 ///
 /// Use this module in combination with serde's [`#[with]`][with] attribute.
 ///
@@ -40,7 +41,7 @@ pub mod option {
     #[allow(clippy::wildcard_imports)]
     use super::*;
 
-    /// Serialize an `Option<OffsetDateTime>` as its Unix timestamp
+    /// Serialize an `Option<OffsetDateTime>` as its Unix timestamp with milliseconds
     pub fn serialize<S: Serializer>(
         option: &Option<OffsetDateTime>,
         serializer: S,
@@ -50,7 +51,7 @@ pub mod option {
             .serialize(serializer)
     }
 
-    /// Deserialize an `Option<OffsetDateTime>` from its Unix timestamp
+    /// Deserialize an `Option<OffsetDateTime>` from its Unix timestamp with milliseconds
     pub fn deserialize<'a, D: Deserializer<'a>>(
         deserializer: D,
     ) -> Result<Option<OffsetDateTime>, D::Error> {

--- a/time/src/serde/timestamp/mod.rs
+++ b/time/src/serde/timestamp/mod.rs
@@ -7,6 +7,8 @@
 //! [Unix timestamp]: https://en.wikipedia.org/wiki/Unix_time
 //! [with]: https://serde.rs/field-attrs.html#with
 
+pub mod milliseconds;
+
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::OffsetDateTime;

--- a/time/src/serde/timestamp/mod.rs
+++ b/time/src/serde/timestamp/mod.rs
@@ -7,8 +7,8 @@
 //! [Unix timestamp]: https://en.wikipedia.org/wiki/Unix_time
 //! [with]: https://serde.rs/field-attrs.html#with
 
-pub mod milliseconds;
 pub mod microseconds;
+pub mod milliseconds;
 pub mod nanoseconds;
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};

--- a/time/src/serde/timestamp/nanoseconds.rs
+++ b/time/src/serde/timestamp/nanoseconds.rs
@@ -1,4 +1,5 @@
-//! Treat an [`OffsetDateTime`] as a [Unix timestamp] for the purposes of serde.
+//! Treat an [`OffsetDateTime`] as a [Unix timestamp] with nanoseconds for
+//! the purposes of serde.
 //!
 //! Use this module in combination with serde's [`#[with]`][with] attribute.
 //!
@@ -7,30 +8,26 @@
 //! [Unix timestamp]: https://en.wikipedia.org/wiki/Unix_time
 //! [with]: https://serde.rs/field-attrs.html#with
 
-pub mod milliseconds;
-pub mod microseconds;
-pub mod nanoseconds;
-
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::OffsetDateTime;
 
-/// Serialize an `OffsetDateTime` as its Unix timestamp
+/// Serialize an `OffsetDateTime` as its Unix timestamp with nanoseconds
 pub fn serialize<S: Serializer>(
     datetime: &OffsetDateTime,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    datetime.unix_timestamp().serialize(serializer)
+    datetime.unix_timestamp_nanos().serialize(serializer)
 }
 
-/// Deserialize an `OffsetDateTime` from its Unix timestamp
+/// Deserialize an `OffsetDateTime` from its Unix timestamp with nanoseconds
 pub fn deserialize<'a, D: Deserializer<'a>>(deserializer: D) -> Result<OffsetDateTime, D::Error> {
-    OffsetDateTime::from_unix_timestamp(<_>::deserialize(deserializer)?)
+    OffsetDateTime::from_unix_timestamp_nanos(<_>::deserialize(deserializer)?)
         .map_err(|err| de::Error::invalid_value(de::Unexpected::Signed(err.value), &err))
 }
 
-/// Treat an `Option<OffsetDateTime>` as a [Unix timestamp] for the purposes of
-/// serde.
+/// Treat an `Option<OffsetDateTime>` as a [Unix timestamp] with nanoseconds
+/// for the purposes of serde.
 ///
 /// Use this module in combination with serde's [`#[with]`][with] attribute.
 ///
@@ -42,22 +39,22 @@ pub mod option {
     #[allow(clippy::wildcard_imports)]
     use super::*;
 
-    /// Serialize an `Option<OffsetDateTime>` as its Unix timestamp
+    /// Serialize an `Option<OffsetDateTime>` as its Unix timestamp with nanoseconds
     pub fn serialize<S: Serializer>(
         option: &Option<OffsetDateTime>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         option
-            .map(OffsetDateTime::unix_timestamp)
+            .map(OffsetDateTime::unix_timestamp_nanos)
             .serialize(serializer)
     }
 
-    /// Deserialize an `Option<OffsetDateTime>` from its Unix timestamp
+    /// Deserialize an `Option<OffsetDateTime>` from its Unix timestamp with nanoseconds
     pub fn deserialize<'a, D: Deserializer<'a>>(
         deserializer: D,
     ) -> Result<Option<OffsetDateTime>, D::Error> {
         Option::deserialize(deserializer)?
-            .map(OffsetDateTime::from_unix_timestamp)
+            .map(OffsetDateTime::from_unix_timestamp_nanos)
             .transpose()
             .map_err(|err| de::Error::invalid_value(de::Unexpected::Signed(err.value), &err))
     }


### PR DESCRIPTION
As discussed in #647 this merge request adds the ability to serialize and deserialize timestamps with milliseconds, microseconds and nanoseconds.

For now I have only implemented the milliseconds because I want to see if it looks right to you @jhpratt if so then I do the rest.

The idea is that you can do the following:

```rust
use serde::{Deserialize, Serialize};
use time::serde::timestamp;
use time::OffsetDateTime;

#[derive(Serialize, Deserialize, Debug)]
struct TimestampSeconds {
    #[serde(with = "timestamp")]
    dt: OffsetDateTime,
}

#[derive(Serialize, Deserialize, Debug)]
struct TimestampMilliseconds {
    #[serde(with = "timestamp::milliseconds")]
    dt: OffsetDateTime,
}
```