### PR TITLE
UTC_OFFSET_FORMAT: use const blocks around function calls

### DIFF
--- a/time/src/serde/mod.rs
+++ b/time/src/serde/mod.rs
@@ -404,22 +404,27 @@ impl<'a> Deserialize<'a> for Time {
 // endregion Time
 
 // region: UtcOffset
+// FIXME: turn these constants into `const { ... }` blocks once we can depend on Rust 1.79.
+#[cfg(feature = "parsing")]
+const UTC_OFFSET_HOUR: modifier::OffsetHour = {
+    let mut m = modifier::OffsetHour::default();
+    m.sign_is_mandatory = true;
+    m
+};
+#[cfg(feature = "parsing")]
+const UTC_OFFSET_MINUTE: modifier::OffsetMinute = modifier::OffsetMinute::default();
+#[cfg(feature = "parsing")]
+const UTC_OFFSET_SECOND: modifier::OffsetSecond = modifier::OffsetSecond::default();
 /// The format used when serializing and deserializing a human-readable `UtcOffset`.
 #[cfg(feature = "parsing")]
 const UTC_OFFSET_FORMAT: &[BorrowedFormatItem<'_>] = &[
-    BorrowedFormatItem::Component(Component::OffsetHour({
-        let mut m = modifier::OffsetHour::default();
-        m.sign_is_mandatory = true;
-        m
-    })),
+    BorrowedFormatItem::Component(Component::OffsetHour(UTC_OFFSET_HOUR)),
     BorrowedFormatItem::Optional(&BorrowedFormatItem::Compound(&[
         BorrowedFormatItem::Literal(b":"),
-        BorrowedFormatItem::Component(Component::OffsetMinute(modifier::OffsetMinute::default())),
+        BorrowedFormatItem::Component(Component::OffsetMinute(UTC_OFFSET_MINUTE)),
         BorrowedFormatItem::Optional(&BorrowedFormatItem::Compound(&[
             BorrowedFormatItem::Literal(b":"),
-            BorrowedFormatItem::Component(Component::OffsetSecond(
-                modifier::OffsetSecond::default(),
-            )),
+            BorrowedFormatItem::Component(Component::OffsetSecond(UTC_OFFSET_SECOND)),
         ])),
     ])),
 ];


### PR DESCRIPTION
Implicit promotion (where `&expr` terms implicitly create a new constant with value `expr` and a borrow with lifetime `'static` to such a constant) has a long and [troubled history](https://github.com/rust-lang/rust/issues/80619). Right now we are in a state that's at least reasonably well-behaved, but it does make for some rather strange behaviors, as is tracked in https://github.com/rust-lang/rust/issues/124328. I wanted to do a crater experiment to see just how much code out there relies on this, by making rustc do longer do promotion of function calls, and it turns out not even cargo builds any more then. :joy: 

The crate that failed to build is time. So I wonder if it would be okay to patch time to make it work under this more strict, more sane promotion regime. The main point in the new regime is to use explicit `const { ... }` blocks to make things into constants, instead of doing that implicitly. So here we wrap all function calls in `const` blocks, so that the entire outer expression is just a bunch of array constructors, enum constructors, `&`, and consts -- which is trivially promotable.

Landing this will raise the MSRV to 1.79. I realize it's too early to do that under your MSRV policy. 1.81 will be released tomorrow so then it would be covered by the policy, but I'm also completely fine with delaying this until later.  I'm in no rush here. :)