### PR TITLE
Delete identity conversion in format_description::parse_owned

### DIFF
--- a/time/src/format_description/parse/mod.rs
+++ b/time/src/format_description/parse/mod.rs
@@ -80,9 +80,7 @@ pub fn parse_owned<const VERSION: usize>(
     let mut lexed = lexer::lex::<VERSION>(s.as_bytes());
     let ast = ast::parse::<_, VERSION>(&mut lexed);
     let format_items = format_item::parse(ast);
-    let items = format_items
-        .map(|res| res.map(Into::into))
-        .collect::<Result<Box<_>, _>>()?;
+    let items = format_items.collect::<Result<Box<_>, _>>()?;
     Ok(items.into())
 }
 


### PR DESCRIPTION
We have `format_items: impl Iterator<Item = Result<Item<'_>, Error>>` and `items: Box<[Item<'_>]>`.

The `Into::into` on the deleted line is resolving to `impl<T> From<T> for T` with T=`Item` which is not load-bearing.

The `into` on the line after this is `impl From<Box<[Item<'_>]>> for OwnedFormatItem`.