### PR TITLE
Truncate milliseconds to i64 before serializing.

### DIFF
--- a/time/src/serde/timestamp/milliseconds_i64.rs
+++ b/time/src/serde/timestamp/milliseconds_i64.rs
@@ -1,4 +1,5 @@
-//! Treat an [`OffsetDateTime`] as a [Unix timestamp] for the purposes of serde.
+//! Treat an [`OffsetDateTime`] as a [Unix timestamp] with milliseconds for
+//! the purposes of serde.
 //!
 //! Use this module in combination with serde's [`#[with]`][with] attribute.
 //!
@@ -7,31 +8,29 @@
 //! [Unix timestamp]: https://en.wikipedia.org/wiki/Unix_time
 //! [with]: https://serde.rs/field-attrs.html#with
 
-pub mod microseconds;
-pub mod milliseconds;
-pub mod milliseconds_i64;
-pub mod nanoseconds;
-
+use num_conv::prelude::*;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::OffsetDateTime;
 
-/// Serialize an `OffsetDateTime` as its Unix timestamp
+/// Serialize an `OffsetDateTime` as its Unix timestamp with milliseconds
 pub fn serialize<S: Serializer>(
     datetime: &OffsetDateTime,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    datetime.unix_timestamp().serialize(serializer)
+    let timestamp = (datetime.unix_timestamp_nanos() / 1_000_000).truncate::<i64>();
+    timestamp.serialize(serializer)
 }
 
-/// Deserialize an `OffsetDateTime` from its Unix timestamp
+/// Deserialize an `OffsetDateTime` from its Unix timestamp with milliseconds
 pub fn deserialize<'a, D: Deserializer<'a>>(deserializer: D) -> Result<OffsetDateTime, D::Error> {
-    OffsetDateTime::from_unix_timestamp(<_>::deserialize(deserializer)?)
+    let value: i64 = <_>::deserialize(deserializer)?;
+    OffsetDateTime::from_unix_timestamp_nanos(value.extend::<i128>() * 1_000_000)
         .map_err(|err| de::Error::invalid_value(de::Unexpected::Signed(err.value), &err))
 }
 
-/// Treat an `Option<OffsetDateTime>` as a [Unix timestamp] for the purposes of
-/// serde.
+/// Treat an `Option<OffsetDateTime>` as a [Unix timestamp] with milliseconds
+/// for the purposes of serde.
 ///
 /// Use this module in combination with serde's [`#[with]`][with] attribute.
 ///
@@ -43,22 +42,24 @@ pub mod option {
     #[allow(clippy::wildcard_imports)]
     use super::*;
 
-    /// Serialize an `Option<OffsetDateTime>` as its Unix timestamp
+    /// Serialize an `Option<OffsetDateTime>` as its Unix timestamp with milliseconds
     pub fn serialize<S: Serializer>(
         option: &Option<OffsetDateTime>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         option
-            .map(OffsetDateTime::unix_timestamp)
+            .map(|timestamp| (timestamp.unix_timestamp_nanos() / 1_000_000).truncate::<i64>())
             .serialize(serializer)
     }
 
-    /// Deserialize an `Option<OffsetDateTime>` from its Unix timestamp
+    /// Deserialize an `Option<OffsetDateTime>` from its Unix timestamp with milliseconds
     pub fn deserialize<'a, D: Deserializer<'a>>(
         deserializer: D,
     ) -> Result<Option<OffsetDateTime>, D::Error> {
         Option::deserialize(deserializer)?
-            .map(OffsetDateTime::from_unix_timestamp)
+            .map(|value: i64| {
+                OffsetDateTime::from_unix_timestamp_nanos(value.extend::<i128>() * 1_000_000)
+            })
             .transpose()
             .map_err(|err| de::Error::invalid_value(de::Unexpected::Signed(err.value), &err))
     }


### PR DESCRIPTION
A fix for #721 