### PR TITLE
Update rstest dev-dependency from 0.23 to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,19 +457,18 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rstest"
-version = "0.23.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.23.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ powerfmt = { version = "0.2.0", default-features = false }
 quickcheck = { version = "1.0.3", default-features = false }
 quickcheck_macros = "1.0.0"
 rand = { version = "0.8.4", default-features = false }
-rstest = { version = "0.23.0", default-features = false }
+rstest = { version = "0.26.0", default-features = false }
 rstest_reuse = "0.7.0"
 # ^1.0.184 due to serde-rs/serde#2538
 serde = { version = "1.0.184", default-features = false }


### PR DESCRIPTION
I don’t see any changes that should affect this project between these two versions (https://github.com/la10736/rstest/blob/v0.26.1/CHANGELOG.md), and I confirmed that `cargo test -p time --all-features` still passes.

(I’m patching the dev-dependency in Fedora’s [`rust-time` package](https://src.fedoraproject.org/rpms/rust-time) to remove one of the dependencies on our [`rust-rstest0.23` compat package](https://src.fedoraproject.org/rpms/rust-rstest0.23) so we don’t have to maintain it indefinitely, and it’s our [policy](https://docs.fedoraproject.org/en-US/packaging-guidelines/#_all_patches_should_have_an_upstream_bug_link_or_comment) to offer patches upstream. See https://github.com/time-rs/time/pull/716 for more discussion on motivation, although this PR should be more straightforward since it doesn’t affect MSRV.)