### PR TITLE
Restore lexer depth on the unclosed-bracket error path

### DIFF
--- a/time/src/format_description/parse/lexer_ast.rs
+++ b/time/src/format_description/parse/lexer_ast.rs
@@ -716,6 +716,13 @@ impl<'input, const VERSION: u8, const OWNED: bool> Lexer<'input, VERSION, OWNED>
 
         let Some(closing_bracket) = self.consume_closing_bracket() else {
             hint::cold_path();
+            // The opening bracket consumed above incremented `self.depth` but was never matched by
+            // a closing bracket. `consume_component` swallows this error and then re-derives the
+            // outer "unclosed bracket" error itself, so we must leave `depth` (and therefore
+            // `context()`) exactly as it was on entry; otherwise the subsequent
+            // `debug_assert!(self.context().is_component())` calls (e.g. in `consume_whitespace`)
+            // are tripped on inputs such as `[a[` or `[hour[`.
+            self.depth -= 1;
             return Err(Error {
                 _inner: unused(opening_bracket.error("unclosed bracket")),
                 public: InvalidFormatDescription::UnclosedOpeningBracket {

--- a/time/tests/integration/parse_format_description.rs
+++ b/time/tests/integration/parse_format_description.rs
@@ -862,6 +862,11 @@ fn nested_v2_error_missing_component_name(
 #[case("[first []", 0)]
 #[case("[optional [", 0)]
 #[case("[optional [[year", 0)]
+// A component header immediately followed by an unclosed nested bracket (no whitespace, so the
+// nested attempt is swallowed and the lexer continues with the outer component). These previously
+// tripped `debug_assert!(self.context().is_component())` instead of reporting the unclosed bracket.
+#[case("[a[", 0)]
+#[case("[hour[", 0)]
 fn nested_v2_error_unclosed(#[case] format_description: &str, #[case] expected_index: usize) {
     assert!(matches!(
         format_description::parse_owned::<2>(format_description),


### PR DESCRIPTION
Parsing a format description with an unclosed nested bracket (`[a[`, `[optional [`, `[hour[`) panics in debug builds via `debug_assert!(self.context().is_component())`, reached through `consume_whitespace`.

The opening bracket increments `self.depth`. On the branch where no closing bracket is found, the lexer returns `UnclosedOpeningBracket` without restoring `self.depth`. `consume_component` discards that error and re-derives the unclosed-bracket error itself, so the lexer keeps going with `depth` one too high; `context()` then reports the wrong context and the assert fails.

The fix decrements `self.depth` before returning, matching the entry state like the other early returns in this function. Release builds skip the assert, so the observable symptom is a debug-build panic; the underlying issue is the leftover depth on this error path.