### PR TITLE
Allow unused_tuple lint under the new dead_code name

### DIFF
--- a/time-macros/src/lib.rs
+++ b/time-macros/src/lib.rs
@@ -68,7 +68,7 @@ enum FormatDescriptionVersion {
 #[cfg(any(feature = "formatting", feature = "parsing"))]
 enum VersionOrModuleName {
     Version(FormatDescriptionVersion),
-    #[cfg_attr(not(feature = "serde"), allow(unused_tuple_struct_fields))]
+    #[cfg_attr(not(feature = "serde"), allow(dead_code, unused_tuple_struct_fields))]
     ModuleName(Ident),
 }
 


### PR DESCRIPTION
As of at least rust 1.77 nightly, the compiler warns that the `unused_tuple_struct_field` lint has been subsumed under `dead_code`. Allow both lints in the relevant field here.

This still warns about the old name on nightly but helps with the severity of the warning for those building with a nightly toolchain and is less likely regress builds with future stable toolchains.