### PR TITLE
Fix large-dates ambiguity by creating a repr:four modifier

### DIFF
--- a/time-macros/src/format_description/format_item.rs
+++ b/time-macros/src/format_description/format_item.rs
@@ -425,6 +425,7 @@ modifier! {
     enum YearRepr {
         #[default]
         Full = b"full",
+        Four = b"four",
         LastTwo = b"last_two",
     }
 }

--- a/time-macros/src/format_description/public/modifier.rs
+++ b/time-macros/src/format_description/public/modifier.rs
@@ -131,6 +131,7 @@ to_tokens! {
 to_tokens! {
     pub(crate) enum YearRepr {
         Full,
+        Four,
         LastTwo,
     }
 }

--- a/time/src/format_description/modifier.rs
+++ b/time/src/format_description/modifier.rs
@@ -101,6 +101,8 @@ pub struct WeekNumber {
 pub enum YearRepr {
     /// The full value of the year.
     Full,
+    /// Standard 4 digit format, to be used when `large-dates` feature is enabled
+    Four,
     /// Only the last two digits of the year.
     LastTwo,
 }

--- a/time/src/format_description/parse/format_item.rs
+++ b/time/src/format_description/parse/format_item.rs
@@ -522,6 +522,7 @@ modifier! {
         #[default]
         Full = b"full",
         LastTwo = b"last_two",
+        Four = b"four",
     }
 }
 

--- a/time/src/formatting/mod.rs
+++ b/time/src/formatting/mod.rs
@@ -304,18 +304,24 @@ fn fmt_year(
     };
     let value = match repr {
         modifier::YearRepr::Full => full_year,
+        modifier::YearRepr::Four => (full_year % 10000).abs(),
         modifier::YearRepr::LastTwo => (full_year % 100).abs(),
     };
     let format_number = match repr {
+
         #[cfg(feature = "large-dates")]
         modifier::YearRepr::Full if value.abs() >= 100_000 => format_number::<6>,
         #[cfg(feature = "large-dates")]
+        modifier::YearRepr::Four if value.abs() >= 1_000 => format_number::<4>,
+        #[cfg(feature = "large-dates")]
         modifier::YearRepr::Full if value.abs() >= 10_000 => format_number::<5>,
+
         modifier::YearRepr::Full => format_number::<4>,
+        modifier::YearRepr::Four => format_number::<4>,
         modifier::YearRepr::LastTwo => format_number::<2>,
     };
     let mut bytes = 0;
-    if repr != modifier::YearRepr::LastTwo {
+    if repr == modifier::YearRepr::Full {
         if full_year < 0 {
             bytes += write(output, b"-")?;
         } else if sign_is_mandatory || cfg!(feature = "large-dates") && full_year >= 10_000 {

--- a/time/src/parsing/component.rs
+++ b/time/src/parsing/component.rs
@@ -32,6 +32,9 @@ pub(crate) fn parse_year(input: &[u8], modifiers: modifier::Year) -> Option<Pars
                 _ => Some(ParsedItem(input, year.cast_signed())),
             }
         }
+        modifier::YearRepr::Four => Some (
+            exactly_n_digits_padded::<4, u32>(modifiers.padding)(input)?.map(|v| v.cast_signed()),
+        ),
         modifier::YearRepr::LastTwo => Some(
             exactly_n_digits_padded::<2, u32>(modifiers.padding)(input)?.map(|v| v.cast_signed()),
         ),

--- a/time/src/parsing/parsed.rs
+++ b/time/src/parsing/parsed.rs
@@ -6,7 +6,7 @@ use deranged::{
     OptionRangedI128, OptionRangedI32, OptionRangedI8, OptionRangedU16, OptionRangedU32,
     OptionRangedU8, RangedI128, RangedI32, RangedI8, RangedU16, RangedU32, RangedU8,
 };
-use num_conv::prelude::*;
+use num_conv::{prelude::*, CastUnsigned, Truncate};
 
 use crate::convert::{Day, Hour, Minute, Nanosecond, Second};
 use crate::date::{MAX_YEAR, MIN_YEAR};
@@ -296,10 +296,16 @@ impl Parsed {
                     parse_year(input, modifiers).ok_or(InvalidComponent("year"))?;
                 match (modifiers.iso_week_based, modifiers.repr) {
                     (false, modifier::YearRepr::Full) => self.set_year(value),
+                    (false, modifier::YearRepr::Four) => {
+                        self.set_year(value)
+                    }
                     (false, modifier::YearRepr::LastTwo) => {
                         self.set_year_last_two(value.cast_unsigned().truncate())
                     }
                     (true, modifier::YearRepr::Full) => self.set_iso_year(value),
+                    (true, modifier::YearRepr::Four) => {
+                        self.set_iso_year(value)
+                    }
                     (true, modifier::YearRepr::LastTwo) => {
                         self.set_iso_year_last_two(value.cast_unsigned().truncate())
                     }


### PR DESCRIPTION
This is linked to #683 
Tests have still to be written for this PR, thus it's not ready to be merged, but I opened this pull request anyways so that someone else might write them.
Namings and comments might also need to be discussed.