### PR TITLE
fix unsigned to signed conversion bug

### DIFF
--- a/time/src/sys/local_offset_at/windows.rs
+++ b/time/src/sys/local_offset_at/windows.rs
@@ -59,10 +59,9 @@ fn systemtime_to_filetime(systime: &SystemTime) -> Option<FileTime> {
 /// Convert a `FILETIME` to an `i64`, representing a number of seconds.
 fn filetime_to_secs(filetime: &FileTime) -> i64 {
     /// FILETIME represents 100-nanosecond intervals
-    const FT_TO_SECS: i64 = Nanosecond::per(Second) as i64 / 100;
-    (filetime.dwHighDateTime.cast_signed().extend::<i64>() << 32
-        | filetime.dwLowDateTime.cast_signed().extend::<i64>())
-        / FT_TO_SECS
+    const FT_TO_SECS: u64 = Nanosecond::per(Second) as u64 / 100;
+    ((filetime.dwHighDateTime.extend::<u64>() << 32 | filetime.dwLowDateTime.extend::<u64>())
+        / FT_TO_SECS) as i64
 }
 
 /// Convert an [`OffsetDateTime`] to a `SYSTEMTIME`.


### PR DESCRIPTION
Casting `u32` into `i32` and then extending into `i64` does not hold the value when `val_u32 > i32::MAX`.
As explained in [Microsoft Documentation](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime#remarks) one should firstly construct `u64` from `FILETIME` and then perform arithmetics.