### PR TITLE
fix: avoid associated type projection in modifier! From impl

### DIFF
--- a/time/src/format_description/parse/format_item.rs
+++ b/time/src/format_description/parse/format_item.rs
@@ -700,7 +700,7 @@ macro_rules! modifier {
         }
 
         $(#[expect($expect_inner)])?
-        impl From<$name> for <$name as ModifierValue>::Type {
+        impl From<$name> for target_ty!($name $($target_ty)?) {
             #[inline]
             fn from(modifier: $name) -> Self {
                 match modifier {


### PR DESCRIPTION
The modifier! macro generates From<> using the associated type projection <ModifierValue>::Type, which confuses the new trait solver (next-solver=coherence, default since Rust 1.84) during coherence checking. The solver cannot normalize the projection, causing false positive E0119 conflicts with blanket From<T> impls in downstream crates.

Replace the projection with the concrete type via target_ty!, which the macro already uses for ModifierValue::Type. The generated code is identical, but avoids the opaque projection.