### PR TITLE
Added an explicit type to items variable

### DIFF
--- a/time/src/format_description/parse/mod.rs
+++ b/time/src/format_description/parse/mod.rs
@@ -80,7 +80,7 @@ pub fn parse_owned<const VERSION: usize>(
     let mut lexed = lexer::lex::<VERSION>(s.as_bytes());
     let ast = ast::parse::<_, VERSION>(&mut lexed);
     let format_items = format_item::parse(ast);
-    let items = format_items.collect::<Result<Box<_>, _>>()?;
+    let items: Box<[format_item::Item]> = format_items.collect::<Result<Box<_>, _>>()?;
     Ok(items.into())
 }
 


### PR DESCRIPTION
The app I've been building for months has randomly started throwing this error: "error[E0282]: type annotations needed for `Box<_>`". I don't use this Crate directly and haven't updated any that I do use in a couple of weeks, so I'm not sure why the Rust compiler doesn't like this syntax now.

![image](https://github.com/user-attachments/assets/e0a1ee72-cfbe-43d2-a7d9-7c31b01bc154)
