### PR TITLE
Seal Parsable trait methods

### DIFF
--- a/time/src/date.rs
+++ b/time/src/date.rs
@@ -1478,7 +1478,7 @@ impl Date {
         input: &str,
         description: &(impl Parsable + ?Sized),
     ) -> Result<Self, error::Parse> {
-        description.parse_date(input.as_bytes(), None)
+        description.parse_date(input.as_bytes(), None, crate::parsing::SealedToken)
     }
 
     /// Parse a `Date` from the input using the provided [format
@@ -1502,7 +1502,7 @@ impl Date {
         description: &(impl Parsable + ?Sized),
         defaults: Parsed,
     ) -> Result<Self, error::Parse> {
-        description.parse_date(input, Some(defaults))
+        description.parse_date(input, Some(defaults), crate::parsing::SealedToken)
     }
 }
 

--- a/time/src/offset_date_time.rs
+++ b/time/src/offset_date_time.rs
@@ -1542,7 +1542,7 @@ impl OffsetDateTime {
         input: &str,
         description: &(impl Parsable + ?Sized),
     ) -> Result<Self, error::Parse> {
-        description.parse_offset_date_time(input.as_bytes(), None)
+        description.parse_offset_date_time(input.as_bytes(), None, crate::parsing::SealedToken)
     }
 
     /// Parse an `OffsetDateTime` from the input using the provided [format
@@ -1568,7 +1568,7 @@ impl OffsetDateTime {
         description: &(impl Parsable + ?Sized),
         defaults: Parsed,
     ) -> Result<Self, error::Parse> {
-        description.parse_offset_date_time(input, Some(defaults))
+        description.parse_offset_date_time(input, Some(defaults), crate::parsing::SealedToken)
     }
 
     /// A helper method to check if the `OffsetDateTime` is a valid representation of a leap second.

--- a/time/src/parsing/mod.rs
+++ b/time/src/parsing/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod parsable;
 mod parsed;
 pub(crate) mod shim;
 
+pub(crate) use self::parsable::SealedToken;
 pub use self::parsable::Parsable;
 pub use self::parsed::Parsed;
 

--- a/time/src/parsing/parsable.rs
+++ b/time/src/parsing/parsable.rs
@@ -36,11 +36,16 @@ impl Parsable for Rfc3339 {}
 impl<const CONFIG: EncodedConfig> Parsable for Iso8601<CONFIG> {}
 impl<T> Parsable for T where T: Deref<Target: Parsable> {}
 
+pub(crate) use sealed::Token as SealedToken;
+
 /// Seal the trait to prevent downstream users from implementing it, while still allowing it to
 /// exist in generic bounds.
 mod sealed {
     use super::*;
     use crate::{PrimitiveDateTime, Timestamp, UtcDateTime};
+    
+    #[allow(clippy::missing_copy_implementations, clippy::missing_debug_implementations)]
+    pub struct Token;
 
     /// Parse the item using a format description and an input.
     pub trait Sealed {
@@ -51,6 +56,7 @@ mod sealed {
             &self,
             input: &'a [u8],
             parsed: &mut Parsed,
+            _: Token
         ) -> Result<&'a [u8], error::Parse>;
 
         /// Parse the items into a [`Parsed`] struct, using the provided defaults for any components
@@ -59,9 +65,9 @@ mod sealed {
         /// This method can only be used to parse a complete value of a type. If any characters
         /// remain after parsing, an error will be returned.
         #[inline]
-        fn parse(&self, input: &[u8], defaults: Option<Parsed>) -> Result<Parsed, error::Parse> {
+        fn parse(&self, input: &[u8], defaults: Option<Parsed>, _: Token) -> Result<Parsed, error::Parse> {
             let mut parsed = defaults.unwrap_or_default();
-            if self.parse_into(input, &mut parsed)?.is_empty() {
+            if self.parse_into(input, &mut parsed, Token)?.is_empty() {
                 Ok(parsed)
             } else {
                 Err(error::Parse::ParseFromDescription(
@@ -72,14 +78,14 @@ mod sealed {
 
         /// Parse a [`Date`] from the format description.
         #[inline]
-        fn parse_date(&self, input: &[u8], defaults: Option<Parsed>) -> Result<Date, error::Parse> {
-            Ok(self.parse(input, defaults)?.try_into()?)
+        fn parse_date(&self, input: &[u8], defaults: Option<Parsed>, _: Token) -> Result<Date, error::Parse> {
+            Ok(self.parse(input, defaults, Token)?.try_into()?)
         }
 
         /// Parse a [`Time`] from the format description.
         #[inline]
-        fn parse_time(&self, input: &[u8], defaults: Option<Parsed>) -> Result<Time, error::Parse> {
-            Ok(self.parse(input, defaults)?.try_into()?)
+        fn parse_time(&self, input: &[u8], defaults: Option<Parsed>, _: Token) -> Result<Time, error::Parse> {
+            Ok(self.parse(input, defaults, Token)?.try_into()?)
         }
 
         /// Parse a [`UtcOffset`] from the format description.
@@ -88,8 +94,9 @@ mod sealed {
             &self,
             input: &[u8],
             defaults: Option<Parsed>,
+            _: Token
         ) -> Result<UtcOffset, error::Parse> {
-            Ok(self.parse(input, defaults)?.try_into()?)
+            Ok(self.parse(input, defaults, Token)?.try_into()?)
         }
 
         /// Parse a [`PrimitiveDateTime`] from the format description.
@@ -98,8 +105,9 @@ mod sealed {
             &self,
             input: &[u8],
             defaults: Option<Parsed>,
+            _: Token
         ) -> Result<PrimitiveDateTime, error::Parse> {
-            Ok(self.parse(input, defaults)?.try_into()?)
+            Ok(self.parse(input, defaults, Token)?.try_into()?)
         }
 
         /// Parse a [`UtcDateTime`] from the format description.
@@ -108,8 +116,9 @@ mod sealed {
             &self,
             input: &[u8],
             defaults: Option<Parsed>,
+            _: Token
         ) -> Result<UtcDateTime, error::Parse> {
-            Ok(self.parse(input, defaults)?.try_into()?)
+            Ok(self.parse(input, defaults, Token)?.try_into()?)
         }
 
         /// Parse a [`OffsetDateTime`] from the format description.
@@ -118,8 +127,9 @@ mod sealed {
             &self,
             input: &[u8],
             defaults: Option<Parsed>,
+            _: Token
         ) -> Result<OffsetDateTime, error::Parse> {
-            Ok(self.parse(input, defaults)?.try_into()?)
+            Ok(self.parse(input, defaults, Token)?.try_into()?)
         }
 
         /// Parse a [`Timestamp`] from the format description.
@@ -128,8 +138,9 @@ mod sealed {
             &self,
             input: &[u8],
             defaults: Option<Parsed>,
+            _: Token
         ) -> Result<Timestamp, error::Parse> {
-            Ok(self.parse(input, defaults)?.try_into()?)
+            Ok(self.parse(input, defaults, Token)?.try_into()?)
         }
     }
 }
@@ -140,6 +151,7 @@ impl sealed::Sealed for FormatDescriptionV3<'_> {
         &self,
         input: &'a [u8],
         parsed: &mut Parsed,
+        _: SealedToken
     ) -> Result<&'a [u8], error::Parse> {
         Ok(parsed.parse_v3_inner(input, &self.inner)?)
     }
@@ -151,6 +163,7 @@ impl sealed::Sealed for BorrowedFormatItem<'_> {
         &self,
         input: &'a [u8],
         parsed: &mut Parsed,
+        _: SealedToken
     ) -> Result<&'a [u8], error::Parse> {
         Ok(parsed.parse_item(input, self)?)
     }
@@ -162,6 +175,7 @@ impl sealed::Sealed for [BorrowedFormatItem<'_>] {
         &self,
         input: &'a [u8],
         parsed: &mut Parsed,
+        _: SealedToken
     ) -> Result<&'a [u8], error::Parse> {
         Ok(parsed.parse_items(input, self)?)
     }
@@ -174,6 +188,7 @@ impl sealed::Sealed for OwnedFormatItem {
         &self,
         input: &'a [u8],
         parsed: &mut Parsed,
+        _: SealedToken
     ) -> Result<&'a [u8], error::Parse> {
         Ok(parsed.parse_item(input, self)?)
     }
@@ -186,6 +201,7 @@ impl sealed::Sealed for [OwnedFormatItem] {
         &self,
         input: &'a [u8],
         parsed: &mut Parsed,
+        _: SealedToken
     ) -> Result<&'a [u8], error::Parse> {
         Ok(parsed.parse_items(input, self)?)
     }
@@ -200,8 +216,9 @@ where
         &self,
         input: &'a [u8],
         parsed: &mut Parsed,
+        _: SealedToken
     ) -> Result<&'a [u8], error::Parse> {
-        self.deref().parse_into(input, parsed)
+        self.deref().parse_into(input, parsed, SealedToken)
     }
 }
 
@@ -210,6 +227,7 @@ impl sealed::Sealed for Rfc2822 {
         &self,
         input: &'a [u8],
         parsed: &mut Parsed,
+        _: SealedToken
     ) -> Result<&'a [u8], error::Parse> {
         use crate::parsing::combinator::rfc::rfc2822::{cfws, fws, zone_literal};
 
@@ -356,12 +374,13 @@ impl sealed::Sealed for Rfc2822 {
         &self,
         input: &[u8],
         defaults: Option<Parsed>,
+        _: SealedToken
     ) -> Result<OffsetDateTime, error::Parse> {
         use crate::parsing::combinator::rfc::rfc2822::{cfws, fws, zone_literal};
 
         if let Some(mut defaults) = defaults {
             crate::hint::cold_path();
-            return self.parse_into(input, &mut defaults).and_then(|remaining| {
+            return self.parse_into(input, &mut defaults, SealedToken).and_then(|remaining| {
                 if remaining.is_empty() {
                     defaults.try_into().map_err(error::Parse::TryFromParsed)
                 } else {
@@ -518,6 +537,7 @@ impl sealed::Sealed for Rfc3339 {
         &self,
         input: &'a [u8],
         parsed: &mut Parsed,
+        _: SealedToken
     ) -> Result<&'a [u8], error::Parse> {
         let dash = ascii_char::<b'-'>;
         let colon = ascii_char::<b':'>;
@@ -649,10 +669,11 @@ impl sealed::Sealed for Rfc3339 {
         &self,
         input: &[u8],
         defaults: Option<Parsed>,
+        _: SealedToken
     ) -> Result<OffsetDateTime, error::Parse> {
         if let Some(mut defaults) = defaults {
             crate::hint::cold_path();
-            return self.parse_into(input, &mut defaults).and_then(|remaining| {
+            return self.parse_into(input, &mut defaults, SealedToken).and_then(|remaining| {
                 if remaining.is_empty() {
                     defaults.try_into().map_err(error::Parse::TryFromParsed)
                 } else {
@@ -790,6 +811,7 @@ impl<const CONFIG: EncodedConfig> sealed::Sealed for Iso8601<CONFIG> {
         &self,
         mut input: &'a [u8],
         parsed: &mut Parsed,
+        _: SealedToken
     ) -> Result<&'a [u8], error::Parse> {
         use crate::parsing::combinator::rfc::iso8601::ExtendedKind;
 

--- a/time/src/parsing/parsable.rs
+++ b/time/src/parsing/parsable.rs
@@ -44,7 +44,10 @@ mod sealed {
     use super::*;
     use crate::{PrimitiveDateTime, Timestamp, UtcDateTime};
     
-    #[allow(clippy::missing_copy_implementations, clippy::missing_debug_implementations)]
+    #[allow(
+        missing_copy_implementations,
+        missing_debug_implementations
+    )]
     pub struct Token;
 
     /// Parse the item using a format description and an input.

--- a/time/src/primitive_date_time.rs
+++ b/time/src/primitive_date_time.rs
@@ -1093,7 +1093,7 @@ impl PrimitiveDateTime {
         input: &str,
         description: &(impl Parsable + ?Sized),
     ) -> Result<Self, error::Parse> {
-        description.parse_primitive_date_time(input.as_bytes(), None)
+        description.parse_primitive_date_time(input.as_bytes(), None, crate::parsing::SealedToken)
     }
 
     /// Parse a `PrimitiveDateTime` from the input using the provided [format
@@ -1117,7 +1117,7 @@ impl PrimitiveDateTime {
         description: &(impl Parsable + ?Sized),
         defaults: Parsed,
     ) -> Result<Self, error::Parse> {
-        description.parse_primitive_date_time(input, Some(defaults))
+        description.parse_primitive_date_time(input, Some(defaults), crate::parsing::SealedToken)
     }
 }
 

--- a/time/src/time.rs
+++ b/time/src/time.rs
@@ -936,7 +936,7 @@ impl Time {
         input: &str,
         description: &(impl Parsable + ?Sized),
     ) -> Result<Self, error::Parse> {
-        description.parse_time(input.as_bytes(), None)
+        description.parse_time(input.as_bytes(), None, crate::parsing::SealedToken)
     }
 
     /// Parse a `Time` from the input using the provided [format
@@ -960,7 +960,7 @@ impl Time {
         description: &(impl Parsable + ?Sized),
         defaults: Parsed,
     ) -> Result<Self, error::Parse> {
-        description.parse_time(input, Some(defaults))
+        description.parse_time(input, Some(defaults), crate::parsing::SealedToken)
     }
 }
 

--- a/time/src/timestamp.rs
+++ b/time/src/timestamp.rs
@@ -1337,7 +1337,7 @@ impl Timestamp {
         input: &str,
         description: &(impl Parsable + ?Sized),
     ) -> Result<Self, error::Parse> {
-        description.parse_timestamp(input.as_bytes(), None)
+        description.parse_timestamp(input.as_bytes(), None, crate::parsing::SealedToken)
     }
 
     /// Parse a `Timestamp` from the input using the provided [format
@@ -1361,7 +1361,7 @@ impl Timestamp {
         description: &(impl Parsable + ?Sized),
         defaults: Parsed,
     ) -> Result<Self, error::Parse> {
-        description.parse_timestamp(input, Some(defaults))
+        description.parse_timestamp(input, Some(defaults), crate::parsing::SealedToken)
     }
 }
 

--- a/time/src/utc_date_time.rs
+++ b/time/src/utc_date_time.rs
@@ -1212,7 +1212,7 @@ impl UtcDateTime {
         input: &str,
         description: &(impl Parsable + ?Sized),
     ) -> Result<Self, error::Parse> {
-        description.parse_utc_date_time(input.as_bytes(), None)
+        description.parse_utc_date_time(input.as_bytes(), None, crate::parsing::SealedToken)
     }
 
     /// Parse a `UtcDateTime` from the input using the provided [format
@@ -1236,7 +1236,7 @@ impl UtcDateTime {
         description: &(impl Parsable + ?Sized),
         defaults: Parsed,
     ) -> Result<Self, error::Parse> {
-        description.parse_utc_date_time(input, Some(defaults))
+        description.parse_utc_date_time(input, Some(defaults), crate::parsing::SealedToken)
     }
 
     /// A helper method to check if the `UtcDateTime` is a valid representation of a leap second.

--- a/time/src/utc_offset.rs
+++ b/time/src/utc_offset.rs
@@ -509,7 +509,7 @@ impl UtcOffset {
         input: &str,
         description: &(impl Parsable + ?Sized),
     ) -> Result<Self, error::Parse> {
-        description.parse_offset(input.as_bytes(), None)
+        description.parse_offset(input.as_bytes(), None, crate::parsing::SealedToken)
     }
 
     /// Parse a `UtcOffset` from the input using the provided [format
@@ -535,7 +535,7 @@ impl UtcOffset {
         description: &(impl Parsable + ?Sized),
         defaults: Parsed,
     ) -> Result<Self, error::Parse> {
-        description.parse_offset(input, Some(defaults))
+        description.parse_offset(input, Some(defaults), crate::parsing::SealedToken)
     }
 }
 


### PR DESCRIPTION
This PR prevents the issue in #793 from reoccurring in the future, by embedding an unnameable type in the trait method signatures. The logic is analogous to what can be seen in the following code:

```rs
mod outer_sealed {
    mod inner_sealed {
        pub struct Token;
        pub struct Seal<T>(T);
    }
    
    pub(self) use inner_sealed::Token;
    
    pub trait SealedTrait {
        fn method(&self, _: inner_sealed::Token);
        fn method_with_return(&self) -> inner_sealed::Seal<u32>;
    }
}

use outer_sealed::SealedTrait; // The trait remains publicly usable
// use outer_sealed::Token; // This causes an error, which is what we want
```

For more info on this practice, see the following:
https://rust-lang.github.io/api-guidelines/future-proofing.html#newtypes-encapsulate-implementation-details-c-newtype-hide
https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/

I have tested this PR by running `cargo test --all-features`, and also also by checking that the build fails when importing the unnameable type. This PR can be considered breaking in the same way the changes to #793 were, but will improve future API stability. 