### PR TITLE
Add `#[inline]` to `Time::from_hms` for performance

### DIFF
--- a/time/src/time.rs
+++ b/time/src/time.rs
@@ -194,6 +194,7 @@ impl Time {
     /// assert!(Time::from_hms(0, 60, 0).is_err()); // 60 isn't a valid minute.
     /// assert!(Time::from_hms(0, 0, 60).is_err()); // 60 isn't a valid second.
     /// ```
+    #[inline]
     pub const fn from_hms(hour: u8, minute: u8, second: u8) -> Result<Self, error::ComponentRange> {
         Ok(Self::from_hms_nanos_ranged(
             ensure_ranged!(Hours: hour),


### PR DESCRIPTION
This makes [decoding `Time` in `bitcode`](https://github.com/SoftbearStudios/bitcode/pull/43) 6X faster.

It works since `bitcode` checks the range of integers up front, all at once, using vector instructions, and then uses `unreachable_unchecked` right before calling `Time::from_hms` to communicate that fact to `rustc`. This only works if `Time::from_hms` is inlinable.