### PR TITLE
fix: resolve E0119 trait coherence error in rustc >= 1.95.0

### DIFF
--- a/time-macros/src/format_description/format_item.rs
+++ b/time-macros/src/format_description/format_item.rs
@@ -737,7 +737,7 @@ macro_rules! modifier {
                 type Type = target_ty!($name $($target_ty)?);
             }
 
-            impl From<$name> for <$name as ModifierValue>::Type {
+            impl From<$name> for target_ty!($name $($target_ty)?) {
                 #[inline]
                 fn from(modifier: $name) -> Self {
                     match modifier {

--- a/time/src/format_description/parse/format_item.rs
+++ b/time/src/format_description/parse/format_item.rs
@@ -700,7 +700,7 @@ macro_rules! modifier {
         }
 
         $(#[expect($expect_inner)])?
-        impl From<$name> for <$name as ModifierValue>::Type {
+        impl From<$name> for target_ty!($name $($target_ty)?) {
             #[inline]
             fn from(modifier: $name) -> Self {
                 match modifier {


### PR DESCRIPTION
Replaced the use of the associated type `< as ModifierValue>::Type` with the concrete type via `target_ty!( ?)` in the generated `From` trait implementations inside `format_item.rs`.

This prevents trait coherence conflicts (E0119) in newer versions of the Rust compiler (1.95.0+), which are stricter about blanket implementations and associated types overlapping with downstream generic implementations (such as in `cookie` or `actix-web`).