### PR TITLE
Allow `clippy::ref_option` lint for `serde::format_description`.

### DIFF
--- a/time-macros/src/quote.rs
+++ b/time-macros/src/quote.rs
@@ -101,6 +101,20 @@ macro_rules! quote_inner {
         quote_inner!($ts $($tail)*);
     };
 
+    // Attribute
+    ($ts:ident #[$($inner:tt)*] $($tail:tt)*) => {
+        $ts.extend([
+            ::proc_macro::TokenTree::from(
+                ::proc_macro::Punct::new('#', ::proc_macro::Spacing::Alone)
+            ),
+            ::proc_macro::TokenTree::Group(::proc_macro::Group::new(
+                ::proc_macro::Delimiter::Bracket,
+                quote!($($inner)*)
+            )),
+        ]);
+        quote_inner!($ts $($tail)*);
+    };
+
     // Groups
     ($ts:ident ($($inner:tt)*) $($tail:tt)*) => {
         $ts.extend([::proc_macro::TokenTree::Group(::proc_macro::Group::new(

--- a/time-macros/src/serde_format_description.rs
+++ b/time-macros/src/serde_format_description.rs
@@ -103,6 +103,7 @@ pub(crate) fn build(
 
     let serialize_option = if cfg!(feature = "formatting") {
         quote! {
+            #[allow(clippy::ref_option)]
             pub fn serialize<S: ::serde::Serializer>(
                 option: &Option<__TimeSerdeType>,
                 serializer: S,


### PR DESCRIPTION
`time::serde::format_description!` generates a serialize function that takes `&Option<T>`, which is picked up by the `clippy::ref_option` lint for an end user.

```
error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
  |
  | time::serde::format_description!(iso8601, Date, "[year]-[month]-[day]");
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ref_option
```