### PR TITLE
Fix type annotation for collection in parse_owned function

### DIFF
--- a/time/src/format_description/parse/mod.rs
+++ b/time/src/format_description/parse/mod.rs
@@ -80,7 +80,7 @@ pub fn parse_owned<const VERSION: usize>(
     let mut lexed = lexer::lex::<VERSION>(s.as_bytes());
     let ast = ast::parse::<_, VERSION>(&mut lexed);
     let format_items = format_item::parse(ast);
-    let items = format_items.collect::<Result<Box<_>, _>>()?;
+    let items: Box<_> = format_items.collect::<Result<Box<_>, _>>()?;
     Ok(items.into())
 }
 


### PR DESCRIPTION
    Explicitly annotate the type of items collected from format_items to resolve
    compiler error E0282. The type Box<_> ensures correct inference of the boxed
    collection type. This resolves issues encountered during compilation with
    Ferrocene.

    Closes: #689