### PR TITLE
Fractional Time Component Representations

### DIFF
--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -884,6 +884,25 @@ impl OffsetDateTime {
         self.time().hour()
     }
 
+    /// Get the fractional clock hour (i.e. 1:30 -> 1.5).
+    ///
+    /// The returned value will always be in the range `0.0..24.0`.
+    ///
+    /// ```rust
+    /// # use time_macros::{datetime, offset};
+    /// assert_eq!(datetime!(2019-01-01 1:30:00 UTC).fractional_hour(), 1.5);
+    /// assert_eq!(
+    ///     datetime!(2019-01-01 23:30:45 UTC)
+    ///         .to_offset(offset!(-2))
+    ///         .fractional_hour(),
+    ///     21.5125,
+    /// );
+    /// ```
+    #[inline]
+    pub const fn fractional_hour(self) -> f32 {
+        self.time().fractional_hour()
+    }
+
     /// Get the minute within the hour in the stored offset.
     ///
     /// The returned value will always be in the range `0..60`.
@@ -903,6 +922,25 @@ impl OffsetDateTime {
         self.time().minute()
     }
 
+    /// Get the fractional minute within the hour (i.e. 1:30:30 -> 30.5).
+    ///
+    /// The returned value will always be in the range `0.0..60.0`.
+    ///
+    /// ```rust
+    /// # use time_macros::{datetime, offset};
+    /// assert_eq!(datetime!(2019-01-01 1:30:30 UTC).fractional_minute(), 30.5);
+    /// assert_eq!(
+    ///     datetime!(2019-01-01 23:15:45 UTC)
+    ///         .to_offset(offset!(+0:30))
+    ///         .fractional_minute(),
+    ///     45.75,
+    /// );
+    /// ```
+    #[inline]
+    pub const fn fractional_minute(self) -> f32 {
+        self.time().fractional_minute()
+    }
+
     /// Get the second within the minute in the stored offset.
     ///
     /// The returned value will always be in the range `0..60`.
@@ -920,6 +958,25 @@ impl OffsetDateTime {
     #[inline]
     pub const fn second(self) -> u8 {
         self.time().second()
+    }
+
+    /// Get the fractional second within the hour (i.e. 1:30:30 -> 30.5).
+    ///
+    /// The returned value will always be in the range `0.0..60.0`.
+    ///
+    /// ```rust
+    /// # use time_macros::{datetime, offset};
+    /// assert_eq!(datetime!(2019-01-01 1:00:30.550 UTC).fractional_second(), 30.55);
+    /// assert_eq!(
+    ///     datetime!(2019-01-01 23:00:15.500 UTC)
+    ///         .to_offset(offset!(+0:00:30))
+    ///         .fractional_second(),
+    ///     45.5,
+    /// );
+    /// ```
+    #[inline]
+    pub const fn fractional_second(self) -> f32 {
+        self.time().fractional_second()
     }
 
     // Because a `UtcOffset` is limited in resolution to one second, any subsecond value will not

--- a/time/src/primitive_date_time.rs
+++ b/time/src/primitive_date_time.rs
@@ -455,6 +455,20 @@ impl PrimitiveDateTime {
         self.time().hour()
     }
 
+    /// Get the fractional clock hour (i.e. 1:30 -> 1.5).
+    ///
+    /// The returned value will always be in the range `0.0..24.0`.
+    ///
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(datetime!(2019-01-01 1:30:00).fractional_hour(), 1.5);
+    /// assert_eq!(datetime!(2019-01-01 23:00:00).fractional_hour(), 23.0);
+    /// ```
+    #[inline]
+    pub const fn fractional_hour(self) -> f32 {
+        self.time.fractional_hour()
+    }
+
     /// Get the minute within the hour.
     ///
     /// The returned value will always be in the range `0..60`.
@@ -469,6 +483,20 @@ impl PrimitiveDateTime {
         self.time().minute()
     }
 
+    /// Get the fractional minute within the hour (i.e. 1:30:30 -> 30.5).
+    ///
+    /// The returned value will always be in the range `0.0..60.0`.
+    ///
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(datetime!(2019-01-01 1:30:30).fractional_minute(), 30.5);
+    /// assert_eq!(datetime!(2019-01-01 23:00:30.600).fractional_minute(), 0.51);
+    /// ```
+    #[inline]
+    pub const fn fractional_minute(self) -> f32 {
+        self.time.fractional_minute()
+    }
+
     /// Get the second within the minute.
     ///
     /// The returned value will always be in the range `0..60`.
@@ -481,6 +509,20 @@ impl PrimitiveDateTime {
     #[inline]
     pub const fn second(self) -> u8 {
         self.time().second()
+    }
+
+    /// Get the fractional second within the minute (i.e. 1:00:10.500 -> 10.5).
+    ///
+    /// The returned value will always be in the range `0.0..60.0`.
+    ///
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(datetime!(2019-01-01 1:00:00.500).fractional_second(), 0.5);
+    /// assert_eq!(datetime!(2019-01-01 23:00:30.500).fractional_second(), 30.5);
+    /// ```
+    #[inline]
+    pub const fn fractional_second(self) -> f32 {
+        self.time.fractional_second()
     }
 
     /// Get the milliseconds within the second.

--- a/time/src/time.rs
+++ b/time/src/time.rs
@@ -384,6 +384,23 @@ impl Time {
         self.hour.get()
     }
 
+    /// Get the fractional clock hour (i.e. 1:30 -> 1.5).
+    ///
+    /// The returned value will always be in the range `0.0..24.0`.
+    ///
+    /// ```rust
+    /// # use time_macros::time;
+    /// assert_eq!(time!(1:30:00).fractional_hour(), 1.5);
+    /// assert_eq!(time!(23:00:00).fractional_hour(), 23.0);
+    /// ```
+    #[inline]
+    pub const fn fractional_hour(self) -> f32 {
+        self.hour.get() as f32
+            + (self.minute.get() as f32 / 60.0)
+            + (self.second.get() as f32 / (60.0 * 60.0))
+            + (self.nanosecond.get() as f32 / (60.0 * 60.0 * 1.0e9))
+    }
+
     /// Get the minute within the hour.
     ///
     /// The returned value will always be in the range `0..60`.
@@ -398,6 +415,22 @@ impl Time {
         self.minute.get()
     }
 
+    /// Get the fractional minute within the hour (i.e. 1:30:30 -> 30.5).
+    ///
+    /// The returned value will always be in the range `0.0..60.0`.
+    ///
+    /// ```rust
+    /// # use time_macros::time;
+    /// assert_eq!(time!(1:30:30).fractional_minute(), 30.5);
+    /// assert_eq!(time!(23:00:30.600).fractional_minute(), 0.51);
+    /// ```
+    #[inline]
+    pub const fn fractional_minute(self) -> f32 {
+        self.minute.get() as f32
+            + (self.second.get() as f32 / (60.0))
+            + (self.nanosecond.get() as f32 / (60.0 * 1.0e9))
+    }
+
     /// Get the second within the minute.
     ///
     /// The returned value will always be in the range `0..60`.
@@ -410,6 +443,20 @@ impl Time {
     #[inline]
     pub const fn second(self) -> u8 {
         self.second.get()
+    }
+
+    /// Get the fractional second within the minute (i.e. 1:00:10.500 -> 10.5).
+    ///
+    /// The returned value will always be in the range `0.0..60.0`.
+    ///
+    /// ```rust
+    /// # use time_macros::time;
+    /// assert_eq!(time!(1:00:00.500).fractional_second(), 0.5);
+    /// assert_eq!(time!(23:00:30.500).fractional_second(), 30.5);
+    /// ```
+    #[inline]
+    pub const fn fractional_second(self) -> f32 {
+        self.second.get() as f32 + (self.nanosecond.get() as f32 / 1.0e9)
     }
 
     /// Get the milliseconds within the second.


### PR DESCRIPTION
This pull request adds helper methods on `Time`, `PrimitiveDateTime`, and `OffsetDateTime` to obtain fractional time component representations for hours, minutes, and seconds.

For example, `time!(01:30:00.0000).fractional_hour() == 1.5`, `time!(01:30:30.0000).fractional_hour() == 30.5`, and so on. 