### PR TITLE
Implement trait `ToSql` for `Date` and `Time`

### DIFF
--- a/time/src/time.rs
+++ b/time/src/time.rs
@@ -12,6 +12,7 @@ use deranged::{RangedU32, RangedU8};
 use num_conv::prelude::*;
 use powerfmt::ext::FormatterExt;
 use powerfmt::smart_display::{self, FormatterOptions, Metadata, SmartDisplay};
+use rusqlite::ToSql;
 
 use crate::convert::*;
 #[cfg(feature = "formatting")]
@@ -833,6 +834,13 @@ impl fmt::Debug for Time {
     }
 }
 // endregion formatting & parsing
+
+impl ToSql for Time {
+    fn to_sql(&self) -> Result<ToSqlOutput<'_> {
+        formatted_time = format!("{self.hour}:{self.minute}:{self.second}:{self.nanosecond}");
+        return ToSqlOutput::Owned(Value::Text(formatted_time));
+    }
+}
 
 // region: trait impls
 impl Add<Duration> for Time {


### PR DESCRIPTION
I have implemented a `ToSql` that can be used in `rusqlite` for SQL data. This can be implemented like this:
```rust
conn.execute("INSERT INTO users (name, age, date_of_birth) VALUES (?, ?, ?)", (person.name, person.age, person.date_of_birth))
```
And also `Time`, as:
```rust
conn.execute("INSERT INTO items (time) VALUES (?)", (item.time))
```