### PR TITLE
Add must_use function attributes

### DIFF
--- a/tests/date.rs
+++ b/tests/date.rs
@@ -1154,35 +1154,35 @@ fn nth_prev_occurrence_test() {
 #[test]
 #[should_panic]
 fn next_occurrence_overflow_test() {
-    date!(+999999 - 12 - 25).next_occurrence(Weekday::Saturday);
+    let _ = date!(+999999 - 12 - 25).next_occurrence(Weekday::Saturday);
 }
 
 #[test]
 #[should_panic]
 fn prev_occurrence_overflow_test() {
-    date!(-999999 - 01 - 07).prev_occurrence(Weekday::Sunday);
+    let _ = date!(-999999 - 01 - 07).prev_occurrence(Weekday::Sunday);
 }
 
 #[test]
 #[should_panic]
 fn nth_next_occurrence_overflow_test() {
-    date!(+999999 - 12 - 25).nth_next_occurrence(Weekday::Saturday, 1);
+    let _ = date!(+999999 - 12 - 25).nth_next_occurrence(Weekday::Saturday, 1);
 }
 
 #[test]
 #[should_panic]
 fn nth_next_occurence_zeroth_occurence_test() {
-    date!(2023 - 06 - 25).nth_next_occurrence(Weekday::Monday, 0);
+    let _ = date!(2023 - 06 - 25).nth_next_occurrence(Weekday::Monday, 0);
 }
 
 #[test]
 #[should_panic]
 fn nth_prev_occurence_zeroth_occurence_test() {
-    date!(2023 - 06 - 27).nth_prev_occurrence(Weekday::Monday, 0);
+    let _ = date!(2023 - 06 - 27).nth_prev_occurrence(Weekday::Monday, 0);
 }
 
 #[test]
 #[should_panic]
 fn nth_prev_occurrence_overflow_test() {
-    date!(-999999 - 01 - 07).nth_prev_occurrence(Weekday::Sunday, 1);
+    let _ = date!(-999999 - 01 - 07).nth_prev_occurrence(Weekday::Sunday, 1);
 }

--- a/time-core/src/util.rs
+++ b/time-core/src/util.rs
@@ -11,6 +11,7 @@
 /// assert!(!is_leap_year(2005));
 /// assert!(!is_leap_year(2100));
 /// ```
+#[must_use = "This method only computes the returned value"]
 pub const fn is_leap_year(year: i32) -> bool {
     year % 4 == 0 && (year % 25 != 0 || year % 16 == 0)
 }
@@ -27,6 +28,7 @@ pub const fn is_leap_year(year: i32) -> bool {
 /// assert_eq!(days_in_year(2005), 365);
 /// assert_eq!(days_in_year(2100), 365);
 /// ```
+#[must_use = "This method only computes the returned value"]
 pub const fn days_in_year(year: i32) -> u16 {
     if is_leap_year(year) { 366 } else { 365 }
 }
@@ -40,6 +42,7 @@ pub const fn days_in_year(year: i32) -> u16 {
 /// assert_eq!(weeks_in_year(2019), 52);
 /// assert_eq!(weeks_in_year(2020), 53);
 /// ```
+#[must_use = "This method only computes the returned value"]
 pub const fn weeks_in_year(year: i32) -> u8 {
     match year.rem_euclid(400) {
         4 | 9 | 15 | 20 | 26 | 32 | 37 | 43 | 48 | 54 | 60 | 65 | 71 | 76 | 82 | 88 | 93 | 99

--- a/time/src/date.rs
+++ b/time/src/date.rs
@@ -308,6 +308,7 @@ impl Date {
     /// assert_eq!(date!(2019 - 12 - 31).year(), 2019);
     /// assert_eq!(date!(2020 - 01 - 01).year(), 2020);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn year(self) -> i32 {
         self.value.get() >> 9
     }
@@ -320,6 +321,7 @@ impl Date {
     /// assert_eq!(date!(2019 - 01 - 01).month(), Month::January);
     /// assert_eq!(date!(2019 - 12 - 31).month(), Month::December);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn month(self) -> Month {
         self.month_day().0
     }
@@ -333,6 +335,7 @@ impl Date {
     /// assert_eq!(date!(2019 - 01 - 01).day(), 1);
     /// assert_eq!(date!(2019 - 12 - 31).day(), 31);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn day(self) -> u8 {
         self.month_day().1
     }
@@ -387,6 +390,7 @@ impl Date {
     /// assert_eq!(date!(2019 - 01 - 01).ordinal(), 1);
     /// assert_eq!(date!(2019 - 12 - 31).ordinal(), 365);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn ordinal(self) -> u16 {
         (self.value.get() & 0x1FF) as _
     }
@@ -414,6 +418,7 @@ impl Date {
     /// assert_eq!(date!(2020 - 12 - 31).iso_week(), 53);
     /// assert_eq!(date!(2021 - 01 - 01).iso_week(), 53);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn iso_week(self) -> u8 {
         self.iso_year_week().1
     }
@@ -429,6 +434,7 @@ impl Date {
     /// assert_eq!(date!(2020 - 12 - 31).sunday_based_week(), 52);
     /// assert_eq!(date!(2021 - 01 - 01).sunday_based_week(), 0);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn sunday_based_week(self) -> u8 {
         ((self.ordinal() as i16 - self.weekday().number_days_from_sunday() as i16 + 6) / 7) as _
     }
@@ -444,6 +450,7 @@ impl Date {
     /// assert_eq!(date!(2020 - 12 - 31).monday_based_week(), 52);
     /// assert_eq!(date!(2021 - 01 - 01).monday_based_week(), 0);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn monday_based_week(self) -> u8 {
         ((self.ordinal() as i16 - self.weekday().number_days_from_monday() as i16 + 6) / 7) as _
     }
@@ -458,6 +465,7 @@ impl Date {
     ///     (2019, Month::January, 1)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_calendar_date(self) -> (i32, Month, u8) {
         let (month, day) = self.month_day();
         (self.year(), month, day)
@@ -469,6 +477,7 @@ impl Date {
     /// # use time_macros::date;
     /// assert_eq!(date!(2019 - 01 - 01).to_ordinal_date(), (2019, 1));
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_ordinal_date(self) -> (i32, u16) {
         (self.year(), self.ordinal())
     }
@@ -490,6 +499,7 @@ impl Date {
     /// );
     /// assert_eq!(date!(2021 - 01 - 01).to_iso_week_date(), (2020, 53, Friday));
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_iso_week_date(self) -> (i32, u8, Weekday) {
         let (year, ordinal) = self.to_ordinal_date();
         let weekday = self.weekday();
@@ -519,6 +529,7 @@ impl Date {
     /// assert_eq!(date!(2019 - 11 - 01).weekday(), Friday);
     /// assert_eq!(date!(2019 - 12 - 01).weekday(), Sunday);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn weekday(self) -> Weekday {
         match self.to_julian_day() % 7 {
             -6 | 1 => Weekday::Tuesday,
@@ -553,6 +564,7 @@ impl Date {
     /// );
     /// assert_eq!(Date::MAX.next_day(), None);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn next_day(self) -> Option<Self> {
         if self.ordinal() == 366 || (self.ordinal() == 365 && !is_leap_year(self.year())) {
             if self.value.get() == Self::MAX.value.get() {
@@ -588,6 +600,7 @@ impl Date {
     /// );
     /// assert_eq!(Date::MIN.previous_day(), None);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn previous_day(self) -> Option<Self> {
         if self.ordinal() != 1 {
             Some(Self {
@@ -622,6 +635,7 @@ impl Date {
     ///     date!(2023 - 06 - 26)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn next_occurrence(self, weekday: Weekday) -> Self {
         expect_opt!(
             self.checked_next_occurrence(weekday),
@@ -647,6 +661,7 @@ impl Date {
     ///     date!(2023 - 06 - 12)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn prev_occurrence(self, weekday: Weekday) -> Self {
         expect_opt!(
             self.checked_prev_occurrence(weekday),
@@ -672,6 +687,7 @@ impl Date {
     ///     date!(2023 - 07 - 31)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn nth_next_occurrence(self, weekday: Weekday, n: u8) -> Self {
         expect_opt!(
             self.checked_nth_next_occurrence(weekday, n),
@@ -697,6 +713,7 @@ impl Date {
     ///     date!(2023 - 06 - 05)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn nth_prev_occurrence(self, weekday: Weekday, n: u8) -> Self {
         expect_opt!(
             self.checked_nth_prev_occurrence(weekday, n),
@@ -716,6 +733,7 @@ impl Date {
     /// assert_eq!(date!(2019 - 01 - 01).to_julian_day(), 2_458_485);
     /// assert_eq!(date!(2019 - 12 - 31).to_julian_day(), 2_458_849);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_julian_day(self) -> i32 {
         let year = self.year() - 1;
         let ordinal = self.ordinal() as i32;
@@ -758,6 +776,7 @@ impl Date {
     ///     Some(date!(2021 - 01 - 01))
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `Date`."]
     pub const fn checked_add(self, duration: Duration) -> Option<Self> {
         let whole_days = duration.whole_days();
         if whole_days < i32::MIN as i64 || whole_days > i32::MAX as i64 {
@@ -801,6 +820,7 @@ impl Date {
     ///     Some(date!(2021 - 01 - 01))
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `Date`."]
     pub const fn checked_add_std(self, duration: StdDuration) -> Option<Self> {
         let whole_days = duration.as_secs() / Second::per(Day) as u64;
         if whole_days > i32::MAX as u64 {
@@ -846,6 +866,7 @@ impl Date {
     ///     Some(date!(2020 - 12 - 30))
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `Date`."]
     pub const fn checked_sub(self, duration: Duration) -> Option<Self> {
         let whole_days = duration.whole_days();
         if whole_days < i32::MIN as i64 || whole_days > i32::MAX as i64 {
@@ -889,6 +910,7 @@ impl Date {
     ///     Some(date!(2020 - 12 - 30))
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `Date`."]
     pub const fn checked_sub_std(self, duration: StdDuration) -> Option<Self> {
         let whole_days = duration.as_secs() / Second::per(Day) as u64;
         if whole_days > i32::MAX as u64 {
@@ -994,6 +1016,7 @@ impl Date {
     ///     date!(2021 - 01 - 01)
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `Date`."]
     pub const fn saturating_add(self, duration: Duration) -> Self {
         if let Some(datetime) = self.checked_add(duration) {
             datetime
@@ -1034,6 +1057,7 @@ impl Date {
     ///     date!(2020 - 12 - 30)
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `Date`."]
     pub const fn saturating_sub(self, duration: Duration) -> Self {
         if let Some(datetime) = self.checked_sub(duration) {
             datetime
@@ -1191,6 +1215,7 @@ impl Date {
     /// # use time_macros::{date, datetime};
     /// assert_eq!(date!(1970-01-01).midnight(), datetime!(1970-01-01 0:00));
     /// ```
+    #[must_use = "This method does not mutate the original `Date`."]
     pub const fn midnight(self) -> PrimitiveDateTime {
         PrimitiveDateTime::new(self, Time::MIDNIGHT)
     }
@@ -1204,6 +1229,7 @@ impl Date {
     ///     datetime!(1970-01-01 0:00),
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `Date`."]
     pub const fn with_time(self, time: Time) -> PrimitiveDateTime {
         PrimitiveDateTime::new(self, time)
     }

--- a/time/src/duration.rs
+++ b/time/src/duration.rs
@@ -276,6 +276,7 @@ impl Duration {
     /// assert!(0.seconds().is_zero());
     /// assert!(!1.nanoseconds().is_zero());
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn is_zero(self) -> bool {
         self.seconds == 0 && self.nanoseconds.get() == 0
     }
@@ -288,6 +289,7 @@ impl Duration {
     /// assert!(!0.seconds().is_negative());
     /// assert!(!1.seconds().is_negative());
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn is_negative(self) -> bool {
         self.seconds < 0 || self.nanoseconds.get() < 0
     }
@@ -300,6 +302,7 @@ impl Duration {
     /// assert!(!0.seconds().is_positive());
     /// assert!(!(-1).seconds().is_positive());
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn is_positive(self) -> bool {
         self.seconds > 0 || self.nanoseconds.get() > 0
     }
@@ -316,6 +319,7 @@ impl Duration {
     /// assert_eq!(0.seconds().abs(), 0.seconds());
     /// assert_eq!((-1).seconds().abs(), 1.seconds());
     /// ```
+    #[must_use = "This method does not mutate the original `Duration`."]
     pub const fn abs(self) -> Self {
         match self.seconds.checked_abs() {
             Some(seconds) => Self::new_ranged_unchecked(seconds, self.nanoseconds.abs()),
@@ -332,6 +336,7 @@ impl Duration {
     /// assert_eq!(0.seconds().unsigned_abs(), 0.std_seconds());
     /// assert_eq!((-1).seconds().unsigned_abs(), 1.std_seconds());
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn unsigned_abs(self) -> StdDuration {
         StdDuration::new(
             self.seconds.unsigned_abs(),
@@ -385,6 +390,7 @@ impl Duration {
     /// # Panics
     ///
     /// This may panic if an overflow occurs.
+    #[must_use = "This method only computes the returned value"]
     pub const fn new(mut seconds: i64, mut nanoseconds: i32) -> Self {
         seconds = expect_opt!(
             seconds.checked_add(nanoseconds as i64 / Nanosecond::per(Second) as i64),
@@ -440,6 +446,7 @@ impl Duration {
     /// # Panics
     ///
     /// This may panic if an overflow occurs.
+    #[must_use = "This method only computes the returned value"]
     pub const fn weeks(weeks: i64) -> Self {
         Self::seconds(expect_opt!(
             weeks.checked_mul(Second::per(Week) as _),
@@ -458,6 +465,7 @@ impl Duration {
     /// # Panics
     ///
     /// This may panic if an overflow occurs.
+    #[must_use = "This method only computes the returned value"]
     pub const fn days(days: i64) -> Self {
         Self::seconds(expect_opt!(
             days.checked_mul(Second::per(Day) as _),
@@ -476,6 +484,7 @@ impl Duration {
     /// # Panics
     ///
     /// This may panic if an overflow occurs.
+    #[must_use = "This method only computes the returned value"]
     pub const fn hours(hours: i64) -> Self {
         Self::seconds(expect_opt!(
             hours.checked_mul(Second::per(Hour) as _),
@@ -494,6 +503,7 @@ impl Duration {
     /// # Panics
     ///
     /// This may panic if an overflow occurs.
+    #[must_use = "This method only computes the returned value"]
     pub const fn minutes(minutes: i64) -> Self {
         Self::seconds(expect_opt!(
             minutes.checked_mul(Second::per(Minute) as _),
@@ -507,6 +517,7 @@ impl Duration {
     /// # use time::{Duration, ext::NumericalDuration};
     /// assert_eq!(Duration::seconds(1), 1_000.milliseconds());
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn seconds(seconds: i64) -> Self {
         Self::new_ranged_unchecked(seconds, Nanoseconds::new_static::<0>())
     }
@@ -518,6 +529,7 @@ impl Duration {
     /// assert_eq!(Duration::seconds_f64(0.5), 0.5.seconds());
     /// assert_eq!(Duration::seconds_f64(-0.5), -0.5.seconds());
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub fn seconds_f64(seconds: f64) -> Self {
         try_from_secs!(
             secs = seconds,
@@ -540,6 +552,7 @@ impl Duration {
     /// assert_eq!(Duration::seconds_f32(0.5), 0.5.seconds());
     /// assert_eq!(Duration::seconds_f32(-0.5), (-0.5).seconds());
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub fn seconds_f32(seconds: f32) -> Self {
         try_from_secs!(
             secs = seconds,
@@ -577,6 +590,7 @@ impl Duration {
     ///     Duration::MAX,
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub fn saturating_seconds_f64(seconds: f64) -> Self {
         try_from_secs!(
             secs = seconds,
@@ -614,6 +628,7 @@ impl Duration {
     ///     Duration::MAX,
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub fn saturating_seconds_f32(seconds: f32) -> Self {
         try_from_secs!(
             secs = seconds,
@@ -641,6 +656,7 @@ impl Duration {
     /// assert_eq!(Duration::checked_seconds_f64(f64::NEG_INFINITY), None);
     /// assert_eq!(Duration::checked_seconds_f64(f64::INFINITY), None);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub fn checked_seconds_f64(seconds: f64) -> Option<Self> {
         Some(try_from_secs!(
             secs = seconds,
@@ -668,6 +684,7 @@ impl Duration {
     /// assert_eq!(Duration::checked_seconds_f32(f32::NEG_INFINITY), None);
     /// assert_eq!(Duration::checked_seconds_f32(f32::INFINITY), None);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub fn checked_seconds_f32(seconds: f32) -> Option<Self> {
         Some(try_from_secs!(
             secs = seconds,
@@ -690,6 +707,7 @@ impl Duration {
     /// assert_eq!(Duration::milliseconds(1), 1_000.microseconds());
     /// assert_eq!(Duration::milliseconds(-1), (-1_000).microseconds());
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn milliseconds(milliseconds: i64) -> Self {
         // Safety: `nanoseconds` is guaranteed to be in range because of the modulus.
         unsafe {
@@ -708,6 +726,7 @@ impl Duration {
     /// assert_eq!(Duration::microseconds(1), 1_000.nanoseconds());
     /// assert_eq!(Duration::microseconds(-1), (-1_000).nanoseconds());
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn microseconds(microseconds: i64) -> Self {
         // Safety: `nanoseconds` is guaranteed to be in range because of the modulus.
         unsafe {
@@ -726,6 +745,7 @@ impl Duration {
     /// assert_eq!(Duration::nanoseconds(1), 1.microseconds() / 1_000);
     /// assert_eq!(Duration::nanoseconds(-1), (-1).microseconds() / 1_000);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn nanoseconds(nanoseconds: i64) -> Self {
         // Safety: `nanoseconds` is guaranteed to be in range because of the modulus.
         unsafe {
@@ -763,6 +783,7 @@ impl Duration {
     /// assert_eq!(6.days().whole_weeks(), 0);
     /// assert_eq!((-6).days().whole_weeks(), 0);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn whole_weeks(self) -> i64 {
         self.whole_seconds() / Second::per(Week) as i64
     }
@@ -776,6 +797,7 @@ impl Duration {
     /// assert_eq!(23.hours().whole_days(), 0);
     /// assert_eq!((-23).hours().whole_days(), 0);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn whole_days(self) -> i64 {
         self.whole_seconds() / Second::per(Day) as i64
     }
@@ -789,6 +811,7 @@ impl Duration {
     /// assert_eq!(59.minutes().whole_hours(), 0);
     /// assert_eq!((-59).minutes().whole_hours(), 0);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn whole_hours(self) -> i64 {
         self.whole_seconds() / Second::per(Hour) as i64
     }
@@ -802,6 +825,7 @@ impl Duration {
     /// assert_eq!(59.seconds().whole_minutes(), 0);
     /// assert_eq!((-59).seconds().whole_minutes(), 0);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn whole_minutes(self) -> i64 {
         self.whole_seconds() / Second::per(Minute) as i64
     }
@@ -815,6 +839,7 @@ impl Duration {
     /// assert_eq!(1.minutes().whole_seconds(), 60);
     /// assert_eq!((-1).minutes().whole_seconds(), -60);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn whole_seconds(self) -> i64 {
         self.seconds
     }
@@ -826,6 +851,7 @@ impl Duration {
     /// assert_eq!(1.5.seconds().as_seconds_f64(), 1.5);
     /// assert_eq!((-1.5).seconds().as_seconds_f64(), -1.5);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub fn as_seconds_f64(self) -> f64 {
         self.seconds as f64 + self.nanoseconds.get() as f64 / Nanosecond::per(Second) as f64
     }
@@ -837,6 +863,7 @@ impl Duration {
     /// assert_eq!(1.5.seconds().as_seconds_f32(), 1.5);
     /// assert_eq!((-1.5).seconds().as_seconds_f32(), -1.5);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub fn as_seconds_f32(self) -> f32 {
         self.seconds as f32 + self.nanoseconds.get() as f32 / Nanosecond::per(Second) as f32
     }
@@ -850,6 +877,7 @@ impl Duration {
     /// assert_eq!(1.milliseconds().whole_milliseconds(), 1);
     /// assert_eq!((-1).milliseconds().whole_milliseconds(), -1);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn whole_milliseconds(self) -> i128 {
         self.seconds as i128 * Millisecond::per(Second) as i128
             + self.nanoseconds.get() as i128 / Nanosecond::per(Millisecond) as i128
@@ -865,6 +893,7 @@ impl Duration {
     /// assert_eq!((-1.4).seconds().subsec_milliseconds(), -400);
     /// ```
     // Allow the lint, as the value is guaranteed to be less than 1000.
+    #[must_use = "This method only computes the returned value"]
     pub const fn subsec_milliseconds(self) -> i16 {
         (self.nanoseconds.get() / Nanosecond::per(Millisecond) as i32) as _
     }
@@ -878,6 +907,7 @@ impl Duration {
     /// assert_eq!(1.microseconds().whole_microseconds(), 1);
     /// assert_eq!((-1).microseconds().whole_microseconds(), -1);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn whole_microseconds(self) -> i128 {
         self.seconds as i128 * Microsecond::per(Second) as i128
             + self.nanoseconds.get() as i128 / Nanosecond::per(Microsecond) as i128
@@ -892,6 +922,7 @@ impl Duration {
     /// assert_eq!(1.0004.seconds().subsec_microseconds(), 400);
     /// assert_eq!((-1.0004).seconds().subsec_microseconds(), -400);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn subsec_microseconds(self) -> i32 {
         self.nanoseconds.get() / Nanosecond::per(Microsecond) as i32
     }
@@ -905,6 +936,7 @@ impl Duration {
     /// assert_eq!(1.nanoseconds().whole_nanoseconds(), 1);
     /// assert_eq!((-1).nanoseconds().whole_nanoseconds(), -1);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn whole_nanoseconds(self) -> i128 {
         self.seconds as i128 * Nanosecond::per(Second) as i128 + self.nanoseconds.get() as i128
     }
@@ -918,6 +950,7 @@ impl Duration {
     /// assert_eq!(1.000_000_400.seconds().subsec_nanoseconds(), 400);
     /// assert_eq!((-1.000_000_400).seconds().subsec_nanoseconds(), -400);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn subsec_nanoseconds(self) -> i32 {
         self.nanoseconds.get()
     }
@@ -938,6 +971,7 @@ impl Duration {
     /// assert_eq!(Duration::MAX.checked_add(1.nanoseconds()), None);
     /// assert_eq!((-5).seconds().checked_add(5.seconds()), Some(0.seconds()));
     /// ```
+    #[must_use = "This method does not mutate the original `Duration`."]
     pub const fn checked_add(self, rhs: Self) -> Option<Self> {
         let mut seconds = const_try_opt!(self.seconds.checked_add(rhs.seconds));
         let mut nanoseconds = self.nanoseconds.get() + rhs.nanoseconds.get();
@@ -963,6 +997,7 @@ impl Duration {
     /// assert_eq!(Duration::MIN.checked_sub(1.nanoseconds()), None);
     /// assert_eq!(5.seconds().checked_sub(10.seconds()), Some((-5).seconds()));
     /// ```
+    #[must_use = "This method does not mutate the original `Duration`."]
     pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
         let mut seconds = const_try_opt!(self.seconds.checked_sub(rhs.seconds));
         let mut nanoseconds = self.nanoseconds.get() - rhs.nanoseconds.get();
@@ -990,6 +1025,7 @@ impl Duration {
     /// assert_eq!(Duration::MAX.checked_mul(2), None);
     /// assert_eq!(Duration::MIN.checked_mul(2), None);
     /// ```
+    #[must_use = "This method does not mutate the original `Duration`."]
     pub const fn checked_mul(self, rhs: i32) -> Option<Self> {
         // Multiply nanoseconds as i64, because it cannot overflow that way.
         let total_nanos = self.nanoseconds.get() as i64 * rhs as i64;
@@ -1011,6 +1047,7 @@ impl Duration {
     /// assert_eq!(10.seconds().checked_div(-2), Some((-5).seconds()));
     /// assert_eq!(1.seconds().checked_div(0), None);
     /// ```
+    #[must_use = "This method does not mutate the original `Duration`."]
     pub const fn checked_div(self, rhs: i32) -> Option<Self> {
         let (secs, extra_secs) = (
             const_try_opt!(self.seconds.checked_div(rhs as i64)),
@@ -1038,6 +1075,7 @@ impl Duration {
     /// );
     /// assert_eq!((-5).seconds().saturating_add(5.seconds()), Duration::ZERO);
     /// ```
+    #[must_use = "This method does not mutate the original `Duration`."]
     pub const fn saturating_add(self, rhs: Self) -> Self {
         let (mut seconds, overflow) = self.seconds.overflowing_add(rhs.seconds);
         if overflow {
@@ -1079,6 +1117,7 @@ impl Duration {
     /// );
     /// assert_eq!(5.seconds().saturating_sub(10.seconds()), (-5).seconds());
     /// ```
+    #[must_use = "This method does not mutate the original `Duration`."]
     pub const fn saturating_sub(self, rhs: Self) -> Self {
         let (mut seconds, overflow) = self.seconds.overflowing_sub(rhs.seconds);
         if overflow {
@@ -1120,6 +1159,7 @@ impl Duration {
     /// assert_eq!(Duration::MAX.saturating_mul(-2), Duration::MIN);
     /// assert_eq!(Duration::MIN.saturating_mul(-2), Duration::MAX);
     /// ```
+    #[must_use = "This method does not mutate the original `Duration`."]
     pub const fn saturating_mul(self, rhs: i32) -> Self {
         // Multiply nanoseconds as i64, because it cannot overflow that way.
         let total_nanos = self.nanoseconds.get() as i64 * rhs as i64;

--- a/time/src/ext.rs
+++ b/time/src/ext.rs
@@ -62,20 +62,28 @@ mod sealed {
 /// capacity.
 pub trait NumericalDuration: sealed::Sealed {
     /// Create a [`Duration`] from the number of nanoseconds.
+    #[must_use = "This method only computes the returned value"]
     fn nanoseconds(self) -> Duration;
     /// Create a [`Duration`] from the number of microseconds.
+    #[must_use = "This method only computes the returned value"]
     fn microseconds(self) -> Duration;
     /// Create a [`Duration`] from the number of milliseconds.
+    #[must_use = "This method only computes the returned value"]
     fn milliseconds(self) -> Duration;
     /// Create a [`Duration`] from the number of seconds.
+    #[must_use = "This method only computes the returned value"]
     fn seconds(self) -> Duration;
     /// Create a [`Duration`] from the number of minutes.
+    #[must_use = "This method only computes the returned value"]
     fn minutes(self) -> Duration;
     /// Create a [`Duration`] from the number of hours.
+    #[must_use = "This method only computes the returned value"]
     fn hours(self) -> Duration;
     /// Create a [`Duration`] from the number of days.
+    #[must_use = "This method only computes the returned value"]
     fn days(self) -> Duration;
     /// Create a [`Duration`] from the number of weeks.
+    #[must_use = "This method only computes the returned value"]
     fn weeks(self) -> Duration;
 }
 
@@ -187,20 +195,28 @@ impl NumericalDuration for f64 {
 /// capacity.
 pub trait NumericalStdDuration: sealed::Sealed {
     /// Create a [`std::time::Duration`] from the number of nanoseconds.
+    #[must_use = "This method only computes the returned value"]
     fn std_nanoseconds(self) -> StdDuration;
     /// Create a [`std::time::Duration`] from the number of microseconds.
+    #[must_use = "This method only computes the returned value"]
     fn std_microseconds(self) -> StdDuration;
     /// Create a [`std::time::Duration`] from the number of milliseconds.
+    #[must_use = "This method only computes the returned value"]
     fn std_milliseconds(self) -> StdDuration;
     /// Create a [`std::time::Duration`] from the number of seconds.
+    #[must_use = "This method only computes the returned value"]
     fn std_seconds(self) -> StdDuration;
     /// Create a [`std::time::Duration`] from the number of minutes.
+    #[must_use = "This method only computes the returned value"]
     fn std_minutes(self) -> StdDuration;
     /// Create a [`std::time::Duration`] from the number of hours.
+    #[must_use = "This method only computes the returned value"]
     fn std_hours(self) -> StdDuration;
     /// Create a [`std::time::Duration`] from the number of days.
+    #[must_use = "This method only computes the returned value"]
     fn std_days(self) -> StdDuration;
     /// Create a [`std::time::Duration`] from the number of weeks.
+    #[must_use = "This method only computes the returned value"]
     fn std_weeks(self) -> StdDuration;
 }
 

--- a/time/src/instant.rs
+++ b/time/src/instant.rs
@@ -38,6 +38,7 @@ impl Instant {
     /// # use time::Instant;
     /// println!("{:?}", Instant::now());
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub fn now() -> Self {
         Self(StdInstant::now())
     }
@@ -52,6 +53,7 @@ impl Instant {
     /// thread::sleep(1.std_milliseconds());
     /// assert!(instant.elapsed() >= 1.milliseconds());
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub fn elapsed(self) -> Duration {
         Self::now() - self
     }
@@ -68,6 +70,7 @@ impl Instant {
     /// assert_eq!(now.checked_add(5.seconds()), Some(now + 5.seconds()));
     /// assert_eq!(now.checked_add((-5).seconds()), Some(now + (-5).seconds()));
     /// ```
+    #[must_use = "This method does not mutate the original `Instant`."]
     pub fn checked_add(self, duration: Duration) -> Option<Self> {
         if duration.is_zero() {
             Some(self)
@@ -89,6 +92,7 @@ impl Instant {
     /// assert_eq!(now.checked_sub(5.seconds()), Some(now - 5.seconds()));
     /// assert_eq!(now.checked_sub((-5).seconds()), Some(now - (-5).seconds()));
     /// ```
+    #[must_use = "This method does not mutate the original `Instant`."]
     pub fn checked_sub(self, duration: Duration) -> Option<Self> {
         if duration.is_zero() {
             Some(self)
@@ -108,6 +112,7 @@ impl Instant {
     /// let now = Instant::now();
     /// assert_eq!(now.into_inner(), now.0);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn into_inner(self) -> StdInstant {
         self.0
     }

--- a/time/src/month.rs
+++ b/time/src/month.rs
@@ -71,6 +71,7 @@ impl Month {
     /// # use time::Month;
     /// assert_eq!(Month::January.previous(), Month::December);
     /// ```
+    #[must_use = "This method does not mutate the original `Month`."]
     pub const fn previous(self) -> Self {
         match self {
             January => December,
@@ -94,6 +95,7 @@ impl Month {
     /// # use time::Month;
     /// assert_eq!(Month::January.next(), Month::February);
     /// ```
+    #[must_use = "This method does not mutate the original `Month`."]
     pub const fn next(self) -> Self {
         match self {
             January => February,
@@ -118,6 +120,7 @@ impl Month {
     /// assert_eq!(Month::January.nth_next(4), Month::May);
     /// assert_eq!(Month::July.nth_next(9), Month::April);
     /// ```
+    #[must_use = "This method does not mutate the original `Month`."]
     pub const fn nth_next(self, n: u8) -> Self {
         match (self as u8 - 1 + n % 12) % 12 {
             0 => January,
@@ -145,6 +148,7 @@ impl Month {
     /// assert_eq!(Month::January.nth_prev(4), Month::September);
     /// assert_eq!(Month::July.nth_prev(9), Month::October);
     /// ```
+    #[must_use = "This method does not mutate the original `Month`."]
     pub const fn nth_prev(self, n: u8) -> Self {
         match self as i8 - 1 - (n % 12) as i8 {
             1 | -11 => February,

--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -95,6 +95,7 @@ impl OffsetDateTime {
     /// assert_eq!(OffsetDateTime::now_utc().offset(), offset!(UTC));
     /// ```
     #[cfg(feature = "std")]
+    #[must_use = "This method only computes the returned value"]
     pub fn now_utc() -> Self {
         #[cfg(all(
             target_family = "wasm",
@@ -142,6 +143,7 @@ impl OffsetDateTime {
     /// assert_eq!(dt, datetime!(2024-01-01 12:59:59.5 -5));
     /// # Ok::<_, time::error::Error>(())
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn new_in_offset(date: Date, time: Time, offset: UtcOffset) -> Self {
         Self {
             local_date_time: date.with_time(time),
@@ -161,6 +163,7 @@ impl OffsetDateTime {
     /// assert_eq!(dt, datetime!(2024-01-01 12:59:59.5 UTC));
     /// # Ok::<_, time::error::Error>(())
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn new_utc(date: Date, time: Time) -> Self {
         PrimitiveDateTime::new(date, time).assume_utc()
     }
@@ -190,6 +193,7 @@ impl OffsetDateTime {
     /// # Panics
     ///
     /// This method panics if the local date-time in the new offset is outside the supported range.
+    #[must_use = "This method does not mutate the original `OffsetDateTime`."]
     pub const fn to_offset(self, offset: UtcOffset) -> Self {
         expect_opt!(
             self.checked_to_offset(offset),
@@ -217,6 +221,7 @@ impl OffsetDateTime {
     ///     None,
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `OffsetDateTime`."]
     pub const fn checked_to_offset(self, offset: UtcOffset) -> Option<Self> {
         if self.offset.whole_hours() == offset.whole_hours()
             && self.offset.minutes_past_hour() == offset.minutes_past_hour()
@@ -393,6 +398,7 @@ impl OffsetDateTime {
     /// assert_eq!(datetime!(2019-01-01 0:00 UTC).offset(), offset!(UTC));
     /// assert_eq!(datetime!(2019-01-01 0:00 +1).offset(), offset!(+1));
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn offset(self) -> UtcOffset {
         self.offset
     }
@@ -404,6 +410,7 @@ impl OffsetDateTime {
     /// assert_eq!(datetime!(1970-01-01 0:00 UTC).unix_timestamp(), 0);
     /// assert_eq!(datetime!(1970-01-01 0:00 -1).unix_timestamp(), 3_600);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn unix_timestamp(self) -> i64 {
         let days =
             (self.to_julian_day() as i64 - UNIX_EPOCH_JULIAN_DAY as i64) * Second::per(Day) as i64;
@@ -424,11 +431,13 @@ impl OffsetDateTime {
     ///     3_600_000_000_000,
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn unix_timestamp_nanos(self) -> i128 {
         self.unix_timestamp() as i128 * Nanosecond::per(Second) as i128 + self.nanosecond() as i128
     }
 
     /// Get the [`PrimitiveDateTime`] in the stored offset.
+    #[must_use = "This method only computes the returned value"]
     const fn date_time(self) -> PrimitiveDateTime {
         self.local_date_time
     }
@@ -445,6 +454,7 @@ impl OffsetDateTime {
     ///     date!(2018-12-31),
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn date(self) -> Date {
         self.date_time().date()
     }
@@ -461,6 +471,7 @@ impl OffsetDateTime {
     ///     time!(23:00)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn time(self) -> Time {
         self.date_time().time()
     }
@@ -479,6 +490,7 @@ impl OffsetDateTime {
     /// );
     /// assert_eq!(datetime!(2020-01-01 0:00 UTC).year(), 2020);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn year(self) -> i32 {
         self.date().year()
     }
@@ -496,6 +508,7 @@ impl OffsetDateTime {
     ///     Month::January,
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn month(self) -> Month {
         self.date().month()
     }
@@ -514,6 +527,7 @@ impl OffsetDateTime {
     ///     1,
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn day(self) -> u8 {
         self.date().day()
     }
@@ -532,6 +546,7 @@ impl OffsetDateTime {
     ///     1,
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn ordinal(self) -> u16 {
         self.date().ordinal()
     }
@@ -547,6 +562,7 @@ impl OffsetDateTime {
     /// assert_eq!(datetime!(2020-12-31 0:00 UTC).iso_week(), 53);
     /// assert_eq!(datetime!(2021-01-01 0:00 UTC).iso_week(), 53);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn iso_week(self) -> u8 {
         self.date().iso_week()
     }
@@ -562,6 +578,7 @@ impl OffsetDateTime {
     /// assert_eq!(datetime!(2020-12-31 0:00 UTC).sunday_based_week(), 52);
     /// assert_eq!(datetime!(2021-01-01 0:00 UTC).sunday_based_week(), 0);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn sunday_based_week(self) -> u8 {
         self.date().sunday_based_week()
     }
@@ -577,6 +594,7 @@ impl OffsetDateTime {
     /// assert_eq!(datetime!(2020-12-31 0:00 UTC).monday_based_week(), 52);
     /// assert_eq!(datetime!(2021-01-01 0:00 UTC).monday_based_week(), 0);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn monday_based_week(self) -> u8 {
         self.date().monday_based_week()
     }
@@ -591,6 +609,7 @@ impl OffsetDateTime {
     ///     (2019, Month::January, 1)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_calendar_date(self) -> (i32, Month, u8) {
         self.date().to_calendar_date()
     }
@@ -604,6 +623,7 @@ impl OffsetDateTime {
     ///     (2019, 1)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_ordinal_date(self) -> (i32, u16) {
         self.date().to_ordinal_date()
     }
@@ -634,6 +654,7 @@ impl OffsetDateTime {
     ///     (2020, 53, Friday)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_iso_week_date(self) -> (i32, u8, Weekday) {
         self.date().to_iso_week_date()
     }
@@ -647,6 +668,7 @@ impl OffsetDateTime {
     /// assert_eq!(datetime!(2019-02-01 0:00 UTC).weekday(), Friday);
     /// assert_eq!(datetime!(2019-03-01 0:00 UTC).weekday(), Friday);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn weekday(self) -> Weekday {
         self.date().weekday()
     }
@@ -663,6 +685,7 @@ impl OffsetDateTime {
     /// assert_eq!(datetime!(2019-01-01 0:00 UTC).to_julian_day(), 2_458_485);
     /// assert_eq!(datetime!(2019-12-31 0:00 UTC).to_julian_day(), 2_458_849);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_julian_day(self) -> i32 {
         self.date().to_julian_day()
     }
@@ -676,6 +699,7 @@ impl OffsetDateTime {
     /// assert_eq!(datetime!(2020-01-01 0:00:00 UTC).to_hms(), (0, 0, 0));
     /// assert_eq!(datetime!(2020-01-01 23:59:59 UTC).to_hms(), (23, 59, 59));
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_hms(self) -> (u8, u8, u8) {
         self.time().as_hms()
     }
@@ -693,6 +717,7 @@ impl OffsetDateTime {
     ///     (23, 59, 59, 999)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_hms_milli(self) -> (u8, u8, u8, u16) {
         self.time().as_hms_milli()
     }
@@ -710,6 +735,7 @@ impl OffsetDateTime {
     ///     (23, 59, 59, 999_999)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_hms_micro(self) -> (u8, u8, u8, u32) {
         self.time().as_hms_micro()
     }
@@ -727,6 +753,7 @@ impl OffsetDateTime {
     ///     (23, 59, 59, 999_999_999)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_hms_nano(self) -> (u8, u8, u8, u32) {
         self.time().as_hms_nano()
     }
@@ -745,6 +772,7 @@ impl OffsetDateTime {
     ///     21,
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn hour(self) -> u8 {
         self.time().hour()
     }
@@ -763,6 +791,7 @@ impl OffsetDateTime {
     ///     29,
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn minute(self) -> u8 {
         self.time().minute()
     }
@@ -781,6 +810,7 @@ impl OffsetDateTime {
     ///     29,
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn second(self) -> u8 {
         self.time().second()
     }
@@ -797,6 +827,7 @@ impl OffsetDateTime {
     /// assert_eq!(datetime!(2019-01-01 0:00 UTC).millisecond(), 0);
     /// assert_eq!(datetime!(2019-01-01 23:59:59.999 UTC).millisecond(), 999);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn millisecond(self) -> u16 {
         self.time().millisecond()
     }
@@ -813,6 +844,7 @@ impl OffsetDateTime {
     ///     999_999,
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn microsecond(self) -> u32 {
         self.time().microsecond()
     }
@@ -829,6 +861,7 @@ impl OffsetDateTime {
     ///     999_999_999,
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn nanosecond(self) -> u32 {
         self.time().nanosecond()
     }
@@ -852,6 +885,7 @@ impl OffsetDateTime {
     ///     Some(datetime!(2019 - 11 - 26 18:30 +10))
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `OffsetDateTime`."]
     pub const fn checked_add(self, duration: Duration) -> Option<Self> {
         Some(const_try_opt!(self.date_time().checked_add(duration)).assume_offset(self.offset()))
     }
@@ -872,6 +906,7 @@ impl OffsetDateTime {
     ///     Some(datetime!(2019 - 11 - 24 12:30 +10))
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `OffsetDateTime`."]
     pub const fn checked_sub(self, duration: Duration) -> Option<Self> {
         Some(const_try_opt!(self.date_time().checked_sub(duration)).assume_offset(self.offset()))
     }
@@ -923,6 +958,7 @@ impl OffsetDateTime {
     ///     datetime!(2019 - 11 - 26 18:30 +10)
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `OffsetDateTime`."]
     pub const fn saturating_add(self, duration: Duration) -> Self {
         if let Some(datetime) = self.checked_add(duration) {
             datetime
@@ -978,6 +1014,7 @@ impl OffsetDateTime {
     ///     datetime!(2019 - 11 - 24 12:30 +10)
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `OffsetDateTime`."]
     pub const fn saturating_sub(self, duration: Duration) -> Self {
         if let Some(datetime) = self.checked_sub(duration) {
             datetime

--- a/time/src/primitive_date_time.rs
+++ b/time/src/primitive_date_time.rs
@@ -98,6 +98,7 @@ impl PrimitiveDateTime {
     ///     datetime!(2019-01-01 0:00),
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn new(date: Date, time: Time) -> Self {
         Self { date, time }
     }
@@ -109,6 +110,7 @@ impl PrimitiveDateTime {
     /// # use time_macros::{date, datetime};
     /// assert_eq!(datetime!(2019-01-01 0:00).date(), date!(2019-01-01));
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn date(self) -> Date {
         self.date
     }
@@ -119,6 +121,7 @@ impl PrimitiveDateTime {
     /// # use time_macros::{datetime, time};
     /// assert_eq!(datetime!(2019-01-01 0:00).time(), time!(0:00));
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn time(self) -> Time {
         self.time
     }
@@ -133,6 +136,7 @@ impl PrimitiveDateTime {
     /// assert_eq!(datetime!(2019-12-31 0:00).year(), 2019);
     /// assert_eq!(datetime!(2020-01-01 0:00).year(), 2020);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn year(self) -> i32 {
         self.date().year()
     }
@@ -145,6 +149,7 @@ impl PrimitiveDateTime {
     /// assert_eq!(datetime!(2019-01-01 0:00).month(), Month::January);
     /// assert_eq!(datetime!(2019-12-31 0:00).month(), Month::December);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn month(self) -> Month {
         self.date().month()
     }
@@ -158,6 +163,7 @@ impl PrimitiveDateTime {
     /// assert_eq!(datetime!(2019-01-01 0:00).day(), 1);
     /// assert_eq!(datetime!(2019-12-31 0:00).day(), 31);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn day(self) -> u8 {
         self.date().day()
     }
@@ -171,6 +177,7 @@ impl PrimitiveDateTime {
     /// assert_eq!(datetime!(2019-01-01 0:00).ordinal(), 1);
     /// assert_eq!(datetime!(2019-12-31 0:00).ordinal(), 365);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn ordinal(self) -> u16 {
         self.date().ordinal()
     }
@@ -187,6 +194,7 @@ impl PrimitiveDateTime {
     /// assert_eq!(datetime!(2020-12-31 0:00).iso_week(), 53);
     /// assert_eq!(datetime!(2021-01-01 0:00).iso_week(), 53);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn iso_week(self) -> u8 {
         self.date().iso_week()
     }
@@ -202,6 +210,7 @@ impl PrimitiveDateTime {
     /// assert_eq!(datetime!(2020-12-31 0:00).sunday_based_week(), 52);
     /// assert_eq!(datetime!(2021-01-01 0:00).sunday_based_week(), 0);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn sunday_based_week(self) -> u8 {
         self.date().sunday_based_week()
     }
@@ -217,6 +226,7 @@ impl PrimitiveDateTime {
     /// assert_eq!(datetime!(2020-12-31 0:00).monday_based_week(), 52);
     /// assert_eq!(datetime!(2021-01-01 0:00).monday_based_week(), 0);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn monday_based_week(self) -> u8 {
         self.date().monday_based_week()
     }
@@ -231,6 +241,7 @@ impl PrimitiveDateTime {
     ///     (2019, Month::January, 1)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_calendar_date(self) -> (i32, Month, u8) {
         self.date().to_calendar_date()
     }
@@ -241,6 +252,7 @@ impl PrimitiveDateTime {
     /// # use time_macros::datetime;
     /// assert_eq!(datetime!(2019-01-01 0:00).to_ordinal_date(), (2019, 1));
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_ordinal_date(self) -> (i32, u16) {
         self.date().to_ordinal_date()
     }
@@ -271,6 +283,7 @@ impl PrimitiveDateTime {
     ///     (2020, 53, Friday)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_iso_week_date(self) -> (i32, u8, Weekday) {
         self.date().to_iso_week_date()
     }
@@ -293,6 +306,7 @@ impl PrimitiveDateTime {
     /// assert_eq!(datetime!(2019-11-01 0:00).weekday(), Friday);
     /// assert_eq!(datetime!(2019-12-01 0:00).weekday(), Sunday);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn weekday(self) -> Weekday {
         self.date().weekday()
     }
@@ -309,6 +323,7 @@ impl PrimitiveDateTime {
     /// assert_eq!(datetime!(2019-01-01 0:00).to_julian_day(), 2_458_485);
     /// assert_eq!(datetime!(2019-12-31 0:00).to_julian_day(), 2_458_849);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn to_julian_day(self) -> i32 {
         self.date().to_julian_day()
     }
@@ -322,6 +337,7 @@ impl PrimitiveDateTime {
     /// assert_eq!(datetime!(2020-01-01 0:00:00).as_hms(), (0, 0, 0));
     /// assert_eq!(datetime!(2020-01-01 23:59:59).as_hms(), (23, 59, 59));
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn as_hms(self) -> (u8, u8, u8) {
         self.time().as_hms()
     }
@@ -336,6 +352,7 @@ impl PrimitiveDateTime {
     ///     (23, 59, 59, 999)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn as_hms_milli(self) -> (u8, u8, u8, u16) {
         self.time().as_hms_milli()
     }
@@ -350,6 +367,7 @@ impl PrimitiveDateTime {
     ///     (23, 59, 59, 999_999)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn as_hms_micro(self) -> (u8, u8, u8, u32) {
         self.time().as_hms_micro()
     }
@@ -364,6 +382,7 @@ impl PrimitiveDateTime {
     ///     (23, 59, 59, 999_999_999)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn as_hms_nano(self) -> (u8, u8, u8, u32) {
         self.time().as_hms_nano()
     }
@@ -377,6 +396,7 @@ impl PrimitiveDateTime {
     /// assert_eq!(datetime!(2019-01-01 0:00).hour(), 0);
     /// assert_eq!(datetime!(2019-01-01 23:59:59).hour(), 23);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn hour(self) -> u8 {
         self.time().hour()
     }
@@ -390,6 +410,7 @@ impl PrimitiveDateTime {
     /// assert_eq!(datetime!(2019-01-01 0:00).minute(), 0);
     /// assert_eq!(datetime!(2019-01-01 23:59:59).minute(), 59);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn minute(self) -> u8 {
         self.time().minute()
     }
@@ -403,6 +424,7 @@ impl PrimitiveDateTime {
     /// assert_eq!(datetime!(2019-01-01 0:00).second(), 0);
     /// assert_eq!(datetime!(2019-01-01 23:59:59).second(), 59);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn second(self) -> u8 {
         self.time().second()
     }
@@ -416,6 +438,7 @@ impl PrimitiveDateTime {
     /// assert_eq!(datetime!(2019-01-01 0:00).millisecond(), 0);
     /// assert_eq!(datetime!(2019-01-01 23:59:59.999).millisecond(), 999);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn millisecond(self) -> u16 {
         self.time().millisecond()
     }
@@ -432,6 +455,7 @@ impl PrimitiveDateTime {
     ///     999_999
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn microsecond(self) -> u32 {
         self.time().microsecond()
     }
@@ -448,6 +472,7 @@ impl PrimitiveDateTime {
     ///     999_999_999,
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn nanosecond(self) -> u32 {
         self.time().nanosecond()
     }
@@ -472,6 +497,7 @@ impl PrimitiveDateTime {
     ///     1_546_304_400,
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `PrimitiveDateTime`."]
     pub const fn assume_offset(self, offset: UtcOffset) -> OffsetDateTime {
         OffsetDateTime::new_in_offset(self.date, self.time, offset)
     }
@@ -486,6 +512,7 @@ impl PrimitiveDateTime {
     ///     1_546_300_800,
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `PrimitiveDateTime`."]
     pub const fn assume_utc(self) -> OffsetDateTime {
         self.assume_offset(UtcOffset::UTC)
     }
@@ -508,6 +535,7 @@ impl PrimitiveDateTime {
     ///     Some(datetime!(2019 - 11 - 26 18:30))
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `PrimitiveDateTime`."]
     pub const fn checked_add(self, duration: Duration) -> Option<Self> {
         let (date_adjustment, time) = self.time.adjusting_add(duration);
         let date = const_try_opt!(self.date.checked_add(duration));
@@ -538,6 +566,7 @@ impl PrimitiveDateTime {
     ///     Some(datetime!(2019 - 11 - 24 12:30))
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `PrimitiveDateTime`."]
     pub const fn checked_sub(self, duration: Duration) -> Option<Self> {
         let (date_adjustment, time) = self.time.adjusting_sub(duration);
         let date = const_try_opt!(self.date.checked_sub(duration));
@@ -574,6 +603,7 @@ impl PrimitiveDateTime {
     ///     datetime!(2019 - 11 - 26 18:30)
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `PrimitiveDateTime`."]
     pub const fn saturating_add(self, duration: Duration) -> Self {
         if let Some(datetime) = self.checked_add(duration) {
             datetime
@@ -604,6 +634,7 @@ impl PrimitiveDateTime {
     ///     datetime!(2019 - 11 - 24 12:30)
     /// );
     /// ```
+    #[must_use = "This method does not mutate the original `PrimitiveDateTime`."]
     pub const fn saturating_sub(self, duration: Duration) -> Self {
         if let Some(datetime) = self.checked_sub(duration) {
             datetime

--- a/time/src/time.rs
+++ b/time/src/time.rs
@@ -113,6 +113,7 @@ impl Time {
     /// Provides an u64 based representation **of the correct endianness**
     ///
     /// This representation can be used to do comparisons equality testing or hashing.
+    #[must_use = "This method only computes the returned value"]
     const fn as_u64(self) -> u64 {
         let nano_bytes = self.nanosecond.get().to_ne_bytes();
 
@@ -320,6 +321,7 @@ impl Time {
     /// assert_eq!(time!(0:00:00).as_hms(), (0, 0, 0));
     /// assert_eq!(time!(23:59:59).as_hms(), (23, 59, 59));
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn as_hms(self) -> (u8, u8, u8) {
         (self.hour.get(), self.minute.get(), self.second.get())
     }
@@ -331,6 +333,7 @@ impl Time {
     /// assert_eq!(time!(0:00:00).as_hms_milli(), (0, 0, 0, 0));
     /// assert_eq!(time!(23:59:59.999).as_hms_milli(), (23, 59, 59, 999));
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn as_hms_milli(self) -> (u8, u8, u8, u16) {
         (
             self.hour.get(),
@@ -350,6 +353,7 @@ impl Time {
     ///     (23, 59, 59, 999_999)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn as_hms_micro(self) -> (u8, u8, u8, u32) {
         (
             self.hour.get(),
@@ -369,6 +373,7 @@ impl Time {
     ///     (23, 59, 59, 999_999_999)
     /// );
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn as_hms_nano(self) -> (u8, u8, u8, u32) {
         (
             self.hour.get(),
@@ -393,6 +398,7 @@ impl Time {
     /// assert_eq!(time!(0:00:00).hour(), 0);
     /// assert_eq!(time!(23:59:59).hour(), 23);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn hour(self) -> u8 {
         self.hour.get()
     }
@@ -406,6 +412,7 @@ impl Time {
     /// assert_eq!(time!(0:00:00).minute(), 0);
     /// assert_eq!(time!(23:59:59).minute(), 59);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn minute(self) -> u8 {
         self.minute.get()
     }
@@ -419,6 +426,7 @@ impl Time {
     /// assert_eq!(time!(0:00:00).second(), 0);
     /// assert_eq!(time!(23:59:59).second(), 59);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn second(self) -> u8 {
         self.second.get()
     }
@@ -432,6 +440,7 @@ impl Time {
     /// assert_eq!(time!(0:00).millisecond(), 0);
     /// assert_eq!(time!(23:59:59.999).millisecond(), 999);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn millisecond(self) -> u16 {
         (self.nanosecond.get() / Nanosecond::per(Millisecond)) as _
     }
@@ -445,6 +454,7 @@ impl Time {
     /// assert_eq!(time!(0:00).microsecond(), 0);
     /// assert_eq!(time!(23:59:59.999_999).microsecond(), 999_999);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn microsecond(self) -> u32 {
         self.nanosecond.get() / Nanosecond::per(Microsecond) as u32
     }
@@ -458,6 +468,7 @@ impl Time {
     /// assert_eq!(time!(0:00).nanosecond(), 0);
     /// assert_eq!(time!(23:59:59.999_999_999).nanosecond(), 999_999_999);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn nanosecond(self) -> u32 {
         self.nanosecond.get()
     }

--- a/time/src/utc_offset.rs
+++ b/time/src/utc_offset.rs
@@ -217,6 +217,7 @@ impl UtcOffset {
     /// assert_eq!(offset!(+1:02:03).as_hms(), (1, 2, 3));
     /// assert_eq!(offset!(-1:02:03).as_hms(), (-1, -2, -3));
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn as_hms(self) -> (i8, i8, i8) {
         (self.hours.get(), self.minutes.get(), self.seconds.get())
     }
@@ -236,6 +237,7 @@ impl UtcOffset {
     /// assert_eq!(offset!(+1:02:03).whole_hours(), 1);
     /// assert_eq!(offset!(-1:02:03).whole_hours(), -1);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn whole_hours(self) -> i8 {
         self.hours.get()
     }
@@ -248,6 +250,7 @@ impl UtcOffset {
     /// assert_eq!(offset!(+1:02:03).whole_minutes(), 62);
     /// assert_eq!(offset!(-1:02:03).whole_minutes(), -62);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn whole_minutes(self) -> i16 {
         self.hours.get() as i16 * Minute::per(Hour) as i16 + self.minutes.get() as i16
     }
@@ -260,6 +263,7 @@ impl UtcOffset {
     /// assert_eq!(offset!(+1:02:03).minutes_past_hour(), 2);
     /// assert_eq!(offset!(-1:02:03).minutes_past_hour(), -2);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn minutes_past_hour(self) -> i8 {
         self.minutes.get()
     }
@@ -274,6 +278,7 @@ impl UtcOffset {
     /// ```
     // This may be useful for anyone manually implementing arithmetic, as it
     // would let them construct a `Duration` directly.
+    #[must_use = "This method only computes the returned value"]
     pub const fn whole_seconds(self) -> i32 {
         self.hours.get() as i32 * Second::per(Hour) as i32
             + self.minutes.get() as i32 * Second::per(Minute) as i32
@@ -288,6 +293,7 @@ impl UtcOffset {
     /// assert_eq!(offset!(+1:02:03).seconds_past_minute(), 3);
     /// assert_eq!(offset!(-1:02:03).seconds_past_minute(), -3);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn seconds_past_minute(self) -> i8 {
         self.seconds.get()
     }
@@ -303,6 +309,7 @@ impl UtcOffset {
     /// assert!(!offset!(-1:02:03).is_utc());
     /// assert!(offset!(UTC).is_utc());
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn is_utc(self) -> bool {
         self.hours.get() == 0 && self.minutes.get() == 0 && self.seconds.get() == 0
     }
@@ -315,6 +322,7 @@ impl UtcOffset {
     /// assert!(!offset!(-1:02:03).is_positive());
     /// assert!(!offset!(UTC).is_positive());
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn is_positive(self) -> bool {
         self.hours.get() > 0 || self.minutes.get() > 0 || self.seconds.get() > 0
     }
@@ -327,6 +335,7 @@ impl UtcOffset {
     /// assert!(offset!(-1:02:03).is_negative());
     /// assert!(!offset!(UTC).is_negative());
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn is_negative(self) -> bool {
         self.hours.get() < 0 || self.minutes.get() < 0 || self.seconds.get() < 0
     }

--- a/time/src/util.rs
+++ b/time/src/util.rs
@@ -20,6 +20,7 @@ pub(crate) enum DateAdjustment {
 /// # use time::{Month, util};
 /// assert_eq!(util::days_in_year_month(2020, Month::February), 29);
 /// ```
+#[must_use = "This method only computes the returned value"]
 pub const fn days_in_year_month(year: i32, month: Month) -> u8 {
     use Month::*;
     match month {
@@ -90,6 +91,7 @@ pub mod local_offset {
 
     /// Obtains the soundness of obtaining the local UTC offset. If it is [`Soundness::Unsound`],
     /// it is allowed to invoke undefined behavior when obtaining the local UTC offset.
+    #[must_use = "This method only computes the returned value"]
     pub fn get_soundness() -> Soundness {
         match LOCAL_OFFSET_IS_SOUND.load(Ordering::SeqCst) {
             false => Soundness::Unsound,

--- a/time/src/weekday.rs
+++ b/time/src/weekday.rs
@@ -37,6 +37,7 @@ impl Weekday {
     /// # use time::Weekday;
     /// assert_eq!(Weekday::Tuesday.previous(), Weekday::Monday);
     /// ```
+    #[must_use = "This method does not mutate the original `Weekday`."]
     pub const fn previous(self) -> Self {
         match self {
             Monday => Sunday,
@@ -55,6 +56,7 @@ impl Weekday {
     /// # use time::Weekday;
     /// assert_eq!(Weekday::Monday.next(), Weekday::Tuesday);
     /// ```
+    #[must_use = "This method does not mutate the original `Weekday`."]
     pub const fn next(self) -> Self {
         match self {
             Monday => Tuesday,
@@ -74,6 +76,7 @@ impl Weekday {
     /// assert_eq!(Weekday::Monday.nth_next(1), Weekday::Tuesday);
     /// assert_eq!(Weekday::Sunday.nth_next(10), Weekday::Wednesday);
     /// ```
+    #[must_use = "This method does not mutate the original `Weekday`."]
     pub const fn nth_next(self, n: u8) -> Self {
         match (self.number_days_from_monday() + n % 7) % 7 {
             0 => Monday,
@@ -96,6 +99,7 @@ impl Weekday {
     /// assert_eq!(Weekday::Monday.nth_prev(1), Weekday::Sunday);
     /// assert_eq!(Weekday::Sunday.nth_prev(10), Weekday::Thursday);
     /// ```
+    #[must_use = "This method does not mutate the original `Weekday`."]
     pub const fn nth_prev(self, n: u8) -> Self {
         match self.number_days_from_monday() as i8 - (n % 7) as i8 {
             1 | -6 => Tuesday,
@@ -118,6 +122,7 @@ impl Weekday {
     /// assert_eq!(Weekday::Monday.number_from_monday(), 1);
     /// ```
     #[doc(alias = "iso_weekday_number")]
+    #[must_use = "This method only computes the returned value"]
     pub const fn number_from_monday(self) -> u8 {
         self.number_days_from_monday() + 1
     }
@@ -128,6 +133,7 @@ impl Weekday {
     /// # use time::Weekday;
     /// assert_eq!(Weekday::Monday.number_from_sunday(), 2);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn number_from_sunday(self) -> u8 {
         self.number_days_from_sunday() + 1
     }
@@ -138,6 +144,7 @@ impl Weekday {
     /// # use time::Weekday;
     /// assert_eq!(Weekday::Monday.number_days_from_monday(), 0);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn number_days_from_monday(self) -> u8 {
         self as _
     }
@@ -148,6 +155,7 @@ impl Weekday {
     /// # use time::Weekday;
     /// assert_eq!(Weekday::Monday.number_days_from_sunday(), 1);
     /// ```
+    #[must_use = "This method only computes the returned value"]
     pub const fn number_days_from_sunday(self) -> u8 {
         match self {
             Monday => 1,


### PR DESCRIPTION
Annotate several public funtions that either don't modify their original value or only compute a value, except for ones returning `Result`.

Avoid no-op code such as:

    let odt = OffsetDateTime::now_utc();
    odt.saturating_add(Duration::SECOND);