### PR TITLE
Fix wasm32-unknown-unknown build

### DIFF
--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -1596,6 +1596,7 @@ impl From<js_sys::Date> for OffsetDateTime {
     ///
     /// This may panic if the timestamp can not be represented.
     fn from(js_date: js_sys::Date) -> Self {
+        use time_core::convert::Millisecond;
         // get_time() returns milliseconds
         let timestamp_nanos = (js_date.get_time() * Nanosecond::per(Millisecond) as f64) as i128;
         Self::from_unix_timestamp_nanos(timestamp_nanos)
@@ -1610,11 +1611,12 @@ impl From<js_sys::Date> for OffsetDateTime {
 ))]
 impl From<OffsetDateTime> for js_sys::Date {
     fn from(datetime: OffsetDateTime) -> Self {
+        use time_core::convert::Millisecond;
         // new Date() takes milliseconds
         let timestamp = (datetime.unix_timestamp_nanos()
             / Nanosecond::per(Millisecond).cast_signed().extend::<i128>())
             as f64;
-        js_sys::Date::new(&timestamp.into())
+        Self::new(&timestamp.into())
     }
 }
 // endregion trait impls

--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -16,7 +16,7 @@ use deranged::RangedI64;
 use num_conv::prelude::*;
 use powerfmt::ext::FormatterExt as _;
 use powerfmt::smart_display::{self, FormatterOptions, Metadata, SmartDisplay};
-use time_core::convert::{Day, Hour, Minute, Nanosecond, Second};
+use time_core::convert::*;
 
 use crate::date::{MAX_YEAR, MIN_YEAR};
 #[cfg(feature = "formatting")]
@@ -1596,7 +1596,6 @@ impl From<js_sys::Date> for OffsetDateTime {
     ///
     /// This may panic if the timestamp can not be represented.
     fn from(js_date: js_sys::Date) -> Self {
-        use time_core::convert::Millisecond;
         // get_time() returns milliseconds
         let timestamp_nanos = (js_date.get_time() * Nanosecond::per(Millisecond) as f64) as i128;
         Self::from_unix_timestamp_nanos(timestamp_nanos)
@@ -1611,7 +1610,6 @@ impl From<js_sys::Date> for OffsetDateTime {
 ))]
 impl From<OffsetDateTime> for js_sys::Date {
     fn from(datetime: OffsetDateTime) -> Self {
-        use time_core::convert::Millisecond;
         // new Date() takes milliseconds
         let timestamp = (datetime.unix_timestamp_nanos()
             / Nanosecond::per(Millisecond).cast_signed().extend::<i128>())

--- a/time/src/sys/local_offset_at/wasm_js.rs
+++ b/time/src/sys/local_offset_at/wasm_js.rs
@@ -1,4 +1,4 @@
-use num_conv::{CastSigned, Extend};
+use num_conv::prelude::*;
 
 use crate::convert::*;
 use crate::{OffsetDateTime, UtcOffset};

--- a/time/src/sys/local_offset_at/wasm_js.rs
+++ b/time/src/sys/local_offset_at/wasm_js.rs
@@ -1,3 +1,5 @@
+use num_conv::{CastSigned, Extend};
+
 use crate::convert::*;
 use crate::{OffsetDateTime, UtcOffset};
 


### PR DESCRIPTION
This closes #652.

This also probably requires some CI modifications to test the `wasm_bindgen` builds, but that can be done in a follow-up PR.