### PR TITLE
Make the date_time method on struct DateTimeOffset public

### DIFF
--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -427,7 +427,7 @@ impl OffsetDateTime {
     }
 
     /// Get the [`PrimitiveDateTime`] in the stored offset.
-    /// 
+    ///
     /// ```rust
     /// # use time::PrimitiveDateTime;
     /// # use time_macros::{date, datetime, time};

--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -427,7 +427,17 @@ impl OffsetDateTime {
     }
 
     /// Get the [`PrimitiveDateTime`] in the stored offset.
-    const fn date_time(self) -> PrimitiveDateTime {
+    /// 
+    /// ```rust
+    /// # use time::PrimitiveDateTime;
+    /// # use time_macros::{date, datetime, time};
+    /// assert_eq!(datetime!(2019-01-01 0:00 UTC).date_time(), datetime!(2019-01-01 0:00));
+    /// assert_eq!(
+    ///    datetime!(2019-01-01 0:00 +1).date_time(),
+    ///     PrimitiveDateTime::new(date!(2019-01-01), time!(0:00))
+    /// );
+    /// ```
+    pub const fn date_time(self) -> PrimitiveDateTime {
         self.local_date_time
     }
 


### PR DESCRIPTION
I don't know what were the motivations behind it being private (if any)