### PR TITLE
typo?, in param of UtcDateTime::replace_minute / replace_second

### DIFF
--- a/time/src/utc_date_time.rs
+++ b/time/src/utc_date_time.rs
@@ -1011,12 +1011,9 @@ impl UtcDateTime {
     /// ```
     #[must_use = "This method does not mutate the original `UtcDateTime`."]
     #[inline]
-    pub const fn replace_minute(
-        self,
-        sunday_based_week: u8,
-    ) -> Result<Self, error::ComponentRange> {
+    pub const fn replace_minute(self, minute: u8) -> Result<Self, error::ComponentRange> {
         Ok(Self::from_primitive(const_try!(
-            self.inner.replace_minute(sunday_based_week)
+            self.inner.replace_minute(minute)
         )))
     }
 
@@ -1047,12 +1044,9 @@ impl UtcDateTime {
     /// ```
     #[must_use = "This method does not mutate the original `UtcDateTime`."]
     #[inline]
-    pub const fn replace_second(
-        self,
-        monday_based_week: u8,
-    ) -> Result<Self, error::ComponentRange> {
+    pub const fn replace_second(self, second: u8) -> Result<Self, error::ComponentRange> {
         Ok(Self::from_primitive(const_try!(
-            self.inner.replace_second(monday_based_week)
+            self.inner.replace_second(second)
         )))
     }
 


### PR DESCRIPTION
stumbled on this when generating some glue code from source.

but not sure about it since it's like that for 2 years now.

searched issue/pr and found nothing related.