### PR TITLE
add `to_primitive` for OffsetDateTime

### DIFF
--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -404,6 +404,21 @@ impl OffsetDateTime {
         )
     }
 
+    /// Convert the `OffsetDateTime` to a `PrimitiveDateTime` in whatever offset
+    /// it happens to be.
+    ///
+    /// ```rust
+    /// # use time_macros::datetime;
+    /// assert_eq!(
+    ///     datetime!(2000-01-01 0:00 UTC).to_primitive(),
+    ///     datetime!(2000-01-01 0:00),
+    /// );
+    /// ```
+    #[inline]
+    pub const fn to_primitive(self) -> PrimitiveDateTime {
+        PrimitiveDateTime::new(self.date(), self.time())
+    }
+
     /// Create an `OffsetDateTime` from the provided Unix timestamp. Calling `.offset()` on the
     /// resulting value is guaranteed to return UTC.
     ///


### PR DESCRIPTION
When working with my legacy database at work while trying to have a sensible internal API for dealing with times I need to downcast `OffsetDateTime`s to `PrimitiveDateTime`s constantly. I was very surprised to find this isn't built-in since it is simple but needlessly verbose to achieve with the existing API. I cannot express how much nicer my code will become with this method available. Being able to go from wrapping it in a free function to a method call would be lovely.